### PR TITLE
Fix static schema parser missing inline t.index declarations

### DIFF
--- a/lib/rails_ai_context/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_context/introspectors/schema_introspector.rb
@@ -136,6 +136,12 @@ module RailsAiContext
             current_table = match[1]
             next if current_table.start_with?("ar_internal_metadata", "schema_migrations")
             tables[current_table] = { columns: [], indexes: [], foreign_keys: [] }
+          elsif current_table && (match = line.match(/t\.index\s+(.+)/))
+            rest = match[1]
+            cols = rest.scan(/"(\w+)"/).flatten
+            unique = rest.include?("unique: true")
+            idx_name = rest.match(/name:\s*"([\w]+)"/)&.[](1)
+            tables[current_table][:indexes] << { name: idx_name, columns: cols, unique: unique }.compact if cols.any?
           elsif current_table && (match = line.match(/t\.(\w+)\s+"(\w+)"/))
             tables[current_table][:columns] << { name: match[2], type: match[1] }
           elsif (match = line.match(/add_index\s+"(\w+)",\s+(.+)/))

--- a/lib/rails_ai_context/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_context/introspectors/schema_introspector.rb
@@ -138,7 +138,7 @@ module RailsAiContext
             tables[current_table] = { columns: [], indexes: [], foreign_keys: [] }
           elsif current_table && (match = line.match(/t\.index\s+(.+)/))
             rest = match[1]
-            cols = rest.scan(/"(\w+)"/).flatten
+            cols = rest.match(/\[([^\]]+)\]/)&.[](1)&.scan(/"(\w+)"/)&.flatten || []
             unique = rest.include?("unique: true")
             idx_name = rest.match(/name:\s*"([\w]+)"/)&.[](1)
             tables[current_table][:indexes] << { name: idx_name, columns: cols, unique: unique }.compact if cols.any?

--- a/lib/rails_ai_context/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_context/introspectors/schema_introspector.rb
@@ -147,7 +147,13 @@ module RailsAiContext
           elsif (match = line.match(/add_index\s+"(\w+)",\s+(.+)/))
             table_name = match[1]
             rest = match[2]
-            cols = rest.scan(/(?::|\")(\w+)/).flatten
+            array_match = rest.match(/\[([^\]]+)\]/)
+            cols = if array_match
+              inside = array_match[1]
+              inside.include?('"') ? inside.scan(/"(\w+)"/).flatten : inside.scan(/\b(\w+)\b/).flatten
+            else
+              rest.match(/(?::|")(\w+)/)&.[](1)&.then { |c| [ c ] } || []
+            end
             unique = rest.include?("unique: true")
             idx_name = rest.match(/name:\s*"(\w+)"/)&.send(:[], 1)
             tables[table_name]&.dig(:indexes)&.push({ name: idx_name, columns: cols, unique: unique }.compact) if cols.any?

--- a/spec/lib/rails_ai_context/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/schema_introspector_spec.rb
@@ -70,6 +70,55 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
       end
     end
 
+    context "with inline t.index declarations in schema.rb" do
+      before do
+        allow(introspector).to receive(:active_record_connected?).and_return(false)
+
+        db_dir = File.join(fixture_path, "db")
+        FileUtils.mkdir_p(db_dir)
+        File.write(File.join(db_dir, "schema.rb"), <<~RUBY)
+          ActiveRecord::Schema[7.1].define(version: 2024_01_15_000000) do
+            create_table "users" do |t|
+              t.string "email"
+              t.string "name"
+              t.integer "role"
+              t.index ["email"], name: "index_users_on_email", unique: true
+              t.index ["name", "role"], name: "index_users_on_name_and_role"
+            end
+          end
+        RUBY
+      end
+
+      after do
+        FileUtils.rm_rf(File.join(fixture_path, "db"))
+      end
+
+      it "extracts inline single-column indexes" do
+        result = introspector.call
+        indexes = result[:tables]["users"][:indexes]
+        expect(indexes).to include(a_hash_including(name: "index_users_on_email", columns: ["email"]))
+      end
+
+      it "extracts inline multi-column indexes" do
+        result = introspector.call
+        indexes = result[:tables]["users"][:indexes]
+        expect(indexes).to include(a_hash_including(name: "index_users_on_name_and_role", columns: ["name", "role"]))
+      end
+
+      it "captures uniqueness on inline indexes" do
+        result = introspector.call
+        indexes = result[:tables]["users"][:indexes]
+        email_index = indexes.find { |i| i[:name] == "index_users_on_email" }
+        expect(email_index[:unique]).to be true
+      end
+
+      it "does not treat t.index lines as columns" do
+        result = introspector.call
+        col_names = result[:tables]["users"][:columns].map { |c| c[:name] }
+        expect(col_names).not_to include("index")
+      end
+    end
+
     context "with a valid structure.sql fixture" do
       before do
         allow(introspector).to receive(:active_record_connected?).and_return(false)


### PR DESCRIPTION
## Problem

When ActiveRecord is not connected (Claude Code, CI, etc.), `parse_schema_rb` falls back to parsing `db/schema.rb` as text. It handled the legacy `add_index` style but not the modern inline `t.index` style that Rails generates inside `create_table` blocks:

```ruby
# Modern style (not handled) ❌
create_table "stations" do |t|
  t.string "callsign"
  t.index ["callsign", "band"], name: "index_stations_on_callsign_and_band"
end

# Legacy style (was handled) ✓
add_index "stations", ["callsign", "band"], name: "index_stations_on_callsign_and_band"
```

This caused all tables to report `0 indexes` when using `rails_get_schema` without a live DB connection, even though indexes exist.

## Fix

Add a `t.index` branch in `parse_schema_rb` that runs before the column-parsing branch, extracting column names, index name, and uniqueness from inline index declarations.

Note: the `t.index` branch must come before the `t.(\w+)` column branch, since `t.index` would otherwise be partially matched as a column named `index`.