### PR TITLE
Use detected test framework for run-tests command in generated context

### DIFF
--- a/lib/rails_ai_context/serializers/claude_serializer.rb
+++ b/lib/rails_ai_context/serializers/claude_serializer.rb
@@ -256,11 +256,15 @@ module RailsAiContext
         lines
       end
 
+      def test_command
+        context.dig(:tests, :framework) == "rspec" ? "bundle exec rspec" : "rails test"
+      end
+
       def render_commands
         [
           "## Commands",
           "- `bin/dev` — start dev server",
-          "- `bundle exec rspec` — run tests",
+          "- `#{test_command}` — run tests",
           "- `rails db:migrate` — run pending migrations",
           ""
         ]
@@ -308,7 +312,7 @@ module RailsAiContext
         rules << "- Use the database schema as the source of truth for column names and types"
         rules << "- Respect existing associations and validations when modifying models"
         rules << "- Match the project's architecture style (#{architecture_summary})" if architecture_summary
-        rules << "- Run `bundle exec rspec` after making changes to verify correctness"
+        rules << "- Run `#{test_command}` after making changes to verify correctness"
         rules << ""
         rules << super
         rules.join("\n")
@@ -317,6 +321,10 @@ module RailsAiContext
       def architecture_summary
         arch = context.dig(:conventions, :architecture)
         arch&.any? ? arch.join(", ") : nil
+      end
+
+      def test_command
+        context.dig(:tests, :framework) == "rspec" ? "bundle exec rspec" : "rails test"
       end
     end
   end

--- a/lib/rails_ai_context/serializers/copilot_serializer.rb
+++ b/lib/rails_ai_context/serializers/copilot_serializer.rb
@@ -135,10 +135,14 @@ module RailsAiContext
         lines << "## Conventions"
         lines << "- Follow existing patterns and naming conventions"
         lines << "- Use MCP tools to check schema before writing migrations"
-        lines << "- Run `bundle exec rspec` after changes"
+        lines << "- Run `#{test_command}` after changes"
         lines << ""
 
         lines.join("\n")
+      end
+
+      def test_command
+        context.dig(:tests, :framework) == "rspec" ? "bundle exec rspec" : "rails test"
       end
     end
 

--- a/lib/rails_ai_context/serializers/markdown_serializer.rb
+++ b/lib/rails_ai_context/serializers/markdown_serializer.rb
@@ -500,6 +500,10 @@ module RailsAiContext
           _This context file is auto-generated. Run `rails ai:context` to regenerate._
         MD
       end
+
+      def test_command
+        context.dig(:tests, :framework) == "rspec" ? "bundle exec rspec" : "rails test"
+      end
     end
   end
 end

--- a/lib/rails_ai_context/serializers/opencode_serializer.rb
+++ b/lib/rails_ai_context/serializers/opencode_serializer.rb
@@ -212,11 +212,15 @@ module RailsAiContext
         lines
       end
 
+      def test_command
+        context.dig(:tests, :framework) == "rspec" ? "bundle exec rspec" : "rails test"
+      end
+
       def render_commands
         [
           "## Commands",
           "- `bin/dev` — start dev server",
-          "- `bundle exec rspec` — run tests",
+          "- `#{test_command}` — run tests",
           "- `rails db:migrate` — run pending migrations",
           ""
         ]
@@ -260,7 +264,7 @@ module RailsAiContext
         rules << "- Use the database schema as the source of truth for column names and types"
         rules << "- Respect existing associations and validations when modifying models"
         rules << "- Match the project's architecture style (#{architecture_summary})" if architecture_summary
-        rules << "- Run `bundle exec rspec` after making changes to verify correctness"
+        rules << "- Run `#{test_command}` after making changes to verify correctness"
         rules << ""
         rules << super
         rules.join("\n")
@@ -269,6 +273,10 @@ module RailsAiContext
       def architecture_summary
         arch = context.dig(:conventions, :architecture)
         arch&.any? ? arch.join(", ") : nil
+      end
+
+      def test_command
+        context.dig(:tests, :framework) == "rspec" ? "bundle exec rspec" : "rails test"
       end
     end
   end

--- a/spec/lib/rails_ai_context/serializers/claude_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/claude_serializer_spec.rb
@@ -78,4 +78,51 @@ RSpec.describe RailsAiContext::Serializers::ClaudeSerializer do
       expect(output).to include("Claude Code")
     end
   end
+
+  describe "test command" do
+    let(:base_context) do
+      {
+        app_name: "App", rails_version: "8.0", ruby_version: "3.4",
+        generated_at: Time.now.iso8601
+      }
+    end
+
+    context "compact mode" do
+      before { RailsAiContext.configuration.context_mode = :compact }
+      after  { RailsAiContext.configuration.context_mode = :compact }
+
+      it "uses rails test for minitest projects" do
+        output = described_class.new(base_context.merge(tests: { framework: "minitest" })).call
+        expect(output).to include("rails test")
+        expect(output).not_to include("bundle exec rspec")
+      end
+
+      it "uses bundle exec rspec for rspec projects" do
+        output = described_class.new(base_context.merge(tests: { framework: "rspec" })).call
+        expect(output).to include("bundle exec rspec")
+        expect(output).not_to include("rails test")
+      end
+
+      it "defaults to rails test when framework is unknown" do
+        output = described_class.new(base_context).call
+        expect(output).to include("rails test")
+      end
+    end
+
+    context "full mode" do
+      before { RailsAiContext.configuration.context_mode = :full }
+      after  { RailsAiContext.configuration.context_mode = :compact }
+
+      it "uses rails test for minitest projects" do
+        output = described_class.new(base_context.merge(tests: { framework: "minitest" })).call
+        expect(output).to include("rails test")
+        expect(output).not_to include("bundle exec rspec")
+      end
+
+      it "uses bundle exec rspec for rspec projects" do
+        output = described_class.new(base_context.merge(tests: { framework: "rspec" })).call
+        expect(output).to include("bundle exec rspec")
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/serializers/copilot_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/copilot_serializer_spec.rb
@@ -34,6 +34,35 @@ RSpec.describe RailsAiContext::Serializers::CopilotSerializer do
     end
   end
 
+  describe "test command" do
+    before { RailsAiContext.configuration.context_mode = :compact }
+    after  { RailsAiContext.configuration.context_mode = :compact }
+
+    let(:base_context) do
+      {
+        app_name: "App", rails_version: "8.0", ruby_version: "3.4",
+        schema: {}, models: {}, routes: {}, gems: {}, conventions: {}
+      }
+    end
+
+    it "uses rails test for minitest projects" do
+      output = described_class.new(base_context.merge(tests: { framework: "minitest" })).call
+      expect(output).to include("rails test")
+      expect(output).not_to include("bundle exec rspec")
+    end
+
+    it "uses bundle exec rspec for rspec projects" do
+      output = described_class.new(base_context.merge(tests: { framework: "rspec" })).call
+      expect(output).to include("bundle exec rspec")
+      expect(output).not_to include("rails test")
+    end
+
+    it "defaults to rails test when framework is unknown" do
+      output = described_class.new(base_context).call
+      expect(output).to include("rails test")
+    end
+  end
+
   describe "full mode" do
     before { RailsAiContext.configuration.context_mode = :full }
     after { RailsAiContext.configuration.context_mode = :compact }

--- a/spec/lib/rails_ai_context/serializers/opencode_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/opencode_serializer_spec.rb
@@ -57,6 +57,28 @@ RSpec.describe RailsAiContext::Serializers::OpencodeSerializer do
       end
     end
 
+    context "test command" do
+      before { RailsAiContext.configuration.context_mode = :compact }
+      after  { RailsAiContext.configuration.context_mode = :compact }
+
+      it "uses rails test for minitest projects" do
+        output = described_class.new(context.merge(tests: { framework: "minitest" })).call
+        expect(output).to include("rails test")
+        expect(output).not_to include("bundle exec rspec")
+      end
+
+      it "uses bundle exec rspec for rspec projects" do
+        output = described_class.new(context.merge(tests: { framework: "rspec" })).call
+        expect(output).to include("bundle exec rspec")
+        expect(output).not_to include("rails test")
+      end
+
+      it "defaults to rails test when framework is unknown" do
+        output = described_class.new(context.except(:tests)).call
+        expect(output).to include("rails test")
+      end
+    end
+
     context "in full mode" do
       before { RailsAiContext.configuration.context_mode = :full }
       after { RailsAiContext.configuration.context_mode = :compact }


### PR DESCRIPTION
## Problem

The serializers hardcoded `bundle exec rspec` in the Commands section and behavioral rules, even though `TestIntrospector` already correctly detects whether a project uses minitest or rspec. Minitest projects (the Rails default) would get the wrong test command in their generated context files.

## Fix

Add a `test_command` helper to each serializer (`ClaudeSerializer`, `OpencodeSerializer`, `CopilotSerializer`, `MarkdownSerializer`) that reads `context.dig(:tests, :framework)` and returns the appropriate command:

- `"rspec"` → `bundle exec rspec`
- anything else → `rails test` (the Rails default)

## Tests

11 new examples across the three compact serializer specs covering minitest, rspec, and unknown/missing framework cases.