### PR TITLE
feat: v5.6.0 — auto-registration, TestHelper, bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.0] — 2026-04-08
+
+### Added — Universal MCP Auto-Discovery & Per-Tool Context Optimization (#51-#56)
+
+Every AI tool now gets its own MCP config file — auto-detected on project open. No manual setup needed for any supported tool.
+
+- **McpConfigGenerator** (`lib/rails_ai_context/mcp_config_generator.rb`) — Shared infrastructure for per-tool MCP config generation. Writes `.mcp.json` (Claude Code), `.cursor/mcp.json` (Cursor), `.vscode/mcp.json` (GitHub Copilot), `opencode.json` (OpenCode), `.codex/config.toml` (Codex CLI). Merge-safe — only manages the `rails-ai-context` entry, preserves other servers. Supports standalone mode and CLI skip.
+
+- **Codex CLI support** (#51) — 5th supported AI tool. Reuses `AGENTS.md` (shared with OpenCode) and `OpencodeRulesSerializer` for directory-level split rules. Config via `.codex/config.toml` (TOML format) with `[mcp_servers.rails-ai-context.env]` subsection that snapshots Ruby environment variables at install time — required because Codex CLI `env_clear()`s the process before spawning MCP servers. Works with all Ruby version managers (rbenv, rvm, asdf, mise, chruby, system). Added to all 3 install paths (generator, CLI, rake), doctor checks, and search exclusions.
+
+- **Cursor improvements** (#52) — `.cursor/mcp.json` auto-generated for MCP auto-discovery. MCP tools rule changed from `alwaysApply: true` to `alwaysApply: false` with descriptive text for agent-requested (Type 3) loading.
+
+- **OpenCode improvements** (#53) — `opencode.json` auto-generated for MCP auto-discovery.
+
+- **Claude Code improvements** (#54) — `paths:` YAML frontmatter added to `.claude/rules/` schema, models, and components rules for conditional loading. Context and mcp-tools rules remain unconditional.
+
+- **Copilot improvements** (#55) — `.vscode/mcp.json` auto-generated for MCP auto-discovery. `name:` and `description:` YAML frontmatter added to all `.github/instructions/` files. Updated `excludeAgent` spec to validate `code-review`, `coding-agent`, and `workspace` per GitHub Copilot docs.
+
+- **All 3 install paths updated** — Install generator, standalone CLI (`rails-ai-context init`), and rake task (`rails ai:setup`) all delegate to McpConfigGenerator. Codex added as option "5" in interactive tool selection.
+
+- **Doctor expanded** — `check_mcp_json` now validates per-tool MCP configs based on configured `ai_tools` (JSON parse validation + TOML existence check).
+
+- **Search exclusions** — `.codex/`, `.vscode/mcp.json`, `opencode.json` added to `search_code` tool exclusions.
+
 ## [5.4.0] — 2026-04-08
 
 ### Added — Phase 3: Dynamic VFS & Live Resource Architecture (Ground Truth Engine Blueprint #39)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.0] — 2026-04-09
+
+### Added — Auto-Registration, TestHelper & Bug Fixes
+
+Developer experience improvements inspired by action_mcp patterns, plus 5 security/correctness bug fixes.
+
+- **Auto-registration via `inherited` hook** — Tools are now auto-discovered from `BaseTool` subclasses. No manual list to maintain — drop a file in `tools/` and it's registered. `Server.builtin_tools` is the new public API. Thread-safe via `@registry_mutex` with deadlock-free design (const_get runs outside mutex to avoid recursive locking from inherited). `Server::TOOLS` preserved as deprecated `const_missing` shim for backwards compatibility.
+
+- **`abstract!` pattern** — `BaseTool.abstract!` excludes a class from the registry. `BaseTool` itself is abstract. Subclasses are concrete by default.
+
+- **TestHelper module** (`lib/rails_ai_context/test_helper.rb`) — Reusable test helper for custom_tools users. Methods: `execute_tool` (by name, short name, or class), `execute_tool_with_error`, `assert_tool_findable`, `assert_tool_response_includes`, `assert_tool_response_excludes`, `extract_response_text`. Works with both RSpec and Minitest. Supports fuzzy name resolution (`schema` → `rails_get_schema`).
+
+### Fixed
+
+- **SQL comment stripping validation bypass** (HIGH) — `#` comment stripping now restricted to line-start only, preventing validation bypass via hash characters in string literals. PostgreSQL JSONB operators (`#>>`) preserved.
+
+- **SHARED_CACHE read outside mutex** (MEDIUM) — `redact_results` now uses `cached_context` for thread-safe access to encrypted column data.
+
+- **McpController double-checked locking** (MEDIUM) — Removed unsynchronized read outside mutex, fixing unsafe pattern on non-GVL Rubies (JRuby/TruffleRuby).
+
+- **PG EXPLAIN parser bare rescue** (LOW) — Changed from `rescue` to `rescue JSON::ParserError`, preventing silent swallowing of bugs in `extract_pg_nodes`.
+
+- **GetConcern `class_methods` block closing** (LOW) — Indent-based tracking to detect the closing `end`, so `def self.` methods after the block are no longer lost.
+
+- **Query spec graceful degradation** — Replaced permanently-pending spec (sqlite3 2.x removed `set_progress_handler`) with a spec that verifies queries execute correctly without it.
+
 ## [5.5.0] — 2026-04-08
 
 ### Added — Universal MCP Auto-Discovery & Per-Tool Context Optimization (#51-#56)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ lib/rails_ai_context/
 1. Create `lib/rails_ai_context/tools/your_tool.rb` inheriting from `BaseTool` (auto-loaded by Zeitwerk)
 2. Define `tool_name`, `description`, `input_schema`, and `annotations`
 3. Implement `def self.call(...)` returning `text_response(string)`
-4. Register in `Server::TOOLS`
+4. Auto-registered — no manual list to update (BaseTool.inherited tracks it)
 5. Write specs in `spec/lib/rails_ai_context/tools/your_tool_spec.rb`
 
 ## Adding a Prism Listener

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <br>
 [![Ruby](https://img.shields.io/badge/Ruby-3.2%20%7C%203.3%20%7C%203.4-CC342D)](https://github.com/crisnahine/rails-ai-context)
 [![Rails](https://img.shields.io/badge/Rails-7.1%20%7C%207.2%20%7C%208.0-CC0000)](https://github.com/crisnahine/rails-ai-context)
-[![Tests](https://img.shields.io/badge/Tests-1864%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
+[![Tests](https://img.shields.io/badge/Tests-1889%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>
@@ -519,7 +519,7 @@ Events: `rails_ai_context.tools.call`, `rails_ai_context.resources.read`, and mo
 ## About
 
 Built by a Rails developer with 10+ years of production experience.<br>
-1864 tests. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
+1889 tests. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
 MIT licensed. [Contributions welcome.](CONTRIBUTING.md)
 
 <br>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <a href="https://cursor.com"><img src="https://img.shields.io/badge/Cursor-000000?style=for-the-badge&logo=cursor&logoColor=white" alt="Cursor"></a>
 <a href="https://github.com/features/copilot"><img src="https://img.shields.io/badge/GitHub_Copilot-000000?style=for-the-badge&logo=githubcopilot&logoColor=white" alt="GitHub Copilot"></a>
 <a href="https://opencode.ai"><img src="https://img.shields.io/badge/OpenCode-4285F4?style=for-the-badge&logoColor=white" alt="OpenCode"></a>
+<a href="https://codex.openai.com"><img src="https://img.shields.io/badge/Codex_CLI-412991?style=for-the-badge&logo=openai&logoColor=white" alt="Codex CLI"></a>
 <a href="#-cli--works-everywhere"><img src="https://img.shields.io/badge/Any_Terminal-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white" alt="Any Terminal"></a>
 
 
@@ -20,7 +21,7 @@
 <br>
 [![Ruby](https://img.shields.io/badge/Ruby-3.2%20%7C%203.3%20%7C%203.4-CC342D)](https://github.com/crisnahine/rails-ai-context)
 [![Rails](https://img.shields.io/badge/Rails-7.1%20%7C%207.2%20%7C%208.0-CC0000)](https://github.com/crisnahine/rails-ai-context)
-[![Tests](https://img.shields.io/badge/Tests-1813%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
+[![Tests](https://img.shields.io/badge/Tests-1864%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>
@@ -131,7 +132,7 @@ Compare what AI outputs with and without these tools wired in. The difference is
 
 ### MCP Server (stdio)
 
-AI calls tools directly via the protocol. Auto-discovered through `.mcp.json`.
+AI calls tools directly via the protocol. Each AI tool gets its own config file — auto-detected on project open.
 
 ```
 rails ai:serve
@@ -438,7 +439,7 @@ cd your-rails-app
 rails-ai-context init
 ```
 
-Both paths ask which AI tools you use and whether you want MCP or CLI mode. `.mcp.json` is auto-detected by Claude Code and Cursor.
+Both paths ask which AI tools you use (Claude Code, Cursor, GitHub Copilot, OpenCode, Codex CLI) and whether you want MCP or CLI mode. Each tool gets its own MCP config file — auto-detected on project open.
 
 <br>
 
@@ -518,7 +519,7 @@ Events: `rails_ai_context.tools.call`, `rails_ai_context.resources.read`, and mo
 ## About
 
 Built by a Rails developer with 10+ years of production experience.<br>
-1813 tests. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
+1864 tests. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
 MIT licensed. [Contributions welcome.](CONTRIBUTING.md)
 
 <br>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,10 @@
 
 | Version | Supported          |
 |---------|--------------------|
+| 5.5.x   | :white_check_mark: |
+| 5.4.x   | :white_check_mark: |
+| 5.3.x   | :white_check_mark: |
+| 5.2.x   | :white_check_mark: |
 | 5.1.x   | :white_check_mark: |
 | 5.0.x   | :white_check_mark: |
 | 4.7.x   | :white_check_mark: |

--- a/app/controllers/rails_ai_context/mcp_controller.rb
+++ b/app/controllers/rails_ai_context/mcp_controller.rb
@@ -18,7 +18,7 @@ module RailsAiContext
       # Class-level memoization — transport persists across requests.
       # Thread-safe: MCP::Server and transport are stateless for reads.
       def mcp_transport
-        @mcp_transport || @transport_mutex.synchronize do
+        @transport_mutex.synchronize do
           @mcp_transport ||= begin
             server = RailsAiContext::Server.new(Rails.application, transport: :http).build
             MCP::Server::Transports::StreamableHTTPTransport.new(server)

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -47,7 +47,7 @@ rails ai:context
 This creates:
 1. `config/initializers/rails_ai_context.rb` — configuration file
 2. `.rails-ai-context.yml` — standalone config (enables switching later)
-3. `.mcp.json` — MCP auto-discovery for Claude Code and Cursor
+3. Per-tool MCP config files — auto-discovery for Claude Code, Cursor, Copilot, OpenCode, and Codex
 4. Context files — tailored for each AI assistant
 
 ### Option B: Standalone (no Gemfile entry needed)
@@ -60,16 +60,16 @@ rails-ai-context init
 
 This creates:
 1. `.rails-ai-context.yml` — configuration file
-2. `.mcp.json` — MCP auto-discovery (if MCP mode selected)
+2. Per-tool MCP config files — auto-discovery (if MCP mode selected)
 3. Context files — tailored for each AI assistant
 
 No Gemfile entry, no initializer, no files in your project besides config and context.
 
 ### What the install generator does
 
-1. Creates `.mcp.json` in project root (MCP auto-discovery)
+1. Creates per-tool MCP config files (`.mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json`, `opencode.json`, `.codex/config.toml`)
 2. Creates `config/initializers/rails_ai_context.rb` with commented defaults
-3. Asks which AI tools you use (Claude, Cursor, Copilot, OpenCode)
+3. Asks which AI tools you use (Claude, Cursor, Copilot, OpenCode, Codex)
 4. Asks whether to enable MCP server (`tool_mode: :mcp`) or use CLI-only mode (`tool_mode: :cli`)
 5. Adds `.ai-context.json` to `.gitignore` (JSON cache — markdown files should be committed)
 6. Generates all context files
@@ -159,7 +159,7 @@ end
 | `.cursor/rules/rails-project.mdc` | Project overview | `alwaysApply: true` — loaded in every conversation. |
 | `.cursor/rules/rails-models.mdc` | Model reference | `globs: app/models/**/*.rb` — auto-attaches when editing models. |
 | `.cursor/rules/rails-controllers.mdc` | Controller reference | `globs: app/controllers/**/*.rb` — auto-attaches when editing controllers. |
-| `.cursor/rules/rails-mcp-tools.mdc` | MCP tool reference | `alwaysApply: true` — always available. |
+| `.cursor/rules/rails-mcp-tools.mdc` | MCP tool reference | `alwaysApply: false` — agent-requested when relevant. |
 
 ### GitHub Copilot (5 files)
 
@@ -193,6 +193,7 @@ Commit **all files except `.ai-context.json`** (which is gitignored). This gives
 | `rails ai:context:full` | full | all | Generate all files in full mode |
 | `rails ai:context:claude` | compact | Claude | CLAUDE.md + .claude/rules/ |
 | `rails ai:context:opencode` | compact | OpenCode | AGENTS.md + per-directory AGENTS.md |
+| `rails ai:context:codex` | compact | Codex | AGENTS.md + .codex/config.toml |
 | `rails ai:context:cursor` | compact | Cursor | .cursor/rules/ |
 | `rails ai:context:copilot` | compact | Copilot | copilot-instructions.md + .github/instructions/ |
 | `rails ai:context:json` | — | JSON | .ai-context.json |
@@ -212,7 +213,7 @@ Commit **all files except `.ai-context.json`** (which is gitignored). This gives
 
 | Command | Transport | Description |
 |---------|-----------|-------------|
-| `rails ai:serve` | stdio | Start MCP server for Claude Code / Cursor. Auto-discovered via `.mcp.json`. |
+| `rails ai:serve` | stdio | Start MCP server. Auto-discovered by each AI tool via its own config file. |
 | `rails ai:serve_http` | HTTP | Start MCP server at `http://127.0.0.1:6029/mcp`. For remote clients. |
 
 ### Utilities
@@ -228,7 +229,7 @@ Commit **all files except `.ai-context.json`** (which is gitignored). This gives
 The gem ships a `rails-ai-context` executable that works **without adding the gem to your Gemfile**. Install globally with `gem install rails-ai-context`, then run from any Rails app directory.
 
 ```bash
-rails-ai-context init                      # Interactive setup (creates .rails-ai-context.yml + .mcp.json)
+rails-ai-context init                      # Interactive setup (creates .rails-ai-context.yml + MCP configs)
 rails-ai-context serve                     # Start MCP server (stdio)
 rails-ai-context serve --transport http    # Start MCP server (HTTP, port 6029)
 rails-ai-context serve --transport http --port 8080  # Custom port
@@ -1036,9 +1037,19 @@ curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=rails-ai-cont
 
 ### Auto-discovery (recommended)
 
-The install generator (or `rails-ai-context init`) creates `.mcp.json` in your project root:
+The install generator (or `rails-ai-context init`) creates per-tool MCP config files based on your selected AI tools:
 
-**In-Gemfile:**
+| AI Tool | Config File | Root Key | Format |
+|---------|------------|----------|--------|
+| Claude Code | `.mcp.json` | `mcpServers` | JSON |
+| Cursor | `.cursor/mcp.json` | `mcpServers` | JSON |
+| GitHub Copilot | `.vscode/mcp.json` | `servers` | JSON |
+| OpenCode | `opencode.json` | `mcp` | JSON |
+| Codex CLI | `.codex/config.toml` | `[mcp_servers]` | TOML |
+
+Each file is merge-safe — only the `rails-ai-context` entry is managed, other servers are preserved.
+
+**Example: `.mcp.json` (Claude Code)**
 ```json
 {
   "mcpServers": {
@@ -1050,19 +1061,20 @@ The install generator (or `rails-ai-context init`) creates `.mcp.json` in your p
 }
 ```
 
-**Standalone:**
-```json
-{
-  "mcpServers": {
-    "rails-ai-context": {
-      "command": "rails-ai-context",
-      "args": ["serve"]
-    }
-  }
-}
+**Example: `.codex/config.toml` (Codex CLI)**
+```toml
+[mcp_servers.rails-ai-context]
+command = "bundle"
+args = ["exec", "rails", "ai:serve"]
+
+[mcp_servers.rails-ai-context.env]
+PATH = "/home/user/.rbenv/shims:/usr/local/bin:/usr/bin"
+GEM_HOME = "/home/user/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0"
 ```
 
-**Claude Code** and **Cursor** auto-detect this file. No manual config needed — just open your project.
+> **Why the `[env]` section?** Codex CLI `env_clear()`s the process before spawning MCP servers, stripping Ruby version manager paths. The install generator snapshots your current Ruby environment (PATH, GEM\_HOME, GEM\_PATH, GEM\_ROOT, RUBY\_VERSION, BUNDLE\_PATH) so the MCP server can find gems regardless of version manager (rbenv, rvm, asdf, mise, chruby, or system Ruby).
+
+Each AI tool auto-detects its own config file. No manual config needed — just open your project.
 
 ### Claude Code
 
@@ -1096,7 +1108,7 @@ Or for standalone: replace `"command": "bundle"` / `"args": ["exec", "rails", "a
 
 ### Cursor
 
-Auto-discovered via `.mcp.json`. Or add manually in **Cursor Settings > MCP**:
+Auto-discovered via `.cursor/mcp.json`. Or add manually in **Cursor Settings > MCP**:
 
 ```json
 {
@@ -1282,7 +1294,7 @@ end
 | `custom_tools` | Array | `[]` | Additional MCP tool classes to register alongside built-in tools |
 | `skip_tools` | Array | `[]` | Built-in tool names to exclude (e.g. `%w[rails_security_scan]`) |
 | `tool_mode` | Symbol | `:mcp` | `:mcp` (MCP primary + CLI fallback) or `:cli` (CLI only, no MCP server needed) |
-| `ai_tools` | Array | `nil` (all) | AI tools to generate context for: `%i[claude cursor copilot opencode]`. Selected during install. |
+| `ai_tools` | Array | `nil` (all) | AI tools to generate context for: `%i[claude cursor copilot opencode codex]`. Selected during install. |
 | `excluded_models` | Array | internal Rails models | Models to skip |
 | `excluded_paths` | Array | `node_modules tmp log vendor .git` | Paths excluded from code search |
 | `sensitive_patterns` | Array | `.env`, `.key`, `.pem`, credentials | File patterns blocked from search and read tools |
@@ -1408,13 +1420,13 @@ config.introspectors = %i[schema models routes gems auth api]
 
 **Context files loaded:**
 - `CLAUDE.md` — read at conversation start
-- `.claude/rules/*.md` — auto-loaded alongside CLAUDE.md
+- `.claude/rules/*.md` — auto-loaded alongside CLAUDE.md (schema, models, and components rules use `paths:` frontmatter for conditional loading)
 
 **MCP tools:** Available immediately via `.mcp.json`.
 
 ### Cursor
 
-**Auto-discovery:** Opens `.mcp.json` automatically. No setup needed.
+**Auto-discovery:** Opens `.cursor/mcp.json` automatically. No setup needed.
 
 **Context files loaded:**
 - `.cursor/rules/*.mdc` — loaded based on `alwaysApply` and `globs` settings
@@ -1422,13 +1434,13 @@ config.introspectors = %i[schema models routes gems auth api]
 **MDC rule activation modes:**
 | Mode | When it activates |
 |------|-------------------|
-| `alwaysApply: true` | Every conversation (project overview, MCP tools) |
+| `alwaysApply: true` | Every conversation (project overview) |
 | `globs: ["app/models/**/*.rb"]` | When editing files matching the glob pattern |
-| `alwaysApply: false` + `description` | When the AI decides it's relevant based on description |
+| `alwaysApply: false` + `description` | Agent-requested — loaded when AI decides it's relevant (MCP tools rule) |
 
 ### OpenCode
 
-**MCP config:** Add to `opencode.json`:
+**Auto-discovery:** `opencode.json` is auto-generated by the install generator. Or add manually:
 
 ```json
 {
@@ -1462,13 +1474,15 @@ For standalone: use `"command": ["rails-ai-context", "serve"]` instead.
 
 OpenCode uses **per-directory lazy-loading**: when the agent reads a file, it walks up the directory tree and auto-loads any `AGENTS.md` it finds. This is how split rules work — no globs or frontmatter needed.
 
-**MCP tools:** Available via `opencode.json` config above.
+**MCP tools:** Available via `opencode.json` (auto-generated or manual config above).
 
 ### GitHub Copilot
 
+**Auto-discovery:** `.vscode/mcp.json` is auto-generated by the install generator.
+
 **Context files loaded:**
 - `.github/copilot-instructions.md` — repo-wide instructions
-- `.github/instructions/*.instructions.md` — path-specific, activated by `applyTo` glob
+- `.github/instructions/*.instructions.md` — path-specific, activated by `applyTo` glob (with `name:` and `description:` frontmatter)
 
 **applyTo patterns:**
 | Pattern | When it activates |
@@ -1476,6 +1490,17 @@ OpenCode uses **per-directory lazy-loading**: when the agent reads a file, it wa
 | `app/models/**/*.rb` | Editing model files |
 | `app/controllers/**/*.rb` | Editing controller files |
 | `**/*` | All files (MCP tool reference) |
+
+### Codex CLI
+
+**Auto-discovery:** `.codex/config.toml` is auto-generated by the install generator, including an `[env]` subsection that snapshots your Ruby environment for sandbox compatibility.
+
+**Context files loaded:**
+- `AGENTS.md` — project overview + MCP tool guide (shared with OpenCode)
+- `app/models/AGENTS.md` — model listing, auto-loaded when agent reads model files
+- `app/controllers/AGENTS.md` — controller listing, auto-loaded when agent reads controller files
+
+**MCP tools:** Available via `.codex/config.toml`.
 
 ---
 
@@ -1628,11 +1653,12 @@ Works in:
 
 ## Troubleshooting
 
-### MCP server not detected by Claude Code / Cursor
+### MCP server not detected by your AI tool
 
-1. Check `.mcp.json` exists in project root
-2. Verify it contains `"command": "bundle"` and `"args": ["exec", "rails", "ai:serve"]`
-3. Restart Claude Code / Cursor
+1. Run `rails ai:doctor` — it checks per-tool MCP config files
+2. Verify the correct config file exists for your tool (`.mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json`, `opencode.json`, `.codex/config.toml`)
+3. Re-run install (`rails generate rails_ai_context:install` or `rails-ai-context init`) to regenerate configs
+4. Restart your AI tool
 
 ### Context files are too large
 

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -403,7 +403,7 @@ class RailsAiContextCLI < Thor
 
     def tool_count_str
       if defined?(::RailsAiContext::Server)
-        ::RailsAiContext::Server::TOOLS.size.to_s
+        ::RailsAiContext::Server.builtin_tools.size.to_s
       else
         "38"
       end

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -167,8 +167,8 @@ class RailsAiContextCLI < Thor
       # --- Write .rails-ai-context.yml ---
       write_yaml_config(ai_tools, tool_mode)
 
-      # --- Write .mcp.json (MCP mode only) ---
-      write_standalone_mcp_json if tool_mode == :mcp
+      # --- Write per-tool MCP config files (MCP mode only) ---
+      write_mcp_configs(ai_tools, tool_mode)
 
       # --- Add .ai-context.json to .gitignore ---
       add_to_gitignore
@@ -200,7 +200,8 @@ class RailsAiContextCLI < Thor
       "1" => { key: :claude,   name: "Claude Code",    files: "CLAUDE.md + .claude/rules/" },
       "2" => { key: :cursor,   name: "Cursor",         files: ".cursor/rules/" },
       "3" => { key: :copilot,  name: "GitHub Copilot", files: ".github/copilot-instructions.md + .github/instructions/" },
-      "4" => { key: :opencode, name: "OpenCode",       files: "AGENTS.md" }
+      "4" => { key: :opencode, name: "OpenCode",       files: "AGENTS.md" },
+      "5" => { key: :codex,   name: "Codex CLI",      files: "AGENTS.md + .codex/config.toml" }
     }.freeze
 
     def prompt_ai_tools
@@ -233,7 +234,7 @@ class RailsAiContextCLI < Thor
       $stderr.puts ""
       $stderr.puts "Do you also want MCP server support?"
       $stderr.puts ""
-      $stderr.puts "  1. Yes — MCP server (generates .mcp.json)"
+      $stderr.puts "  1. Yes — MCP server (generates per-tool MCP config files)"
       $stderr.puts "  2. No  — CLI only (no server needed)"
       $stderr.puts ""
       $stderr.print "Enter number (default: 1): "
@@ -245,12 +246,15 @@ class RailsAiContextCLI < Thor
       mode
     end
 
-    # Files/dirs generated per AI tool format — used for cleanup on tool removal
+    # Files/dirs generated per AI tool format — used for cleanup on tool removal.
+    # MCP config files are NOT listed here — they use merge-safe removal via
+    # McpConfigGenerator.remove to preserve other servers' entries.
     FORMAT_PATHS = {
       claude:   %w[CLAUDE.md .claude/rules],
       cursor:   %w[.cursor/rules],
       copilot:  %w[.github/copilot-instructions.md .github/instructions],
-      opencode: %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md]
+      opencode: %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md],
+      codex:    %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md]
     }.freeze
 
     def read_previous_ai_tools
@@ -297,10 +301,17 @@ class RailsAiContextCLI < Thor
       return if to_remove.empty?
 
       require "fileutils"
+      # Collect paths still needed by remaining tools to avoid deleting shared files
+      kept_paths = current.map(&:to_sym).flat_map { |f| FORMAT_PATHS[f] || [] }.to_set
+
       to_remove.each do |fmt|
         tool = AI_TOOL_OPTIONS.values.find { |t| t[:key] == fmt }
+
+        # Remove context files (skip if another selected tool still needs them)
         paths = FORMAT_PATHS[fmt] || []
         paths.each do |rel_path|
+          next if kept_paths.include?(rel_path)
+
           full = File.join(Dir.pwd, rel_path)
           if File.directory?(full)
             FileUtils.rm_rf(full)
@@ -310,6 +321,11 @@ class RailsAiContextCLI < Thor
             $stderr.puts "  Removed #{rel_path}"
           end
         end
+
+        # Merge-safe MCP config cleanup — removes only the rails-ai-context entry
+        cleaned = RailsAiContext::McpConfigGenerator.remove(tools: [ fmt ], output_dir: Dir.pwd)
+        cleaned.each { |f| $stderr.puts "  Removed MCP entry from #{File.basename(f)}" }
+
         $stderr.puts "  #{tool[:name]} files removed" if tool
       end
     end
@@ -339,26 +355,17 @@ class RailsAiContextCLI < Thor
       $stderr.puts "Created .rails-ai-context.yml"
     end
 
-    def write_standalone_mcp_json
-      require "json"
-      mcp_path = File.join(Dir.pwd, ".mcp.json")
-      server_entry = { "command" => "rails-ai-context", "args" => [ "serve" ] }
-
-      if File.exist?(mcp_path)
-        existing = JSON.parse(File.read(mcp_path)) rescue {}
-        existing["mcpServers"] ||= {}
-        if existing["mcpServers"]["rails-ai-context"] == server_entry
-          $stderr.puts ".mcp.json already up to date — skipped"
-        else
-          existing["mcpServers"]["rails-ai-context"] = server_entry
-          File.write(mcp_path, JSON.pretty_generate(existing) + "\n")
-          $stderr.puts "Updated rails-ai-context in .mcp.json"
-        end
-      else
-        content = JSON.pretty_generate({ mcpServers: { "rails-ai-context" => server_entry } }) + "\n"
-        File.write(mcp_path, content)
-        $stderr.puts "Created .mcp.json (auto-discovered by Claude Code, Cursor, etc.)"
-      end
+    def write_mcp_configs(ai_tools, tool_mode)
+      require_relative "../lib/rails_ai_context/mcp_config_generator"
+      generator = ::RailsAiContext::McpConfigGenerator.new(
+        tools: ai_tools,
+        output_dir: Dir.pwd,
+        standalone: true,
+        tool_mode: tool_mode
+      )
+      result = generator.call
+      result[:written].each { |f| $stderr.puts "  Created/Updated #{f}" }
+      result[:skipped].each { |f| $stderr.puts "  #{f} unchanged — skipped" }
     end
 
     def show_standalone_instructions(ai_tools, tool_mode)
@@ -375,7 +382,7 @@ class RailsAiContextCLI < Thor
       $stderr.puts ""
       $stderr.puts "Commands:"
       $stderr.puts "  rails-ai-context context    # Regenerate context files"
-      $stderr.puts "  rails-ai-context tool NAME  # Run any of the 38 tools"
+      $stderr.puts "  rails-ai-context tool NAME  # Run any of the #{tool_count_str} tools"
       if tool_mode == :mcp
         $stderr.puts "  rails-ai-context serve      # Start MCP server"
       end
@@ -383,8 +390,8 @@ class RailsAiContextCLI < Thor
       $stderr.puts ""
       if tool_mode == :mcp
         $stderr.puts "MCP auto-discovery:"
-        $stderr.puts "  .mcp.json is auto-detected by Claude Code and Cursor."
-        $stderr.puts "  No manual config needed — just open your project."
+        $stderr.puts "  Each AI tool gets its own config file — auto-detected on project open."
+        $stderr.puts "  No manual config needed."
       else
         $stderr.puts "CLI tools:"
         $stderr.puts "  AI agents can run `rails-ai-context tool schema table=users` directly."
@@ -392,6 +399,14 @@ class RailsAiContextCLI < Thor
       $stderr.puts ""
       $stderr.puts "Config: .rails-ai-context.yml (edit anytime, no restart needed)"
       $stderr.puts ""
+    end
+
+    def tool_count_str
+      if defined?(::RailsAiContext::Server)
+        ::RailsAiContext::Server::TOOLS.size.to_s
+      else
+        "38"
+      end
     end
 
     def print_context_result(result)

--- a/lib/generators/rails_ai_context/install/install_generator.rb
+++ b/lib/generators/rails_ai_context/install/install_generator.rb
@@ -241,7 +241,7 @@ module RailsAiContext
         SECTION
         "Extensibility" => <<~SECTION,
             # ── Extensibility ─────────────────────────────────────────────────
-            # Register additional MCP tool classes alongside the #{RailsAiContext::Server::TOOLS.size} built-in tools
+            # Register additional MCP tool classes alongside the #{RailsAiContext::Server.builtin_tools.size} built-in tools
             # config.custom_tools = [MyApp::CustomTool]
 
             # Exclude specific built-in tools by name
@@ -520,7 +520,7 @@ module RailsAiContext
         say ""
         say "Commands:", :yellow
         say "  rails ai:context         # Regenerate context files"
-        tool_count = RailsAiContext::Server::TOOLS.size
+        tool_count = RailsAiContext::Server.builtin_tools.size
         say "  rails 'ai:tool[schema]'    # Run any of the #{tool_count} tools from CLI"
         if @tool_mode == :mcp
           say "  rails ai:serve           # Start MCP server (#{tool_count} live tools)"

--- a/lib/generators/rails_ai_context/install/install_generator.rb
+++ b/lib/generators/rails_ai_context/install/install_generator.rb
@@ -13,15 +13,19 @@ module RailsAiContext
         "1" => { key: :claude,   name: "Claude Code",     files: "CLAUDE.md + .claude/rules/",                        format: :claude },
         "2" => { key: :cursor,   name: "Cursor",          files: ".cursor/rules/",                                     format: :cursor },
         "3" => { key: :copilot,  name: "GitHub Copilot",  files: ".github/copilot-instructions.md + .github/instructions/", format: :copilot },
-        "4" => { key: :opencode, name: "OpenCode",        files: "AGENTS.md",                                          format: :opencode }
+        "4" => { key: :opencode, name: "OpenCode",        files: "AGENTS.md",                                          format: :opencode },
+        "5" => { key: :codex,   name: "Codex CLI",       files: "AGENTS.md + .codex/config.toml",                     format: :codex }
       }.freeze
 
-      # Files/dirs generated per AI tool format — used for cleanup on tool removal
+      # Files/dirs generated per AI tool format — used for cleanup on tool removal.
+      # MCP config files are NOT listed here — they use merge-safe removal via
+      # McpConfigGenerator.remove to preserve other servers' entries.
       FORMAT_PATHS = {
         claude:   %w[CLAUDE.md .claude/rules],
         cursor:   %w[.cursor/rules],
         copilot:  %w[.github/copilot-instructions.md .github/instructions],
-        opencode: %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md]
+        opencode: %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md],
+        codex:    %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md]
       }.freeze
 
       def select_ai_tools
@@ -86,10 +90,17 @@ module RailsAiContext
 
         return if to_remove.empty?
 
+        # Collect paths still needed by remaining tools to avoid deleting shared files
+        kept_paths = @selected_formats.flat_map { |f| FORMAT_PATHS[f] || [] }.to_set
+
         to_remove.each do |fmt|
           tool = AI_TOOLS.values.find { |t| t[:format] == fmt }
+
+          # Remove context files (skip if another selected tool still needs them)
           paths = FORMAT_PATHS[fmt] || []
           paths.each do |rel_path|
+            next if kept_paths.include?(rel_path)
+
             full = Rails.root.join(rel_path)
             if File.directory?(full)
               FileUtils.rm_rf(full)
@@ -99,6 +110,11 @@ module RailsAiContext
               say "  Removed #{rel_path}", :red
             end
           end
+
+          # Merge-safe MCP config cleanup — removes only the rails-ai-context entry
+          cleaned = RailsAiContext::McpConfigGenerator.remove(tools: [ fmt ], output_dir: Rails.root.to_s)
+          cleaned.each { |f| say "  Removed MCP entry from #{Pathname.new(f).relative_path_from(Rails.root)}", :red }
+
           say "  ✓ #{tool[:name]} files removed", :green if tool
         end
       end
@@ -107,7 +123,7 @@ module RailsAiContext
         say ""
         say "Do you also want MCP server support?", :yellow
         say ""
-        say "  1. Yes — MCP primary + CLI fallback (generates .mcp.json)"
+        say "  1. Yes — MCP primary + CLI fallback (generates per-tool MCP config files)"
         say "  2. No  — CLI only (no server needed)"
         say ""
 
@@ -123,34 +139,23 @@ module RailsAiContext
       end
 
       def create_mcp_config
-        # Skip .mcp.json for CLI-only mode
-        if @tool_mode == :cli
-          say "Skipped .mcp.json (CLI-only mode)", :yellow
-          return
+        generator = RailsAiContext::McpConfigGenerator.new(
+          tools: @selected_formats,
+          output_dir: Rails.root.to_s,
+          standalone: false,
+          tool_mode: @tool_mode
+        )
+        result = generator.call
+        result[:written].each do |f|
+          rel = Pathname.new(f).relative_path_from(Rails.root)
+          say "Created/Updated #{rel}", :green
         end
-        mcp_path = Rails.root.join(".mcp.json")
-        server_entry = {
-          "command" => "bundle",
-          "args" => [ "exec", "rails", "ai:serve" ]
-        }
-
-        if File.exist?(mcp_path)
-          existing = JSON.parse(File.read(mcp_path)) rescue {}
-          existing["mcpServers"] ||= {}
-
-          if existing["mcpServers"]["rails-ai-context"] == server_entry
-            say ".mcp.json already up to date — skipped", :yellow
-          else
-            existing["mcpServers"]["rails-ai-context"] = server_entry
-            File.write(mcp_path, JSON.pretty_generate(existing) + "\n")
-            verb = existing["mcpServers"].key?("rails-ai-context") ? "Updated" : "Added"
-            say "#{verb} rails-ai-context in .mcp.json", :green
-          end
-        else
-          create_file ".mcp.json", JSON.pretty_generate({
-            mcpServers: { "rails-ai-context" => server_entry }
-          }) + "\n"
-          say "Created .mcp.json (auto-discovered by Claude Code, Cursor, etc.)", :green
+        result[:skipped].each do |f|
+          rel = Pathname.new(f).relative_path_from(Rails.root)
+          say "#{rel} unchanged — skipped", :yellow
+        end
+        if @tool_mode == :cli
+          say "Skipped MCP config files (CLI-only mode)", :yellow
         end
       end
 
@@ -162,7 +167,7 @@ module RailsAiContext
             # ── AI Tools ──────────────────────────────────────────────────────
             # Which AI tools to generate context files for (selected during install)
             # Run `rails generate rails_ai_context:install` to change selection
-            # config.ai_tools = %i[claude cursor copilot opencode]  # default: all
+            # config.ai_tools = %i[claude cursor copilot opencode codex]  # default: all
 
             # Tool invocation mode:
             #   :mcp — MCP primary + CLI fallback (default, requires `rails ai:serve`)
@@ -525,8 +530,8 @@ module RailsAiContext
         say ""
         if @tool_mode == :mcp
           say "MCP auto-discovery:", :yellow
-          say "  .mcp.json is auto-detected by Claude Code and Cursor."
-          say "  No manual config needed — just open your project."
+          say "  Each AI tool gets its own config file — auto-detected on project open."
+          say "  No manual config needed."
         else
           say "CLI tools:", :yellow
           say "  AI agents can run `rails 'ai:tool[schema]' table=users` directly."
@@ -543,7 +548,7 @@ module RailsAiContext
         say "  rails-ai-context init          # interactive setup"
         say "  rails-ai-context serve         # start MCP server"
         say ""
-        say "Commit context files and .mcp.json so your team benefits!", :green
+        say "Commit context files and MCP config files so your team benefits!", :green
       end
     end
   end

--- a/lib/rails_ai_context/cli/tool_runner.rb
+++ b/lib/rails_ai_context/cli/tool_runner.rb
@@ -48,7 +48,7 @@ module RailsAiContext
       # Filtered tool list respecting skip_tools config.
       def self.available_tools
         skip = RailsAiContext.configuration.skip_tools
-        tools = Server::TOOLS
+        tools = Server.builtin_tools
         tools += RailsAiContext.configuration.custom_tools
         return tools if skip.empty?
         tools.reject { |t| skip.include?(t.tool_name) }

--- a/lib/rails_ai_context/configuration.rb
+++ b/lib/rails_ai_context/configuration.rb
@@ -156,7 +156,7 @@ module RailsAiContext
     attr_accessor :skip_tools
 
     # Which AI tools to generate context for (selected during install)
-    # nil = all formats, or %i[claude cursor copilot opencode]
+    # nil = all formats, or %i[claude cursor copilot opencode codex]
     attr_accessor :ai_tools
 
     # Tool invocation mode: :mcp (MCP primary + CLI fallback) or :cli (CLI only)

--- a/lib/rails_ai_context/doctor.rb
+++ b/lib/rails_ai_context/doctor.rb
@@ -18,6 +18,7 @@ module RailsAiContext
       check_migrations
       check_context_freshness
       check_mcp_json
+      check_codex_env_staleness
       check_mcp_buildable
       check_introspector_health
       check_preset_coverage
@@ -49,6 +50,13 @@ module RailsAiContext
     end
 
     private
+
+    # All configured AI tools, defaulting to all 5 when nil (unconfigured).
+    ALL_AI_TOOLS = %i[claude cursor copilot opencode codex].freeze
+
+    def configured_ai_tools
+      RailsAiContext.configuration.ai_tools || ALL_AI_TOOLS
+    end
 
     # ── Existence checks ──────────────────────────────────────────────
 
@@ -160,45 +168,158 @@ module RailsAiContext
 
     # ── Context file checks ───────────────────────────────────────────
 
+    # Per-tool context paths — root files or split rule directories.
+    # Some tools (cursor) produce only split rules, no root file.
+    CONTEXT_FILES = {
+      claude:   "CLAUDE.md",
+      cursor:   ".cursor/rules",
+      opencode: "AGENTS.md",
+      codex:    "AGENTS.md",
+      copilot:  ".github/copilot-instructions.md"
+    }.freeze
+
     def check_context_freshness
-      claude_path = File.join(app.root, "CLAUDE.md")
-      unless File.exist?(claude_path)
+      ai_tools = configured_ai_tools
+
+      # Find the first existing context file or split rule directory for configured tools
+      context_file = nil
+      context_label = nil
+      ai_tools.each do |tool|
+        filename = CONTEXT_FILES[tool]
+        next unless filename
+
+        path = File.join(app.root, filename)
+        if File.exist?(path) || Dir.exist?(path)
+          context_file = path
+          context_label = filename
+          break
+        end
+      end
+
+      unless context_file
         return Check.new(name: "Context files", status: :warn,
           message: "No context files generated",
           fix: "Run `rails ai:context`")
       end
 
-      generated_at = File.mtime(claude_path)
-      # Check if any source file changed after context was generated
+      generated_at = if File.directory?(context_file)
+        # Split rule directories: use the most recent file's mtime
+        Dir.glob(File.join(context_file, "**/*"))
+          .reject { |f| File.directory?(f) }
+          .map { |f| File.mtime(f) }
+          .max || Time.at(0)
+      else
+        File.mtime(context_file)
+      end
+      # Check if any source file changed after context was generated.
+      # Exclude our own initializer — it's written during install and would
+      # always appear newer than context files generated in the same run.
       stale_dirs = %w[app/models app/controllers app/views config db/migrate].select do |dir|
         full = File.join(app.root, dir)
-        Dir.exist?(full) && Dir.glob(File.join(full, "**/*.rb")).any? { |f| File.mtime(f) > generated_at }
+        Dir.exist?(full) && Dir.glob(File.join(full, "**/*.rb"))
+          .reject { |f| f.end_with?("initializers/rails_ai_context.rb") }
+          .any? { |f| File.mtime(f) > generated_at }
       end
 
       if stale_dirs.empty?
-        Check.new(name: "Context files", status: :pass, message: "CLAUDE.md is up to date", fix: nil)
+        Check.new(name: "Context files", status: :pass, message: "#{context_label} is up to date", fix: nil)
       else
         Check.new(name: "Context files", status: :warn,
-          message: "CLAUDE.md may be stale — #{stale_dirs.join(', ')} changed since last generation",
+          message: "#{context_label} may be stale — #{stale_dirs.join(', ')} changed since last generation",
           fix: "Run `rails ai:context` to regenerate")
       end
     end
 
     def check_mcp_json
-      mcp_path = File.join(app.root, ".mcp.json")
-      unless File.exist?(mcp_path)
-        return Check.new(name: ".mcp.json", status: :warn,
-          message: "No .mcp.json for MCP auto-discovery",
-          fix: "Run `rails generate rails_ai_context:install`")
+      if RailsAiContext.configuration.tool_mode == :cli
+        return Check.new(name: "MCP configs", status: :pass,
+          message: "Skipped (CLI-only mode)", fix: nil)
       end
 
-      begin
-        JSON.parse(File.read(mcp_path))
-        Check.new(name: ".mcp.json", status: :pass, message: ".mcp.json valid", fix: nil)
-      rescue JSON::ParserError => e
-        Check.new(name: ".mcp.json", status: :fail,
-          message: ".mcp.json has invalid JSON: #{e.message}",
-          fix: "Run `rails generate rails_ai_context:install` to regenerate")
+      ai_tools = configured_ai_tools
+      configs = {
+        claude:   { path: ".mcp.json",         label: ".mcp.json (Claude Code)" },
+        cursor:   { path: ".cursor/mcp.json",  label: ".cursor/mcp.json (Cursor)" },
+        copilot:  { path: ".vscode/mcp.json",  label: ".vscode/mcp.json (VS Code/Copilot)" },
+        opencode: { path: "opencode.json",     label: "opencode.json (OpenCode)" },
+        codex:    { path: ".codex/config.toml", label: ".codex/config.toml (Codex CLI)" }
+      }
+
+      # Check at least the Claude Code config (always expected)
+      tools_to_check = ai_tools & configs.keys
+      tools_to_check = %i[claude] if tools_to_check.empty?
+
+      checks = tools_to_check.map do |tool|
+        cfg = configs[tool]
+        full_path = File.join(app.root, cfg[:path])
+        unless File.exist?(full_path)
+          next Check.new(name: cfg[:label], status: :warn,
+            message: "No #{cfg[:path]} for MCP auto-discovery",
+            fix: "Run `rails generate rails_ai_context:install`")
+        end
+
+        if cfg[:path].end_with?(".toml")
+          Check.new(name: cfg[:label], status: :pass, message: "#{cfg[:path]} exists", fix: nil)
+        else
+          begin
+            JSON.parse(File.read(full_path))
+            Check.new(name: cfg[:label], status: :pass, message: "#{cfg[:path]} valid", fix: nil)
+          rescue JSON::ParserError => e
+            Check.new(name: cfg[:label], status: :fail,
+              message: "#{cfg[:path]} has invalid JSON: #{e.message}",
+              fix: "Run `rails generate rails_ai_context:install` to regenerate")
+          end
+        end
+      end
+
+      # Aggregate all results into a single summary check
+      failures = checks.select { |c| c.status != :pass }
+
+      if failures.empty?
+        Check.new(name: "MCP configs", status: :pass,
+          message: "#{checks.size} of #{checks.size} MCP config(s) valid",
+          fix: nil)
+      else
+        labels = failures.map { |c| c.name }
+        worst_status = failures.any? { |c| c.status == :fail } ? :fail : :warn
+        Check.new(name: "MCP configs", status: worst_status,
+          message: "#{failures.size} of #{checks.size} MCP config(s) need attention: #{labels.join(', ')}",
+          fix: "Run `rails generate rails_ai_context:install` to fix")
+      end
+    end
+
+    def check_codex_env_staleness
+      return nil if RailsAiContext.configuration.tool_mode == :cli
+
+      ai_tools = configured_ai_tools
+      return nil unless ai_tools.include?(:codex)
+
+      toml_path = File.join(app.root, ".codex/config.toml")
+      return nil unless File.exist?(toml_path)
+
+      content = File.read(toml_path)
+      match = content.match(/^\[mcp_servers\.rails-ai-context\.env\]\s*$(.+?)(?=\n\[|\z)/m)
+      return nil unless match
+
+      env_section = match[1]
+
+      # Check if snapshotted GEM_HOME directory still exists on disk.
+      # This is version-manager agnostic and OS agnostic — no string format
+      # assumptions. If the directory was removed (e.g. Ruby upgrade), the
+      # env snapshot is definitely stale.
+      gem_home_match = env_section.match(/^GEM_HOME\s*=\s*"([^"]+)"/)
+      return nil unless gem_home_match
+
+      snapshot_gem_home = gem_home_match[1]
+
+      if Dir.exist?(snapshot_gem_home)
+        Check.new(name: "Codex env snapshot", status: :pass,
+          message: "Codex GEM_HOME (#{snapshot_gem_home}) exists — env snapshot is current",
+          fix: nil)
+      else
+        Check.new(name: "Codex env snapshot", status: :warn,
+          message: "Codex MCP env snapshot is stale — GEM_HOME #{snapshot_gem_home} no longer exists. Re-run the install generator to update.",
+          fix: "Run `rails generate rails_ai_context:install` or `rails-ai-context init`")
       end
     end
 

--- a/lib/rails_ai_context/mcp_config_generator.rb
+++ b/lib/rails_ai_context/mcp_config_generator.rb
@@ -1,0 +1,293 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+require "securerandom"
+
+module RailsAiContext
+  # Generates per-tool MCP config files so each AI tool auto-discovers the MCP server.
+  #
+  # Each tool has its own config file format:
+  #   Claude Code  → .mcp.json          (mcpServers key)
+  #   Cursor       → .cursor/mcp.json   (mcpServers key)
+  #   VS Code      → .vscode/mcp.json   (servers key)
+  #   OpenCode     → opencode.json      (mcp key, type: "local", command as array)
+  #   Codex CLI    → .codex/config.toml (TOML, [mcp_servers.NAME] section)
+  class McpConfigGenerator
+    TOOL_CONFIGS = {
+      claude:   { path: ".mcp.json",          root_key: "mcpServers", format: :mcp_json },
+      cursor:   { path: ".cursor/mcp.json",   root_key: "mcpServers", format: :mcp_json },
+      copilot:  { path: ".vscode/mcp.json",   root_key: "servers",    format: :vscode_json },
+      opencode: { path: "opencode.json",      root_key: "mcp",        format: :opencode_json },
+      codex:    { path: ".codex/config.toml",  root_key: nil,          format: :codex_toml }
+    }.freeze
+
+    SERVER_NAME = "rails-ai-context"
+
+    # @param tools [Array<Symbol>] selected AI tool keys (e.g. [:claude, :cursor])
+    # @param output_dir [String] project root path
+    # @param standalone [Boolean] true for standalone CLI mode
+    # @param tool_mode [Symbol] :mcp or :cli
+    def initialize(tools:, output_dir:, standalone: false, tool_mode: :mcp)
+      @tools = Array(tools).map(&:to_sym)
+      @output_dir = output_dir
+      @standalone = standalone
+      @tool_mode = tool_mode
+    end
+
+    # @return [Hash] { written: [paths], skipped: [paths] }
+    def call
+      return { written: [], skipped: [] } if @tool_mode == :cli
+
+      written = []
+      skipped = []
+
+      @tools.each do |tool|
+        config = TOOL_CONFIGS[tool]
+        next unless config
+
+        path = File.join(@output_dir, config[:path])
+        result = generate_for(tool, path, config)
+        case result
+        when :written then written << path
+        when :skipped then skipped << path
+        end
+      end
+
+      { written: written, skipped: skipped }
+    end
+
+    private
+
+    def generate_for(tool, path, config)
+      case config[:format]
+      when :mcp_json     then write_mcp_json(path, config[:root_key])
+      when :vscode_json  then write_vscode_json(path)
+      when :opencode_json then write_opencode_json(path)
+      when :codex_toml   then write_codex_toml(path)
+      end
+    end
+
+    # Claude Code (.mcp.json) and Cursor (.cursor/mcp.json)
+    # Format: { "mcpServers": { "rails-ai-context": { "command": "...", "args": [...] } } }
+    def write_mcp_json(path, root_key)
+      entry = mcp_json_entry
+      merge_json(path, root_key, entry)
+    end
+
+    # VS Code / Copilot (.vscode/mcp.json)
+    # Format: { "servers": { "rails-ai-context": { "command": "...", "args": [...] } } }
+    # Type is optional for stdio — VS Code infers from presence of command.
+    def write_vscode_json(path)
+      entry = mcp_json_entry
+      merge_json(path, "servers", entry)
+    end
+
+    # OpenCode (opencode.json)
+    # Format: { "mcp": { "rails-ai-context": { "type": "local", "command": [...] } } }
+    # Note: command is an ARRAY (not separate command/args)
+    def write_opencode_json(path)
+      cmd = server_command
+      entry = { "type" => "local", "command" => cmd }
+      merge_json(path, "mcp", entry)
+    end
+
+    # Codex CLI (.codex/config.toml)
+    # Format: [mcp_servers.rails-ai-context] section with command (string) and args (string array)
+    def write_codex_toml(path)
+      section = build_codex_section
+      merge_toml(path, section)
+    end
+
+    # --- JSON merge logic ---
+
+    def merge_json(path, root_key, entry)
+      FileUtils.mkdir_p(File.dirname(path))
+
+      if File.exist?(path)
+        existing = begin
+          JSON.parse(File.read(path))
+        rescue JSON::ParserError
+          {}
+        end
+        existing[root_key] ||= {}
+
+        if existing[root_key][SERVER_NAME] == entry
+          return :skipped
+        end
+
+        existing[root_key][SERVER_NAME] = entry
+        atomic_write(path, JSON.pretty_generate(existing) + "\n")
+      else
+        content = JSON.pretty_generate({ root_key => { SERVER_NAME => entry } }) + "\n"
+        atomic_write(path, content)
+      end
+
+      :written
+    end
+
+    # --- TOML merge logic ---
+
+    TOML_SECTION_HEADER = "[mcp_servers.#{SERVER_NAME}]"
+    # Matches the [mcp_servers.rails-ai-context] section and any sub-sections
+    # like [mcp_servers.rails-ai-context.env], stopping at a non-sub-section header.
+    TOML_SECTION_REGEX = /
+      ^\[mcp_servers\.rails-ai-context\]\s*\n           # main section header
+      (?:(?!\n\[(?!mcp_servers\.rails-ai-context\.))[^\n]*\n)*  # lines until non-sub-section
+      (?:(?!\n?\[(?!mcp_servers\.rails-ai-context\.))[^\n]+)?   # optional last line without \n
+    /mx
+
+    def merge_toml(path, section)
+      FileUtils.mkdir_p(File.dirname(path))
+
+      if File.exist?(path)
+        content = File.read(path)
+
+        if content.include?(TOML_SECTION_HEADER)
+          new_content = content.sub(TOML_SECTION_REGEX, section)
+          if new_content == content
+            return :skipped
+          end
+          atomic_write(path, new_content)
+        else
+          # Append our section
+          separator = content.end_with?("\n") ? "\n" : "\n\n"
+          atomic_write(path, content + separator + section)
+        end
+      else
+        atomic_write(path, section)
+      end
+
+      :written
+    end
+
+    def build_codex_section
+      lines = []
+      lines << "[mcp_servers.#{SERVER_NAME}]"
+
+      if @standalone
+        lines << 'command = "rails-ai-context"'
+        lines << 'args = ["serve"]'
+      else
+        lines << 'command = "bundle"'
+        lines << 'args = ["exec", "rails", "ai:serve"]'
+      end
+
+      # Codex CLI env_clear()s the process environment. Capture the current Ruby
+      # environment so the MCP server can find gems regardless of version manager
+      # (rbenv, rvm, asdf, mise, or system Ruby).
+      env_vars = ruby_env_snapshot
+      unless env_vars.empty?
+        lines << ""
+        lines << "[mcp_servers.#{SERVER_NAME}.env]"
+        env_vars.each { |k, v| lines << "#{k} = #{v.inspect}" }
+      end
+
+      lines.join("\n") + "\n"
+    end
+
+    # Snapshot environment variables needed for Ruby/Bundler to work.
+    # Only captures vars that are actually set — works with any version manager.
+    RUBY_ENV_KEYS = %w[PATH GEM_HOME GEM_PATH GEM_ROOT RUBY_VERSION BUNDLE_PATH].freeze
+
+    def ruby_env_snapshot
+      snapshot = {}
+      RUBY_ENV_KEYS.each do |key|
+        val = ENV[key]
+        snapshot[key] = val if val && !val.empty?
+      end
+      snapshot
+    end
+
+    # --- Shared helpers ---
+
+    def mcp_json_entry
+      if @standalone
+        { "command" => "rails-ai-context", "args" => [ "serve" ] }
+      else
+        { "command" => "bundle", "args" => [ "exec", "rails", "ai:serve" ] }
+      end
+    end
+
+    def server_command
+      if @standalone
+        [ "rails-ai-context", "serve" ]
+      else
+        [ "bundle", "exec", "rails", "ai:serve" ]
+      end
+    end
+
+    def atomic_write(path, content)
+      dir = File.dirname(path)
+      tmp = File.join(dir, ".#{File.basename(path)}.#{SecureRandom.hex(4)}.tmp")
+      File.write(tmp, content)
+      File.rename(tmp, path)
+    end
+
+    # --- Merge-safe removal ---
+
+    # Removes only the rails-ai-context entry from each tool's MCP config file,
+    # preserving other servers. Deletes the file only if no other entries remain.
+    #
+    # @param tools [Array<Symbol>] tool keys to remove MCP entries from
+    # @param output_dir [String] project root path
+    # @return [Array<String>] paths that were modified or deleted
+    def self.remove(tools:, output_dir:)
+      cleaned = []
+      Array(tools).map(&:to_sym).each do |tool|
+        config = TOOL_CONFIGS[tool]
+        next unless config
+
+        path = File.join(output_dir, config[:path])
+        next unless File.exist?(path)
+
+        if config[:format] == :codex_toml
+          cleaned << path if remove_toml_entry(path)
+        else
+          root_key = config[:root_key]
+          cleaned << path if remove_json_entry(path, root_key)
+        end
+      end
+      cleaned
+    end
+
+    def self.remove_json_entry(path, root_key)
+      data = JSON.parse(File.read(path))
+      return false unless data.dig(root_key, SERVER_NAME)
+
+      data[root_key].delete(SERVER_NAME)
+
+      if data[root_key].empty?
+        data.delete(root_key)
+      end
+
+      if data.empty?
+        File.delete(path)
+      else
+        File.write(path, JSON.pretty_generate(data) + "\n")
+      end
+      true
+    rescue JSON::ParserError
+      false
+    end
+
+    def self.remove_toml_entry(path)
+      content = File.read(path)
+      return false unless content.include?(TOML_SECTION_HEADER)
+
+      new_content = content.sub(TOML_SECTION_REGEX, "")
+      # Clean up extra blank lines left behind
+      new_content.gsub!(/\n{3,}/, "\n\n")
+      new_content.strip!
+
+      if new_content.empty?
+        File.delete(path)
+      else
+        File.write(path, new_content + "\n")
+      end
+      true
+    end
+
+    private_class_method :remove_json_entry, :remove_toml_entry
+  end
+end

--- a/lib/rails_ai_context/serializers/claude_rules_serializer.rb
+++ b/lib/rails_ai_context/serializers/claude_rules_serializer.rb
@@ -72,6 +72,12 @@ module RailsAiContext
         return nil if tables.empty?
 
         lines = [
+          "---",
+          "paths:",
+          '  - "db/schema.rb"',
+          '  - "db/migrate/**"',
+          "---",
+          "",
           "# Database Tables (#{tables.size})",
           "",
           "_Snapshot — may be stale after migrations. Use `rails_get_schema(table:\"name\")` for live data._",
@@ -152,6 +158,11 @@ module RailsAiContext
         return nil if models.empty?
 
         lines = [
+          "---",
+          "paths:",
+          '  - "app/models/**/*.rb"',
+          "---",
+          "",
           "# ActiveRecord Models (#{models.size})",
           "",
           "_Quick reference — use `rails_get_model_details(model:\"Name\")` for live data with resolved concerns and callbacks._",
@@ -213,6 +224,12 @@ module RailsAiContext
         return nil if components.empty?
 
         lines = [
+          "---",
+          "paths:",
+          '  - "app/components/**/*.rb"',
+          '  - "app/views/components/**"',
+          "---",
+          "",
           "# Components (#{components.size})",
           "",
           "ViewComponent and Phlex components available for reuse.",

--- a/lib/rails_ai_context/serializers/context_file_serializer.rb
+++ b/lib/rails_ai_context/serializers/context_file_serializer.rb
@@ -2,6 +2,7 @@
 
 require "fileutils"
 require "securerandom"
+require "set"
 
 module RailsAiContext
   module Serializers
@@ -18,6 +19,7 @@ module RailsAiContext
       FORMAT_MAP = {
         claude:    "CLAUDE.md",
         opencode:  "AGENTS.md",
+        codex:     "AGENTS.md",
         copilot:   ".github/copilot-instructions.md",
         json:      ".ai-context.json"
       }.freeze
@@ -44,6 +46,8 @@ module RailsAiContext
         written = []
         skipped = []
 
+        seen_root_files = Set.new
+
         formats.each do |fmt|
           next if SPLIT_ONLY_FORMATS.include?(fmt)
 
@@ -55,6 +59,10 @@ module RailsAiContext
 
           # Skip root files when generate_root_files is false
           next unless generate_root
+
+          # Deduplicate: skip if this root file was already written (e.g. AGENTS.md for both :opencode and :codex)
+          next if seen_root_files.include?(filename)
+          seen_root_files << filename
 
           filepath = File.join(output_dir, filename)
           FileUtils.mkdir_p(File.dirname(filepath))
@@ -77,10 +85,10 @@ module RailsAiContext
 
       def serialize(fmt)
         case fmt
-        when :json     then JsonSerializer.new(context).call
-        when :claude   then ClaudeSerializer.new(context).call
-        when :opencode then OpencodeSerializer.new(context).call
-        when :copilot  then CopilotSerializer.new(context).call
+        when :json             then JsonSerializer.new(context).call
+        when :claude           then ClaudeSerializer.new(context).call
+        when :opencode, :codex then OpencodeSerializer.new(context).call
+        when :copilot          then CopilotSerializer.new(context).call
         else MarkdownSerializer.new(context).call
         end
       end
@@ -154,6 +162,13 @@ module RailsAiContext
 
         if formats.include?(:copilot)
           result = CopilotInstructionsSerializer.new(context).call(output_dir)
+          written.concat(result[:written])
+          skipped.concat(result[:skipped])
+        end
+
+        # Codex reuses OpenCode's directory-level AGENTS.md split rules
+        if formats.include?(:codex) && !formats.include?(:opencode)
+          result = OpencodeRulesSerializer.new(context).call(output_dir)
           written.concat(result[:written])
           skipped.concat(result[:skipped])
         end

--- a/lib/rails_ai_context/serializers/copilot_instructions_serializer.rb
+++ b/lib/rails_ai_context/serializers/copilot_instructions_serializer.rb
@@ -33,6 +33,8 @@ module RailsAiContext
         lines = [
           "---",
           "applyTo: \"**/*\"",
+          "name: \"Rails Project Overview\"",
+          "description: \"Rails version, database, models, routes, gems, architecture patterns\"",
           "---",
           "",
           "# #{context[:app_name] || 'Rails App'} — Overview",
@@ -93,6 +95,8 @@ module RailsAiContext
         lines = [
           "---",
           "applyTo: \"app/models/**/*.rb\"",
+          "name: \"Rails Models Reference\"",
+          "description: \"ActiveRecord models — associations, validations, scopes, enums\"",
           "---",
           "",
           "# ActiveRecord Models (#{models.size})",
@@ -122,6 +126,8 @@ module RailsAiContext
         lines = [
           "---",
           "applyTo: \"app/controllers/**/*.rb\"",
+          "name: \"Rails Controllers Reference\"",
+          "description: \"Controllers — actions, filters, strong parameters\"",
           "---",
           "",
           "# Controllers (#{controllers.size})",
@@ -139,6 +145,8 @@ module RailsAiContext
         lines = [
           "---",
           "applyTo: \"**/*\"",
+          "name: \"Rails MCP Tools\"",
+          "description: \"#{tool_count} introspection tools — schema, models, routes, controllers, search, testing, validation\"",
           "excludeAgent: \"code-review\"",
           "---",
           ""

--- a/lib/rails_ai_context/serializers/cursor_rules_serializer.rb
+++ b/lib/rails_ai_context/serializers/cursor_rules_serializer.rb
@@ -155,12 +155,12 @@ module RailsAiContext
         lines.join("\n")
       end
 
-      # Always-on MCP tool reference — strongest enforcement point for Cursor
+      # Agent-requested MCP tool reference — loaded on-demand when agent needs tool guidance
       def render_mcp_tools_rule
         lines = [
           "---",
-          "description: \"Rails tools (#{tool_count}) — MANDATORY, use before reading any reference files\"",
-          "alwaysApply: true",
+          "description: \"Rails MCP tools reference — #{tool_count} tools for schema, models, routes, controllers, search, testing, and more\"",
+          "alwaysApply: false",
           "---",
           ""
         ]

--- a/lib/rails_ai_context/serializers/markdown_serializer.rb
+++ b/lib/rails_ai_context/serializers/markdown_serializer.rb
@@ -61,7 +61,7 @@ module RailsAiContext
           > Generated: #{context[:generated_at]}
           > Rails #{context[:rails_version]} | Ruby #{context[:ruby_version]}
 
-          This file gives AI assistants (Claude Code, Cursor, Copilot) deep context
+          This file gives AI assistants (Claude Code, Cursor, Copilot, OpenCode, Codex) deep context
           about this Rails application's structure, patterns, and conventions.
         MD
       end

--- a/lib/rails_ai_context/serializers/tool_guide_helper.rb
+++ b/lib/rails_ai_context/serializers/tool_guide_helper.rb
@@ -23,9 +23,9 @@ module RailsAiContext
         RailsAiContext.configuration.tool_mode
       end
 
-      # Derived from Server::TOOLS — the single source of truth for tool count.
+      # Derived from BaseTool.registered_tools — the single source of truth for tool count.
       def tool_count
-        RailsAiContext::Server::TOOLS.size
+        RailsAiContext::Server.builtin_tools.size
       end
 
       def tools_header

--- a/lib/rails_ai_context/serializers/tool_guide_helper.rb
+++ b/lib/rails_ai_context/serializers/tool_guide_helper.rb
@@ -43,7 +43,7 @@ module RailsAiContext
           ]
         else
           [
-            "This project has #{tool_count} MCP tools via `rails ai:serve` (configured in `.mcp.json`).",
+            "This project has #{tool_count} MCP tools via `rails ai:serve`.",
             "**MANDATORY — use these instead of reading files.** They return ground truth from the running app:",
             "real schema, real associations, real filters — not guesses from file reads.",
             "Read files ONLY when you are about to Edit them.",

--- a/lib/rails_ai_context/server.rb
+++ b/lib/rails_ai_context/server.rb
@@ -8,46 +8,26 @@ module RailsAiContext
   class Server
     attr_reader :app, :transport_type
 
-    TOOLS = [
-      Tools::GetSchema,
-      Tools::GetRoutes,
-      Tools::GetModelDetails,
-      Tools::GetGems,
-      Tools::SearchCode,
-      Tools::GetConventions,
-      Tools::GetControllers,
-      Tools::GetConfig,
-      Tools::GetTestInfo,
-      Tools::GetView,
-      Tools::GetStimulus,
-      Tools::GetEditContext,
-      Tools::Validate,
-      Tools::AnalyzeFeature,
-      Tools::SecurityScan,
-      Tools::GetConcern,
-      Tools::GetCallbacks,
-      Tools::GetHelperMethods,
-      Tools::GetServicePattern,
-      Tools::GetJobPattern,
-      Tools::GetEnv,
-      Tools::GetPartialInterface,
-      Tools::GetTurboMap,
-      Tools::GetContext,
-      Tools::GetComponentCatalog,
-      Tools::PerformanceCheck,
-      Tools::DependencyGraph,
-      Tools::MigrationAdvisor,
-      Tools::GetFrontendStack,
-      Tools::SearchDocs,
-      Tools::Query,
-      Tools::ReadLogs,
-      Tools::GenerateTest,
-      Tools::Diagnose,
-      Tools::ReviewChanges,
-      Tools::Onboard,
-      Tools::RuntimeInfo,
-      Tools::SessionContext
-    ].freeze
+    # All built-in tools, auto-discovered from Tools::BaseTool subclasses.
+    # Kept as a class method (not a constant) so auto-registration works.
+    # Legacy constant accessor preserved for backwards compatibility.
+    def self.builtin_tools
+      Tools::BaseTool.registered_tools
+    end
+
+    # Backwards-compatible constant — delegates to the registry.
+    # Existing code referencing Server::TOOLS continues to work.
+    # Emits a deprecation notice once to guide migration.
+    def self.const_missing(name)
+      if name == :TOOLS
+        unless @tools_deprecation_warned
+          @tools_deprecation_warned = true
+          $stderr.puts "[rails-ai-context] DEPRECATION: Server::TOOLS is deprecated, use Server.builtin_tools instead" if ENV["DEBUG"]
+        end
+        return builtin_tools
+      end
+      super
+    end
 
     def initialize(app, transport: :stdio)
       @app = app
@@ -102,10 +82,11 @@ module RailsAiContext
     private
 
     def active_tools(config)
+      tools = self.class.builtin_tools
       skip = config.skip_tools
-      return TOOLS if skip.empty?
+      return tools if skip.empty?
 
-      TOOLS.reject { |t| skip.include?(t.tool_name) }
+      tools.reject { |t| skip.include?(t.tool_name) }
     end
 
     def start_stdio(server)

--- a/lib/rails_ai_context/tasks/rails_ai_context.rake
+++ b/lib/rails_ai_context/tasks/rails_ai_context.rake
@@ -7,6 +7,7 @@ ASSISTANT_TABLE = <<~TABLE unless defined?(ASSISTANT_TABLE)
   OpenCode           AGENTS.md                             rails ai:context:opencode
   Cursor             .cursor/rules/                        rails ai:context:cursor
   GitHub Copilot     .github/copilot-instructions.md       rails ai:context:copilot
+  Codex CLI          AGENTS.md + .codex/config.toml        rails ai:context:codex
   JSON (generic)     .ai-context.json                      rails ai:context:json
 TABLE
 
@@ -27,7 +28,8 @@ AI_TOOL_OPTIONS = {
   "1" => { key: :claude,   name: "Claude Code" },
   "2" => { key: :cursor,   name: "Cursor" },
   "3" => { key: :copilot,  name: "GitHub Copilot" },
-  "4" => { key: :opencode, name: "OpenCode" }
+  "4" => { key: :opencode, name: "OpenCode" },
+  "5" => { key: :codex,   name: "Codex CLI" }
 }.freeze unless defined?(AI_TOOL_OPTIONS)
 
 def prompt_ai_tools
@@ -60,7 +62,7 @@ def prompt_tool_mode
   puts ""
   puts "Do you also want MCP server support?"
   puts ""
-  puts "  1. Yes — MCP primary + CLI fallback (generates .mcp.json)"
+  puts "  1. Yes — MCP primary + CLI fallback (generates per-tool MCP config files)"
   puts "  2. No  — CLI only (no server needed)"
   puts ""
   print "Enter number (default: 1): "
@@ -96,28 +98,19 @@ rescue => e
   nil
 end unless defined?(save_tool_mode_to_initializer)
 
-def ensure_mcp_json
-  require "json"
-  mcp_path = Rails.root.join(".mcp.json")
-  server_entry = { "command" => "bundle", "args" => [ "exec", "rails", "ai:serve" ] }
-
-  if File.exist?(mcp_path)
-    existing = JSON.parse(File.read(mcp_path)) rescue {}
-    existing["mcpServers"] ||= {}
-    if existing["mcpServers"]["rails-ai-context"] == server_entry
-      return # already up to date
-    end
-    existing["mcpServers"]["rails-ai-context"] = server_entry
-    File.write(mcp_path, JSON.pretty_generate(existing) + "\n")
-    puts "✅ Updated rails-ai-context in .mcp.json"
-  else
-    content = JSON.pretty_generate({ mcpServers: { "rails-ai-context" => server_entry } }) + "\n"
-    File.write(mcp_path, content)
-    puts "✅ Created .mcp.json (MCP auto-discovery for Claude Code, Cursor, etc.)"
-  end
+def ensure_mcp_configs(ai_tools = nil)
+  tools = ai_tools || RailsAiContext.configuration.ai_tools || RailsAiContext::McpConfigGenerator::TOOL_CONFIGS.keys
+  generator = RailsAiContext::McpConfigGenerator.new(
+    tools: tools,
+    output_dir: Rails.root.to_s,
+    standalone: false,
+    tool_mode: RailsAiContext.configuration.tool_mode
+  )
+  result = generator.call
+  result[:written].each { |f| puts "✅ Created/Updated #{f}" }
 rescue => e
-  puts "⚠️  Could not create .mcp.json: #{e.message}"
-end unless defined?(ensure_mcp_json)
+  puts "⚠️  Could not create MCP config files: #{e.message}"
+end unless defined?(ensure_mcp_configs)
 
 def tool_mode_configured?
   init_path = Rails.root.join("config/initializers/rails_ai_context.rb")
@@ -168,11 +161,15 @@ rescue => e
   nil
 end unless defined?(save_yaml_config)
 
+# Files/dirs generated per AI tool format — used for cleanup on tool removal.
+# MCP config files are NOT listed here — they use merge-safe removal via
+# McpConfigGenerator.remove to preserve other servers' entries.
 FORMAT_PATHS = {
   claude:   %w[CLAUDE.md .claude/rules],
   cursor:   %w[.cursor/rules],
   copilot:  %w[.github/copilot-instructions.md .github/instructions],
-  opencode: %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md]
+  opencode: %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md],
+  codex:    %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md]
 }.freeze unless defined?(FORMAT_PATHS)
 
 def read_previous_ai_tools_from_config
@@ -229,10 +226,17 @@ def cleanup_removed_ai_tools(previous, current)
   return if to_remove.empty?
 
   require "fileutils"
+  # Collect paths still needed by remaining tools to avoid deleting shared files
+  kept_paths = current.map(&:to_sym).flat_map { |f| FORMAT_PATHS[f] || [] }.to_set
+
   to_remove.each do |fmt|
     tool = AI_TOOL_OPTIONS.values.find { |t| t[:key] == fmt }
+
+    # Remove context files (skip if another selected tool still needs them)
     paths = FORMAT_PATHS[fmt] || []
     paths.each do |rel_path|
+      next if kept_paths.include?(rel_path)
+
       full = Rails.root.join(rel_path)
       if File.directory?(full)
         FileUtils.rm_rf(full)
@@ -242,6 +246,11 @@ def cleanup_removed_ai_tools(previous, current)
         puts "  Removed #{rel_path}"
       end
     end
+
+    # Merge-safe MCP config cleanup — removes only the rails-ai-context entry
+    cleaned = RailsAiContext::McpConfigGenerator.remove(tools: [ fmt ], output_dir: Rails.root.to_s)
+    cleaned.each { |f| puts "  Removed MCP entry from #{Pathname.new(f).relative_path_from(Rails.root)}" }
+
     puts "  ✅ #{tool[:name]} files removed" if tool
   end
 end unless defined?(cleanup_removed_ai_tools)
@@ -366,8 +375,8 @@ namespace :ai do
     save_yaml_config(ai_tools || RailsAiContext.configuration.ai_tools,
                      RailsAiContext.configuration.tool_mode)
 
-    # Auto-create/update .mcp.json when tool_mode is :mcp
-    ensure_mcp_json if RailsAiContext.configuration.tool_mode == :mcp
+    # Auto-create/update per-tool MCP config files when tool_mode is :mcp
+    ensure_mcp_configs(ai_tools) if RailsAiContext.configuration.tool_mode == :mcp
 
     # Add .ai-context.json to .gitignore
     add_ai_context_to_gitignore
@@ -396,7 +405,7 @@ namespace :ai do
     puts "  rails-ai-context serve         # start MCP server"
   end
 
-  desc "Generate AI context in a specific format (claude, cursor, copilot, json)"
+  desc "Generate AI context in a specific format (claude, cursor, copilot, opencode, codex, json)"
   task :context_for, [ :format ] => :environment do |_t, args|
     require "rails_ai_context"
 
@@ -413,8 +422,9 @@ namespace :ai do
   end
 
   namespace :context do
-    { claude: "CLAUDE.md", opencode: "AGENTS.md", cursor: ".cursor/rules/",
-      copilot: ".github/copilot-instructions.md", json: ".ai-context.json" }.each do |fmt, file|
+    { claude: "CLAUDE.md", opencode: "AGENTS.md", codex: "AGENTS.md",
+      cursor: ".cursor/rules/", copilot: ".github/copilot-instructions.md",
+      json: ".ai-context.json" }.each do |fmt, file|
       desc "Generate #{file} context file"
       task fmt => :environment do
         require "rails_ai_context"
@@ -454,7 +464,7 @@ namespace :ai do
     end
   end
 
-  desc "Start the MCP server (stdio transport, for Claude Code / Cursor)"
+  desc "Start the MCP server (stdio transport, auto-discovered by configured AI tools)"
   task serve: :environment do
     require "rails_ai_context"
 

--- a/lib/rails_ai_context/test_helper.rb
+++ b/lib/rails_ai_context/test_helper.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module RailsAiContext
+  # Reusable test helper for verifying MCP tools — both built-in and custom.
+  # Works with RSpec and Minitest.
+  #
+  #   # RSpec
+  #   RSpec.configure { |c| c.include RailsAiContext::TestHelper }
+  #
+  #   # Minitest
+  #   class MyToolTest < ActiveSupport::TestCase
+  #     include RailsAiContext::TestHelper
+  #   end
+  #
+  module TestHelper
+    # Execute a tool by name or class, returning the MCP::Tool::Response.
+    # Raises if the tool is not found or returns an error.
+    #
+    #   response = execute_tool("rails_get_schema", table: "users")
+    #   response = execute_tool(MyApp::CustomTool, query: "test")
+    #
+    def execute_tool(name_or_class, **args)
+      tool_class = resolve_tool(name_or_class)
+      raise ArgumentError, "Tool not found: #{name_or_class.inspect}. Available: #{available_tool_names.join(', ')}" unless tool_class
+
+      response = tool_class.call(**args)
+      unless response.is_a?(MCP::Tool::Response)
+        raise "Expected MCP::Tool::Response, got #{response.class}"
+      end
+
+      response
+    end
+
+    # Execute a tool expecting an error response (non-empty error content).
+    #
+    #   response = execute_tool_with_error("rails_query", sql: "DROP TABLE users")
+    #
+    def execute_tool_with_error(name_or_class, **args)
+      tool_class = resolve_tool(name_or_class)
+      raise ArgumentError, "Tool not found: #{name_or_class.inspect}" unless tool_class
+
+      tool_class.call(**args)
+    end
+
+    # Assert that a tool is registered and discoverable.
+    #
+    #   assert_tool_findable("rails_get_schema")
+    #   assert_tool_findable(MyApp::CustomTool)
+    #
+    def assert_tool_findable(name_or_class)
+      tool_class = resolve_tool(name_or_class)
+      label = name_or_class.is_a?(Class) ? name_or_class.name : name_or_class
+      _test_assert tool_class, "Expected tool '#{label}' to be registered, but it was not found"
+    end
+
+    # Assert the response text includes the expected string.
+    #
+    #   assert_tool_response_includes(response, "users")
+    #
+    def assert_tool_response_includes(response, expected)
+      text = extract_response_text(response)
+      _test_assert text.include?(expected),
+        "Expected tool response to include #{expected.inspect}, but got:\n#{text[0..500]}"
+    end
+
+    # Assert the response text does NOT include the given string.
+    #
+    #   assert_tool_response_excludes(response, "password_digest")
+    #
+    def assert_tool_response_excludes(response, excluded)
+      text = extract_response_text(response)
+      _test_assert !text.include?(excluded),
+        "Expected tool response NOT to include #{excluded.inspect}, but it was present"
+    end
+
+    # Extract the text content from an MCP::Tool::Response.
+    #
+    #   text = extract_response_text(response)
+    #
+    def extract_response_text(response)
+      content = response.is_a?(MCP::Tool::Response) ? response.content : response.to_h[:content]
+      return "" unless content.is_a?(Array)
+
+      content.filter_map { |c| c[:text] || c["text"] }.join("\n")
+    end
+
+    private
+
+    def resolve_tool(name_or_class)
+      return name_or_class if name_or_class.is_a?(Class) && name_or_class < MCP::Tool
+
+      name = name_or_class.to_s
+      all_tools.find do |t|
+        t.tool_name == name ||
+          t.tool_name == "rails_#{name}" ||
+          t.tool_name == "rails_get_#{name}" ||
+          t.tool_name == "get_#{name}"
+      end
+    end
+
+    def all_tools
+      tools = RailsAiContext::Tools::BaseTool.registered_tools
+      tools + RailsAiContext.configuration.custom_tools
+    end
+
+    def available_tool_names
+      all_tools.map(&:tool_name)
+    end
+
+    # Framework-agnostic assert: works with both RSpec and Minitest
+    def _test_assert(condition, message = nil)
+      if respond_to?(:expect)
+        # RSpec
+        expect(condition).to be_truthy, message
+      elsif respond_to?(:assert)
+        # Minitest
+        assert condition, message
+      else
+        raise message unless condition
+      end
+    end
+  end
+end

--- a/lib/rails_ai_context/tools/base_tool.rb
+++ b/lib/rails_ai_context/tools/base_tool.rb
@@ -29,9 +29,78 @@ module RailsAiContext
         required: [ "content" ]
       ).freeze
 
+      # ── Auto-registration ────────────────────────────────────────────
+      # Every subclass is tracked automatically via inherited.
+      # BaseTool itself is abstract — only concrete tools are registered.
+      # Thread-safe: Mutex guards @descendants and @eager_loaded.
+      @descendants = []
+      @abstract = true
+      @registry_mutex = Mutex.new
+
       def self.inherited(subclass)
         super
         subclass.instance_variable_set(:@output_schema_value, DEFAULT_OUTPUT_SCHEMA)
+        subclass.instance_variable_set(:@abstract, false)
+        # Thread-safe append. Mutex is NOT held during eager_load!'s const_get
+        # (which triggers inherited), so no recursive locking risk here.
+        BaseTool.registry_mutex.synchronize { BaseTool.descendants << subclass }
+      end
+
+      class << self
+        attr_reader :descendants, :registry_mutex
+
+        # Mark a tool class as abstract (excluded from registration).
+        def abstract!
+          @abstract = true
+          registry_mutex.synchronize { descendants.delete(self) }
+        end
+
+        def abstract?
+          @abstract == true
+        end
+
+        # All non-abstract tool classes. Triggers eager loading first.
+        def registered_tools
+          eager_load!
+          registry_mutex.synchronize { descendants.reject(&:abstract?) }
+        end
+
+        private
+
+        def eager_load!
+          # Double-checked locking: fast path avoids mutex for common case.
+          return if @eager_loaded
+
+          # Collect constants to load OUTSIDE the mutex, then load them.
+          # const_get triggers Zeitwerk autoload → inherited → mutex.synchronize,
+          # so we must NOT hold the mutex during const_get (avoids deadlock).
+          consts_to_load = registry_mutex.synchronize do
+            return if @eager_loaded # re-check inside mutex
+
+            Dir[File.join(__dir__, "*.rb")].filter_map do |path|
+              basename = File.basename(path, ".rb")
+              next if basename == "base_tool"
+              basename.split("_").map(&:capitalize).join.to_sym
+            end
+          end
+
+          # Load outside mutex — inherited callbacks acquire the mutex individually.
+          # Use inherit: false so top-level constants (Set, Hash, etc.) don't
+          # shadow tool classes that Zeitwerk hasn't autoloaded yet.
+          consts_to_load.each do |const|
+            RailsAiContext::Tools.const_get(const, false)
+          rescue NameError => e
+            # Only skip if the constant itself doesn't exist (filename/constant mismatch).
+            # Re-raise if the error came from inside the loaded file (a real bug).
+            if e.name == const && !RailsAiContext::Tools.const_defined?(const, false)
+              $stderr.puts "[rails-ai-context] eager_load! skipped #{const}: #{e.message}" if ENV["DEBUG"]
+            else
+              raise
+            end
+          end
+
+          registry_mutex.synchronize { @eager_loaded = true }
+        end
       end
 
       # Shared cache across all tool subclasses, protected by a Mutex

--- a/lib/rails_ai_context/tools/get_concern.rb
+++ b/lib/rails_ai_context/tools/get_concern.rb
@@ -307,19 +307,26 @@ module RailsAiContext
         in_class_methods = false
         in_private = false
 
+        class_methods_indent = 0
+
         source.each_line do |line|
           if line.match?(/\A\s*class_methods\s+do/)
             in_class_methods = true
             in_private = false
+            class_methods_indent = line[/\A\s*/].length
             next
           end
 
           if in_class_methods
             in_private = true if line.match?(/\A\s*(private|protected)\s*$/)
 
-            if line.match?(/\A\s*end\s*$/) && !in_private
-              # Could be end of class_methods block — track via indent
-              # Simplified: we'll just collect until we see a top-level end
+            if line.match?(/\A\s*end\s*$/)
+              current_indent = line[/\A\s*/].length
+              if current_indent <= class_methods_indent
+                in_class_methods = false
+                in_private = false
+                next
+              end
             end
 
             if !in_private && (match = line.match(/\A\s*def\s+([\w?!]+(?:\([^)]*\))?)/))

--- a/lib/rails_ai_context/tools/get_partial_interface.rb
+++ b/lib/rails_ai_context/tools/get_partial_interface.rb
@@ -26,6 +26,11 @@ module RailsAiContext
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(partial:, detail: "standard", server_context: nil)
+        # Guard: required parameter
+        if partial.nil? || partial.strip.empty?
+          return text_response("The `partial` parameter is required. Provide a partial path relative to app/views (e.g. 'shared/status_badge').")
+        end
+
         # Reject path traversal attempts
         if partial.include?("..") || partial.start_with?("/")
           return text_response("Path not allowed: #{partial}")

--- a/lib/rails_ai_context/tools/query.rb
+++ b/lib/rails_ai_context/tools/query.rb
@@ -118,7 +118,7 @@ module RailsAiContext
         sql
           .gsub(/\/\*.*?\*\//m, " ")   # Block comments: /* ... */
           .gsub(/--[^\n]*/, " ")        # Line comments: -- ...
-          .gsub(/#[^\n]*/, " ")         # MySQL-style comments: # ...
+          .gsub(/^\s*#[^\n]*/m, " ")   # MySQL-style comments: # at line start only
           .squeeze(" ").strip
       end
 
@@ -313,13 +313,13 @@ module RailsAiContext
 
         # PostgreSQL JSON format returns plan as JSON
         begin
-          plan_data = JSON.parse(raw) rescue nil
+          plan_data = JSON.parse(raw)
           if plan_data.is_a?(Array) && plan_data.first.is_a?(Hash)
             plan = plan_data.first["Plan"]
             extract_pg_nodes(plan, scans, warnings) if plan
           end
-        rescue
-          # Fall through to raw output
+        rescue JSON::ParserError
+          # Non-JSON EXPLAIN format — fall through to raw output
         end
 
         { scan_types: scans, warnings: warnings, raw: raw }
@@ -405,7 +405,7 @@ module RailsAiContext
         redacted_cols = config.query_redacted_columns.map(&:downcase).to_set
 
         # Auto-redact columns declared with `encrypts` in models
-        models_data = (SHARED_CACHE[:context] || cached_context)&.dig(:models)
+        models_data = cached_context&.dig(:models)
         if models_data.is_a?(Hash)
           models_data.each_value do |data|
             next unless data.is_a?(Hash)

--- a/lib/rails_ai_context/tools/runtime_info.rb
+++ b/lib/rails_ai_context/tools/runtime_info.rb
@@ -55,6 +55,8 @@ module RailsAiContext
         # ── Connection pool ──────────────────────────────────────────────
 
         def gather_connection_pool
+          return [ "## Connection Pool", "", "_ActiveRecord not available._", "" ] unless defined?(ActiveRecord::Base)
+
           stat = ActiveRecord::Base.connection_pool.stat
           lines = [ "## Connection Pool", "" ]
           lines << "| Metric | Value |"
@@ -79,6 +81,8 @@ module RailsAiContext
         # ── Database section ─────────────────────────────────────────────
 
         def gather_database(detail) # rubocop:disable Metrics
+          return [ "## Database", "", "_ActiveRecord not available._", "" ] unless defined?(ActiveRecord::Base)
+
           conn = ActiveRecord::Base.connection
           adapter = conn.adapter_name.downcase
           lines = [ "## Database", "" ]

--- a/lib/rails_ai_context/tools/search_code.rb
+++ b/lib/rails_ai_context/tools/search_code.rb
@@ -202,15 +202,20 @@ module RailsAiContext
         # Claude
         cmd << "--glob=!CLAUDE.md"
         cmd << "--glob=!.claude/"
+        cmd << "--glob=!.mcp.json"
         # Cursor
         cmd << "--glob=!.cursor/"
         cmd << "--glob=!.cursorrules"
         # GitHub Copilot
         cmd << "--glob=!.github/copilot-instructions.md"
         cmd << "--glob=!.github/instructions/"
+        cmd << "--glob=!.vscode/mcp.json"
         # OpenCode
         cmd << "--glob=!AGENTS.md"
         cmd << "--glob=!**/AGENTS.md"
+        cmd << "--glob=!opencode.json"
+        # Codex CLI
+        cmd << "--glob=!.codex/"
         # JSON export
         cmd << "--glob=!.ai-context.json"
 
@@ -250,7 +255,7 @@ module RailsAiContext
         excluded = RailsAiContext.configuration.excluded_paths
         sensitive = RailsAiContext.configuration.sensitive_patterns
         test_dirs = %w[test/ spec/ features/]
-        ai_context_files = %w[CLAUDE.md AGENTS.md .claude/ .cursor/ .cursorrules .github/copilot-instructions.md .github/instructions/ .ai-context.json]
+        ai_context_files = %w[CLAUDE.md AGENTS.md .claude/ .cursor/ .cursorrules .github/copilot-instructions.md .github/instructions/ .vscode/mcp.json .codex/ .mcp.json opencode.json .ai-context.json]
 
         Dir.glob(File.join(search_path, glob)).each do |file|
           relative = file.sub("#{root}/", "")

--- a/lib/rails_ai_context/version.rb
+++ b/lib/rails_ai_context/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiContext
-  VERSION = "5.5.0"
+  VERSION = "5.6.0"
 end

--- a/lib/rails_ai_context/version.rb
+++ b/lib/rails_ai_context/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiContext
-  VERSION = "5.4.0"
+  VERSION = "5.5.0"
 end

--- a/rails-ai-context.gemspec
+++ b/rails-ai-context.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
     associations, routes, inherited filters, conventions, and test patterns.
     Semantic validation catches cross-file errors (wrong columns, missing partials,
     broken routes) before code runs — so AI writes correct code on the first try.
-    Auto-generates context files for Claude Code, Cursor, GitHub Copilot, and
-    OpenCode. Works standalone or in-Gemfile.
+    Auto-generates context files for Claude Code, Cursor, GitHub Copilot,
+    OpenCode, and Codex CLI. Works standalone or in-Gemfile.
   DESC
 
   spec.homepage      = "https://github.com/crisnahine/rails-ai-context"

--- a/server.json
+++ b/server.json
@@ -2,16 +2,16 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.crisnahine/rails-ai-context",
   "title": "Rails AI Context",
-  "description": "Stop AI from guessing your Rails app. 38 MCP tools give agents live schema, routes, conventions.",
+  "description": "Stop AI from guessing your Rails app. 38 MCP tools give agents live schema, routes, conventions. Works with Claude Code, Cursor, GitHub Copilot, OpenCode, and Codex CLI.",
   "repository": {
     "url": "https://github.com/crisnahine/rails-ai-context",
     "source": "github"
   },
-  "version": "5.4.0",
+  "version": "5.5.0",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/crisnahine/rails-ai-context/releases/download/v5.4.0/rails-ai-context-mcp.mcpb",
+      "identifier": "https://github.com/crisnahine/rails-ai-context/releases/download/v5.5.0/rails-ai-context-mcp.mcpb",
       "fileSha256": "0000000000000000000000000000000000000000000000000000000000000000",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/crisnahine/rails-ai-context",
     "source": "github"
   },
-  "version": "5.5.0",
+  "version": "5.6.0",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/crisnahine/rails-ai-context/releases/download/v5.5.0/rails-ai-context-mcp.mcpb",
+      "identifier": "https://github.com/crisnahine/rails-ai-context/releases/download/v5.6.0/rails-ai-context-mcp.mcpb",
       "fileSha256": "0000000000000000000000000000000000000000000000000000000000000000",
       "transport": {
         "type": "stdio"

--- a/spec/lib/rails_ai_context/doctor_spec.rb
+++ b/spec/lib/rails_ai_context/doctor_spec.rb
@@ -64,4 +64,371 @@ RSpec.describe RailsAiContext::Doctor do
       expect(preset).not_to be_nil
     end
   end
+
+  describe "#check_codex_env_staleness" do
+    subject(:check) { doctor.send(:check_codex_env_staleness) }
+
+    let(:toml_path) { File.join(Rails.application.root, ".codex/config.toml") }
+
+    context "when codex is not in ai_tools" do
+      before do
+        allow(RailsAiContext.configuration).to receive(:ai_tools).and_return(%i[claude cursor])
+      end
+
+      it "returns nil (skipped)" do
+        expect(check).to be_nil
+      end
+    end
+
+    context "when codex is in ai_tools" do
+      before do
+        allow(RailsAiContext.configuration).to receive(:ai_tools).and_return(%i[claude codex])
+      end
+
+      context "when .codex/config.toml does not exist" do
+        before do
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(toml_path).and_return(false)
+        end
+
+        it "returns nil (skipped)" do
+          expect(check).to be_nil
+        end
+      end
+
+      context "when .codex/config.toml exists but has no env section" do
+        before do
+          toml_content = <<~TOML
+            [mcp_servers.rails-ai-context]
+            command = "bundle"
+            args = ["exec", "rails", "ai:serve"]
+          TOML
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(toml_path).and_return(true)
+          allow(File).to receive(:read).and_call_original
+          allow(File).to receive(:read).with(toml_path).and_return(toml_content)
+        end
+
+        it "returns nil (skipped)" do
+          expect(check).to be_nil
+        end
+      end
+
+      context "when env section exists but has no GEM_HOME" do
+        before do
+          toml_content = <<~TOML
+            [mcp_servers.rails-ai-context]
+            command = "bundle"
+            args = ["exec", "rails", "ai:serve"]
+
+            [mcp_servers.rails-ai-context.env]
+            PATH = "/usr/local/bin:/usr/bin"
+          TOML
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(toml_path).and_return(true)
+          allow(File).to receive(:read).and_call_original
+          allow(File).to receive(:read).with(toml_path).and_return(toml_content)
+        end
+
+        it "returns nil (skipped)" do
+          expect(check).to be_nil
+        end
+      end
+
+      context "when GEM_HOME directory exists on disk" do
+        let(:gem_home) { Dir.mktmpdir("gem_home_test") }
+
+        after { FileUtils.rm_rf(gem_home) }
+
+        before do
+          toml_content = <<~TOML
+            [mcp_servers.rails-ai-context]
+            command = "bundle"
+            args = ["exec", "rails", "ai:serve"]
+
+            [mcp_servers.rails-ai-context.env]
+            GEM_HOME = "#{gem_home}"
+            PATH = "/usr/local/bin:/usr/bin"
+          TOML
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(toml_path).and_return(true)
+          allow(File).to receive(:read).and_call_original
+          allow(File).to receive(:read).with(toml_path).and_return(toml_content)
+        end
+
+        it "returns a pass check" do
+          expect(check.status).to eq(:pass)
+          expect(check.name).to eq("Codex env snapshot")
+          expect(check.message).to include(gem_home)
+        end
+      end
+
+      context "when GEM_HOME directory no longer exists" do
+        let(:stale_gem_home) { "/nonexistent/path/to/gems/3.3.0" }
+
+        before do
+          toml_content = <<~TOML
+            [mcp_servers.rails-ai-context]
+            command = "bundle"
+            args = ["exec", "rails", "ai:serve"]
+
+            [mcp_servers.rails-ai-context.env]
+            GEM_HOME = "#{stale_gem_home}"
+            PATH = "/usr/local/bin:/usr/bin"
+          TOML
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(toml_path).and_return(true)
+          allow(File).to receive(:read).and_call_original
+          allow(File).to receive(:read).with(toml_path).and_return(toml_content)
+        end
+
+        it "returns a warn check with stale GEM_HOME path" do
+          expect(check.status).to eq(:warn)
+          expect(check.name).to eq("Codex env snapshot")
+          expect(check.message).to include("stale")
+          expect(check.message).to include(stale_gem_home)
+          expect(check.fix).to include("install")
+        end
+      end
+
+      context "when env section is followed by another TOML section" do
+        let(:gem_home) { Dir.mktmpdir("gem_home_boundary") }
+
+        after { FileUtils.rm_rf(gem_home) }
+
+        before do
+          toml_content = <<~TOML
+            [mcp_servers.rails-ai-context]
+            command = "bundle"
+            args = ["exec", "rails", "ai:serve"]
+
+            [mcp_servers.rails-ai-context.env]
+            GEM_HOME = "#{gem_home}"
+
+            [mcp_servers.other-tool]
+            command = "other"
+          TOML
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(toml_path).and_return(true)
+          allow(File).to receive(:read).and_call_original
+          allow(File).to receive(:read).with(toml_path).and_return(toml_content)
+        end
+
+        it "correctly parses the env section and returns pass" do
+          expect(check.status).to eq(:pass)
+          expect(check.message).to include(gem_home)
+        end
+      end
+    end
+  end
+
+  describe "#check_mcp_json" do
+    subject(:check) { doctor.send(:check_mcp_json) }
+
+    let(:root) { Rails.application.root }
+
+    context "when tool_mode is :cli" do
+      before do
+        allow(RailsAiContext.configuration).to receive(:tool_mode).and_return(:cli)
+      end
+
+      it "returns pass with skip message" do
+        expect(check.status).to eq(:pass)
+        expect(check.message).to include("CLI-only")
+      end
+    end
+
+    context "when multiple tools configured, some configs missing" do
+      before do
+        allow(RailsAiContext.configuration).to receive(:tool_mode).and_return(:mcp)
+        allow(RailsAiContext.configuration).to receive(:ai_tools).and_return(%i[claude cursor copilot])
+        # .mcp.json exists and is valid
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(File.join(root, ".mcp.json")).and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(File.join(root, ".mcp.json")).and_return('{"mcpServers":{}}')
+        # .cursor/mcp.json missing
+        allow(File).to receive(:exist?).with(File.join(root, ".cursor/mcp.json")).and_return(false)
+        # .vscode/mcp.json missing
+        allow(File).to receive(:exist?).with(File.join(root, ".vscode/mcp.json")).and_return(false)
+      end
+
+      it "aggregates all failures into a single check" do
+        expect(check.status).to eq(:warn)
+        expect(check.message).to include("2 of 3")
+        expect(check.message).to include(".cursor/mcp.json")
+        expect(check.message).to include(".vscode/mcp.json")
+      end
+    end
+
+    context "when all configs present and valid" do
+      before do
+        allow(RailsAiContext.configuration).to receive(:tool_mode).and_return(:mcp)
+        allow(RailsAiContext.configuration).to receive(:ai_tools).and_return(%i[claude opencode])
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(File.join(root, ".mcp.json")).and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(File.join(root, ".mcp.json")).and_return('{"mcpServers":{}}')
+        allow(File).to receive(:exist?).with(File.join(root, "opencode.json")).and_return(true)
+        allow(File).to receive(:read).with(File.join(root, "opencode.json")).and_return('{"mcp":{}}')
+      end
+
+      it "returns pass with count" do
+        expect(check.status).to eq(:pass)
+        expect(check.message).to include("2 of 2")
+      end
+    end
+
+    context "when no tools configured (defaults to all)" do
+      before do
+        allow(RailsAiContext.configuration).to receive(:tool_mode).and_return(:mcp)
+        allow(RailsAiContext.configuration).to receive(:ai_tools).and_return(nil)
+        # Stub all 5 config files as present
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:read).and_call_original
+        %w[.mcp.json .cursor/mcp.json .vscode/mcp.json opencode.json].each do |path|
+          allow(File).to receive(:exist?).with(File.join(root, path)).and_return(true)
+          allow(File).to receive(:read).with(File.join(root, path)).and_return("{}")
+        end
+        allow(File).to receive(:exist?).with(File.join(root, ".codex/config.toml")).and_return(true)
+      end
+
+      it "checks all 5 tools and returns pass" do
+        expect(check.status).to eq(:pass)
+        expect(check.message).to include("5 of 5")
+      end
+    end
+
+    context "when a JSON config has invalid JSON" do
+      before do
+        allow(RailsAiContext.configuration).to receive(:tool_mode).and_return(:mcp)
+        allow(RailsAiContext.configuration).to receive(:ai_tools).and_return(%i[claude])
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(File.join(root, ".mcp.json")).and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(File.join(root, ".mcp.json")).and_return("not json{{{")
+      end
+
+      it "returns fail status with tool label" do
+        expect(check.status).to eq(:fail)
+        expect(check.message).to include("1 of 1")
+        expect(check.message).to include(".mcp.json")
+      end
+    end
+  end
+
+  describe "#check_context_freshness" do
+    subject(:check) { doctor.send(:check_context_freshness) }
+
+    let(:app) { Rails.application }
+
+    context "when cursor-only (split rules only, no root file)" do
+      before do
+        allow(RailsAiContext.configuration).to receive(:ai_tools).and_return(%i[cursor])
+        allow(File).to receive(:exist?).and_call_original
+        allow(Dir).to receive(:exist?).and_call_original
+
+        cursor_rules_path = File.join(app.root, ".cursor/rules")
+        # No root file, but split rule directory exists
+        allow(File).to receive(:exist?).with(cursor_rules_path).and_return(false)
+        allow(Dir).to receive(:exist?).with(cursor_rules_path).and_return(true)
+        allow(File).to receive(:directory?).and_call_original
+        allow(File).to receive(:directory?).with(cursor_rules_path).and_return(true)
+
+        # Mock split rule files with recent mtime
+        rule_files = [ File.join(cursor_rules_path, "rails-context.mdc") ]
+        allow(Dir).to receive(:glob).and_call_original
+        allow(Dir).to receive(:glob).with(File.join(cursor_rules_path, "**/*")).and_return(rule_files)
+        allow(File).to receive(:mtime).and_call_original
+        allow(File).to receive(:mtime).with(rule_files.first).and_return(Time.now)
+
+        # No stale source dirs
+        %w[app/models app/controllers app/views config db/migrate].each do |dir|
+          allow(Dir).to receive(:exist?).with(File.join(app.root, dir)).and_return(false)
+        end
+      end
+
+      it "detects .cursor/rules as valid context" do
+        expect(check.status).to eq(:pass)
+        expect(check.message).to include(".cursor/rules")
+      end
+    end
+
+    context "when multi-tool configured with existing files" do
+      before do
+        allow(RailsAiContext.configuration).to receive(:ai_tools).and_return(%i[claude copilot])
+        allow(File).to receive(:exist?).and_call_original
+        allow(Dir).to receive(:exist?).and_call_original
+
+        claude_path = File.join(app.root, "CLAUDE.md")
+        allow(File).to receive(:exist?).with(claude_path).and_return(true)
+        allow(File).to receive(:directory?).and_call_original
+        allow(File).to receive(:directory?).with(claude_path).and_return(false)
+        allow(File).to receive(:mtime).and_call_original
+        allow(File).to receive(:mtime).with(claude_path).and_return(Time.now)
+
+        %w[app/models app/controllers app/views config db/migrate].each do |dir|
+          allow(Dir).to receive(:exist?).with(File.join(app.root, dir)).and_return(false)
+        end
+      end
+
+      it "checks the first available file (CLAUDE.md)" do
+        expect(check.status).to eq(:pass)
+        expect(check.message).to include("CLAUDE.md")
+      end
+    end
+
+    context "when no context files exist" do
+      before do
+        allow(RailsAiContext.configuration).to receive(:ai_tools).and_return(%i[claude cursor])
+        allow(File).to receive(:exist?).and_call_original
+        allow(Dir).to receive(:exist?).and_call_original
+
+        allow(File).to receive(:exist?).with(File.join(app.root, "CLAUDE.md")).and_return(false)
+        allow(Dir).to receive(:exist?).with(File.join(app.root, "CLAUDE.md")).and_return(false)
+        allow(File).to receive(:exist?).with(File.join(app.root, ".cursor/rules")).and_return(false)
+        allow(Dir).to receive(:exist?).with(File.join(app.root, ".cursor/rules")).and_return(false)
+      end
+
+      it "returns warn with 'no context files generated'" do
+        expect(check.status).to eq(:warn)
+        expect(check.message).to include("No context files generated")
+      end
+    end
+
+    context "when context file is stale" do
+      before do
+        allow(RailsAiContext.configuration).to receive(:ai_tools).and_return(%i[claude])
+        allow(File).to receive(:exist?).and_call_original
+        allow(Dir).to receive(:exist?).and_call_original
+
+        claude_path = File.join(app.root, "CLAUDE.md")
+        allow(File).to receive(:exist?).with(claude_path).and_return(true)
+        allow(File).to receive(:directory?).and_call_original
+        allow(File).to receive(:directory?).with(claude_path).and_return(false)
+        # Context generated 1 hour ago
+        allow(File).to receive(:mtime).and_call_original
+        allow(File).to receive(:mtime).with(claude_path).and_return(Time.now - 3600)
+
+        # app/models exists and has a file newer than context
+        models_dir = File.join(app.root, "app/models")
+        allow(Dir).to receive(:exist?).with(models_dir).and_return(true)
+        model_file = File.join(models_dir, "user.rb")
+        allow(Dir).to receive(:glob).and_call_original
+        allow(Dir).to receive(:glob).with(File.join(models_dir, "**/*.rb")).and_return([ model_file ])
+        allow(File).to receive(:mtime).with(model_file).and_return(Time.now)
+
+        # Other dirs don't exist
+        %w[app/controllers app/views config db/migrate].each do |dir|
+          allow(Dir).to receive(:exist?).with(File.join(app.root, dir)).and_return(false)
+        end
+      end
+
+      it "returns warn with stale message" do
+        expect(check.status).to eq(:warn)
+        expect(check.message).to include("stale")
+        expect(check.message).to include("app/models")
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/mcp_config_generator_spec.rb
+++ b/spec/lib/rails_ai_context/mcp_config_generator_spec.rb
@@ -1,0 +1,330 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "yaml"
+
+RSpec.describe RailsAiContext::McpConfigGenerator do
+  let(:tools) { %i[claude cursor copilot opencode codex] }
+
+  describe "#call" do
+    context "with :mcp tool_mode" do
+      it "generates .mcp.json for :claude with mcpServers key" do
+        Dir.mktmpdir do |dir|
+          result = described_class.new(tools: [ :claude ], output_dir: dir, tool_mode: :mcp).call
+          expect(result[:written].size).to eq(1)
+
+          content = JSON.parse(File.read(File.join(dir, ".mcp.json")))
+          expect(content).to have_key("mcpServers")
+          expect(content["mcpServers"]).to have_key("rails-ai-context")
+
+          entry = content["mcpServers"]["rails-ai-context"]
+          expect(entry["command"]).to eq("bundle")
+          expect(entry["args"]).to eq([ "exec", "rails", "ai:serve" ])
+        end
+      end
+
+      it "generates .cursor/mcp.json for :cursor with mcpServers key" do
+        Dir.mktmpdir do |dir|
+          result = described_class.new(tools: [ :cursor ], output_dir: dir, tool_mode: :mcp).call
+          expect(result[:written].size).to eq(1)
+
+          path = File.join(dir, ".cursor", "mcp.json")
+          expect(File.exist?(path)).to be true
+          content = JSON.parse(File.read(path))
+          expect(content).to have_key("mcpServers")
+          expect(content["mcpServers"]["rails-ai-context"]["command"]).to eq("bundle")
+        end
+      end
+
+      it "generates .vscode/mcp.json for :copilot with servers key" do
+        Dir.mktmpdir do |dir|
+          result = described_class.new(tools: [ :copilot ], output_dir: dir, tool_mode: :mcp).call
+          expect(result[:written].size).to eq(1)
+
+          path = File.join(dir, ".vscode", "mcp.json")
+          expect(File.exist?(path)).to be true
+          content = JSON.parse(File.read(path))
+          expect(content).to have_key("servers")
+          expect(content).not_to have_key("mcpServers")
+
+          entry = content["servers"]["rails-ai-context"]
+          expect(entry["command"]).to eq("bundle")
+          expect(entry["args"]).to eq([ "exec", "rails", "ai:serve" ])
+        end
+      end
+
+      it "generates opencode.json for :opencode with mcp key and type local" do
+        Dir.mktmpdir do |dir|
+          result = described_class.new(tools: [ :opencode ], output_dir: dir, tool_mode: :mcp).call
+          expect(result[:written].size).to eq(1)
+
+          content = JSON.parse(File.read(File.join(dir, "opencode.json")))
+          expect(content).to have_key("mcp")
+
+          entry = content["mcp"]["rails-ai-context"]
+          expect(entry["type"]).to eq("local")
+          expect(entry["command"]).to eq([ "bundle", "exec", "rails", "ai:serve" ])
+          expect(entry).not_to have_key("args")
+        end
+      end
+
+      it "generates .codex/config.toml for :codex as TOML with env snapshot" do
+        Dir.mktmpdir do |dir|
+          result = described_class.new(tools: [ :codex ], output_dir: dir, tool_mode: :mcp).call
+          expect(result[:written].size).to eq(1)
+
+          path = File.join(dir, ".codex", "config.toml")
+          expect(File.exist?(path)).to be true
+          content = File.read(path)
+          expect(content).to include("[mcp_servers.rails-ai-context]")
+          expect(content).to include('command = "bundle"')
+          expect(content).to include('args = ["exec", "rails", "ai:serve"]')
+          # Env section captures PATH for Codex sandbox compatibility
+          expect(content).to include("[mcp_servers.rails-ai-context.env]")
+          expect(content).to include("PATH = ")
+        end
+      end
+
+      it "generates all 5 configs when all tools selected" do
+        Dir.mktmpdir do |dir|
+          result = described_class.new(tools: tools, output_dir: dir, tool_mode: :mcp).call
+          expect(result[:written].size).to eq(5)
+
+          expect(File.exist?(File.join(dir, ".mcp.json"))).to be true
+          expect(File.exist?(File.join(dir, ".cursor", "mcp.json"))).to be true
+          expect(File.exist?(File.join(dir, ".vscode", "mcp.json"))).to be true
+          expect(File.exist?(File.join(dir, "opencode.json"))).to be true
+          expect(File.exist?(File.join(dir, ".codex", "config.toml"))).to be true
+        end
+      end
+    end
+
+    context "merge logic" do
+      it "merges into existing .mcp.json without overwriting other servers" do
+        Dir.mktmpdir do |dir|
+          existing = { "mcpServers" => { "other-server" => { "command" => "node" } } }
+          File.write(File.join(dir, ".mcp.json"), JSON.pretty_generate(existing))
+
+          described_class.new(tools: [ :claude ], output_dir: dir, tool_mode: :mcp).call
+
+          content = JSON.parse(File.read(File.join(dir, ".mcp.json")))
+          expect(content["mcpServers"]).to have_key("other-server")
+          expect(content["mcpServers"]).to have_key("rails-ai-context")
+        end
+      end
+
+      it "merges into existing .vscode/mcp.json without overwriting other servers" do
+        Dir.mktmpdir do |dir|
+          vscode_dir = File.join(dir, ".vscode")
+          FileUtils.mkdir_p(vscode_dir)
+          existing = { "servers" => { "other-mcp" => { "command" => "npx" } } }
+          File.write(File.join(vscode_dir, "mcp.json"), JSON.pretty_generate(existing))
+
+          described_class.new(tools: [ :copilot ], output_dir: dir, tool_mode: :mcp).call
+
+          content = JSON.parse(File.read(File.join(vscode_dir, "mcp.json")))
+          expect(content["servers"]).to have_key("other-mcp")
+          expect(content["servers"]).to have_key("rails-ai-context")
+        end
+      end
+
+      it "merges into existing opencode.json without overwriting other MCP entries" do
+        Dir.mktmpdir do |dir|
+          existing = { "mcp" => { "other-tool" => { "type" => "local", "command" => [ "node" ] } }, "model" => "gpt-4" }
+          File.write(File.join(dir, "opencode.json"), JSON.pretty_generate(existing))
+
+          described_class.new(tools: [ :opencode ], output_dir: dir, tool_mode: :mcp).call
+
+          content = JSON.parse(File.read(File.join(dir, "opencode.json")))
+          expect(content["mcp"]).to have_key("other-tool")
+          expect(content["mcp"]).to have_key("rails-ai-context")
+          expect(content["model"]).to eq("gpt-4")
+        end
+      end
+
+      it "merges into existing .codex/config.toml without overwriting other sections" do
+        Dir.mktmpdir do |dir|
+          codex_dir = File.join(dir, ".codex")
+          FileUtils.mkdir_p(codex_dir)
+          existing = <<~TOML
+            model = "o3"
+
+            [mcp_servers.other-tool]
+            command = "node"
+            args = ["server.js"]
+          TOML
+          File.write(File.join(codex_dir, "config.toml"), existing)
+
+          described_class.new(tools: [ :codex ], output_dir: dir, tool_mode: :mcp).call
+
+          content = File.read(File.join(codex_dir, "config.toml"))
+          expect(content).to include("[mcp_servers.other-tool]")
+          expect(content).to include("[mcp_servers.rails-ai-context]")
+          expect(content).to include('model = "o3"')
+        end
+      end
+
+      it "replaces existing rails-ai-context section in .codex/config.toml" do
+        Dir.mktmpdir do |dir|
+          codex_dir = File.join(dir, ".codex")
+          FileUtils.mkdir_p(codex_dir)
+          existing = <<~TOML
+            [mcp_servers.rails-ai-context]
+            command = "old-command"
+            args = ["old"]
+          TOML
+          File.write(File.join(codex_dir, "config.toml"), existing)
+
+          described_class.new(tools: [ :codex ], output_dir: dir, tool_mode: :mcp).call
+
+          content = File.read(File.join(codex_dir, "config.toml"))
+          expect(content).not_to include("old-command")
+          expect(content).to include('command = "bundle"')
+        end
+      end
+
+      it "replaces existing rails-ai-context section including env sub-section" do
+        Dir.mktmpdir do |dir|
+          codex_dir = File.join(dir, ".codex")
+          FileUtils.mkdir_p(codex_dir)
+          existing = <<~TOML
+            [mcp_servers.rails-ai-context]
+            command = "old-command"
+            args = ["old"]
+
+            [mcp_servers.rails-ai-context.env]
+            PATH = "/old/path"
+            GEM_HOME = "/old/gem"
+
+            [mcp_servers.other-tool]
+            command = "node"
+          TOML
+          File.write(File.join(codex_dir, "config.toml"), existing)
+
+          described_class.new(tools: [ :codex ], output_dir: dir, tool_mode: :mcp).call
+
+          content = File.read(File.join(codex_dir, "config.toml"))
+          expect(content).not_to include("old-command")
+          expect(content).not_to include("/old/path")
+          expect(content).to include('command = "bundle"')
+          expect(content).to include("[mcp_servers.other-tool]")
+        end
+      end
+    end
+
+    context "idempotency" do
+      it "skips unchanged files on re-run" do
+        Dir.mktmpdir do |dir|
+          first = described_class.new(tools: tools, output_dir: dir, tool_mode: :mcp).call
+          second = described_class.new(tools: tools, output_dir: dir, tool_mode: :mcp).call
+          expect(second[:written]).to be_empty
+          expect(second[:skipped].size).to eq(first[:written].size)
+        end
+      end
+    end
+
+    context "standalone mode" do
+      it "uses rails-ai-context serve command for JSON configs" do
+        Dir.mktmpdir do |dir|
+          described_class.new(tools: [ :claude ], output_dir: dir, standalone: true, tool_mode: :mcp).call
+
+          content = JSON.parse(File.read(File.join(dir, ".mcp.json")))
+          entry = content["mcpServers"]["rails-ai-context"]
+          expect(entry["command"]).to eq("rails-ai-context")
+          expect(entry["args"]).to eq([ "serve" ])
+        end
+      end
+
+      it "uses rails-ai-context serve command for OpenCode" do
+        Dir.mktmpdir do |dir|
+          described_class.new(tools: [ :opencode ], output_dir: dir, standalone: true, tool_mode: :mcp).call
+
+          content = JSON.parse(File.read(File.join(dir, "opencode.json")))
+          entry = content["mcp"]["rails-ai-context"]
+          expect(entry["command"]).to eq([ "rails-ai-context", "serve" ])
+        end
+      end
+
+      it "uses rails-ai-context serve command for Codex TOML" do
+        Dir.mktmpdir do |dir|
+          described_class.new(tools: [ :codex ], output_dir: dir, standalone: true, tool_mode: :mcp).call
+
+          content = File.read(File.join(dir, ".codex", "config.toml"))
+          expect(content).to include('command = "rails-ai-context"')
+          expect(content).to include('args = ["serve"]')
+        end
+      end
+    end
+
+    context "with :cli tool_mode" do
+      it "skips all MCP config generation" do
+        Dir.mktmpdir do |dir|
+          result = described_class.new(tools: tools, output_dir: dir, tool_mode: :cli).call
+          expect(result[:written]).to be_empty
+          expect(result[:skipped]).to be_empty
+        end
+      end
+    end
+  end
+
+  describe ".remove" do
+    it "removes only rails-ai-context entry from JSON config, preserving others" do
+      Dir.mktmpdir do |dir|
+        content = {
+          "mcpServers" => {
+            "rails-ai-context" => { "command" => "bundle", "args" => [ "exec", "rails", "ai:serve" ] },
+            "other-server" => { "command" => "node", "args" => [ "server.js" ] }
+          }
+        }
+        File.write(File.join(dir, ".mcp.json"), JSON.pretty_generate(content))
+
+        cleaned = described_class.remove(tools: [ :claude ], output_dir: dir)
+        expect(cleaned.size).to eq(1)
+
+        result = JSON.parse(File.read(File.join(dir, ".mcp.json")))
+        expect(result["mcpServers"]).not_to have_key("rails-ai-context")
+        expect(result["mcpServers"]).to have_key("other-server")
+      end
+    end
+
+    it "deletes JSON file entirely when rails-ai-context is the only entry" do
+      Dir.mktmpdir do |dir|
+        described_class.new(tools: [ :claude ], output_dir: dir, tool_mode: :mcp).call
+
+        described_class.remove(tools: [ :claude ], output_dir: dir)
+        expect(File.exist?(File.join(dir, ".mcp.json"))).to be false
+      end
+    end
+
+    it "removes rails-ai-context section from TOML, preserving others" do
+      Dir.mktmpdir do |dir|
+        codex_dir = File.join(dir, ".codex")
+        FileUtils.mkdir_p(codex_dir)
+        toml = <<~TOML
+          [mcp_servers.rails-ai-context]
+          command = "bundle"
+          args = ["exec", "rails", "ai:serve"]
+
+          [mcp_servers.other-tool]
+          command = "node"
+        TOML
+        File.write(File.join(codex_dir, "config.toml"), toml)
+
+        cleaned = described_class.remove(tools: [ :codex ], output_dir: dir)
+        expect(cleaned.size).to eq(1)
+
+        result = File.read(File.join(codex_dir, "config.toml"))
+        expect(result).not_to include("rails-ai-context")
+        expect(result).to include("[mcp_servers.other-tool]")
+      end
+    end
+
+    it "returns empty array when file does not exist" do
+      Dir.mktmpdir do |dir|
+        cleaned = described_class.remove(tools: [ :claude ], output_dir: dir)
+        expect(cleaned).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_context/serializers/claude_rules_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/claude_rules_serializer_spec.rb
@@ -76,4 +76,41 @@ RSpec.describe RailsAiContext::Serializers::ClaudeRulesSerializer do
       expect(result[:written].size).to eq(3) # context + schema + mcp-tools
     end
   end
+
+  describe "paths: frontmatter" do
+    it "includes paths: frontmatter on schema rule" do
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        content = File.read(File.join(dir, ".claude", "rules", "rails-schema.md"))
+        expect(content).to start_with("---")
+        expect(content).to include('- "db/schema.rb"')
+        expect(content).to include('- "db/migrate/**"')
+      end
+    end
+
+    it "includes paths: frontmatter on models rule" do
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        content = File.read(File.join(dir, ".claude", "rules", "rails-models.md"))
+        expect(content).to start_with("---")
+        expect(content).to include('- "app/models/**/*.rb"')
+      end
+    end
+
+    it "does NOT include paths: frontmatter on context rule" do
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        content = File.read(File.join(dir, ".claude", "rules", "rails-context.md"))
+        expect(content).not_to start_with("---")
+      end
+    end
+
+    it "does NOT include paths: frontmatter on mcp-tools rule" do
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        content = File.read(File.join(dir, ".claude", "rules", "rails-mcp-tools.md"))
+        expect(content).not_to start_with("---")
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/serializers/context_file_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/context_file_serializer_spec.rb
@@ -73,8 +73,28 @@ RSpec.describe RailsAiContext::Serializers::ContextFileSerializer do
         allow(RailsAiContext.configuration).to receive(:output_dir_for).and_return(dir)
         serializer = described_class.new(context, format: :opencode)
         result = serializer.call
-        agents_file = result[:written].find { |f| f.end_with?("AGENTS.md") }
+        agents_file = result[:written].find { |f| f.end_with?("AGENTS.md") && !f.include?("app/") }
         expect(agents_file).not_to be_nil
+      end
+    end
+
+    it "generates AGENTS.md when writing codex format" do
+      Dir.mktmpdir do |dir|
+        allow(RailsAiContext.configuration).to receive(:output_dir_for).and_return(dir)
+        serializer = described_class.new(context, format: :codex)
+        result = serializer.call
+        agents_file = result[:written].find { |f| f.end_with?("AGENTS.md") && !f.include?("app/") }
+        expect(agents_file).not_to be_nil
+      end
+    end
+
+    it "does not write AGENTS.md twice when both opencode and codex are selected" do
+      Dir.mktmpdir do |dir|
+        allow(RailsAiContext.configuration).to receive(:output_dir_for).and_return(dir)
+        serializer = described_class.new(context, format: :all)
+        result = serializer.call
+        root_agents = result[:written].select { |f| File.basename(f) == "AGENTS.md" && !f.include?("app/") }
+        expect(root_agents.size).to eq(1)
       end
     end
 

--- a/spec/lib/rails_ai_context/serializers/copilot_compliance_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/copilot_compliance_spec.rb
@@ -9,8 +9,8 @@ require "yaml"
 # - Root file: .github/copilot-instructions.md — NO YAML frontmatter, plain markdown
 # - Path-specific: .github/instructions/*.instructions.md — MUST have applyTo frontmatter
 # - Supported frontmatter fields: applyTo (required), excludeAgent, name, description
-# - excludeAgent values: "code-review" or "coding-agent"
-# - Copilot Code Review: 4,000 character hard limit per instruction file
+# - excludeAgent values: "code-review", "coding-agent", or "workspace"
+# - Copilot Code Review: ~1,000 lines soft recommendation per instruction file
 # - Glob patterns: **/* (all), app/models/**/*.rb, *.{js,ts} — standard glob syntax
 # - No order guarantee between matching instruction files
 # - Subdirectory organization allowed in .github/instructions/
@@ -143,8 +143,21 @@ RSpec.describe "Copilot instructions compliance" do
         end
       end
 
+      it "all instruction files have name and description" do
+        generated_files.each do |filename, file|
+          fm = parse_frontmatter(file[:content])
+          next unless fm.is_a?(Hash)
+          expect(fm).to have_key("name"),
+            "#{filename} missing name frontmatter field"
+          expect(fm["name"]).to be_a(String)
+          expect(fm).to have_key("description"),
+            "#{filename} missing description frontmatter field"
+          expect(fm["description"]).to be_a(String)
+        end
+      end
+
       it "excludeAgent uses valid values when present" do
-        valid_values = %w[code-review coding-agent]
+        valid_values = %w[code-review coding-agent workspace]
         generated_files.each do |filename, file|
           fm = parse_frontmatter(file[:content])
           next unless fm.is_a?(Hash) && fm.key?("excludeAgent")

--- a/spec/lib/rails_ai_context/serializers/cursor_mdc_compliance_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/cursor_mdc_compliance_spec.rb
@@ -135,13 +135,25 @@ RSpec.describe "Cursor MDC compliance" do
     end
 
     it "always-apply rules have alwaysApply: true" do
-      %w[rails-project.mdc rails-mcp-tools.mdc].each do |filename|
+      %w[rails-project.mdc].each do |filename|
         file = generated_files[filename]
         next unless file
         fm = parse_frontmatter(file[:content])
         expect(fm["alwaysApply"]).to be(true),
           "#{filename} should be alwaysApply: true"
       end
+    end
+
+    it "mcp-tools rule is agent-requested (Type 3)" do
+      file = generated_files["rails-mcp-tools.mdc"]
+      expect(file).not_to be_nil
+      fm = parse_frontmatter(file[:content])
+      expect(fm["alwaysApply"]).to be(false),
+        "rails-mcp-tools.mdc should be alwaysApply: false (agent-requested)"
+      expect(fm["description"]).to be_a(String)
+      expect(fm["description"]).to include("tools")
+      expect(fm).not_to have_key("globs"),
+        "agent-requested rules should not have globs"
     end
 
     it "auto-attached rules have alwaysApply: false" do

--- a/spec/lib/rails_ai_context/serializers/cursor_rules_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/cursor_rules_serializer_spec.rb
@@ -64,12 +64,12 @@ RSpec.describe RailsAiContext::Serializers::CursorRulesSerializer do
     end
   end
 
-  it "generates MCP tools rule with alwaysApply" do
+  it "generates MCP tools rule as agent-requested (alwaysApply false)" do
     Dir.mktmpdir do |dir|
       described_class.new(context).call(dir)
 
       tools_rule = File.read(File.join(dir, ".cursor", "rules", "rails-mcp-tools.mdc"))
-      expect(tools_rule).to include("alwaysApply: true")
+      expect(tools_rule).to include("alwaysApply: false")
       expect(tools_rule).to include("Tools (#{RailsAiContext::Server::TOOLS.size})")
       expect(tools_rule).to include("rails_get_schema")
       expect(tools_rule).to include("Step-by-step workflows")

--- a/spec/lib/rails_ai_context/server_spec.rb
+++ b/spec/lib/rails_ai_context/server_spec.rb
@@ -26,21 +26,21 @@ RSpec.describe RailsAiContext::Server do
     end
   end
 
-  describe "TOOLS" do
-    it "is a frozen array of tool classes" do
-      expect(described_class::TOOLS).to be_frozen
-      expect(described_class::TOOLS).to be_an(Array)
+  describe ".builtin_tools" do
+    it "returns an array of tool classes" do
+      expect(described_class.builtin_tools).to be_an(Array)
+      expect(described_class.builtin_tools).not_to be_empty
     end
 
     it "contains only MCP::Tool subclasses" do
-      described_class::TOOLS.each do |tool|
+      described_class.builtin_tools.each do |tool|
         expect(tool).to be < MCP::Tool
       end
     end
 
     it "includes core tools like GetSchema and GetRoutes" do
-      expect(described_class::TOOLS).to include(RailsAiContext::Tools::GetSchema)
-      expect(described_class::TOOLS).to include(RailsAiContext::Tools::GetRoutes)
+      expect(described_class.builtin_tools).to include(RailsAiContext::Tools::GetSchema)
+      expect(described_class.builtin_tools).to include(RailsAiContext::Tools::GetRoutes)
     end
   end
 
@@ -115,7 +115,7 @@ RSpec.describe RailsAiContext::Server do
       it "includes all tools when skip_tools is empty" do
         RailsAiContext.configuration.skip_tools = []
         mcp_server = server.build
-        described_class::TOOLS.each do |tool|
+        described_class.builtin_tools.each do |tool|
           expect(mcp_server.tools.values).to include(tool)
         end
       end

--- a/spec/lib/rails_ai_context/test_helper_spec.rb
+++ b/spec/lib/rails_ai_context/test_helper_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiContext::TestHelper do
+  include described_class
+
+  describe "#execute_tool" do
+    it "executes a tool by full MCP name" do
+      response = execute_tool("rails_get_schema", detail: "summary")
+      expect(response).to be_a(MCP::Tool::Response)
+    end
+
+    it "executes a tool by short name" do
+      response = execute_tool("schema", detail: "summary")
+      expect(response).to be_a(MCP::Tool::Response)
+    end
+
+    it "executes a tool by class" do
+      response = execute_tool(RailsAiContext::Tools::GetSchema, detail: "summary")
+      expect(response).to be_a(MCP::Tool::Response)
+    end
+
+    it "raises ArgumentError for unknown tool name" do
+      expect { execute_tool("nonexistent_tool") }.to raise_error(ArgumentError, /not found/)
+    end
+  end
+
+  describe "#execute_tool_with_error" do
+    it "returns the response even for error cases" do
+      response = execute_tool_with_error("rails_query", sql: "DROP TABLE users")
+      expect(response).to be_a(MCP::Tool::Response)
+    end
+  end
+
+  describe "#assert_tool_findable" do
+    it "passes for a registered tool" do
+      assert_tool_findable("rails_get_schema")
+    end
+
+    it "passes for a tool class" do
+      assert_tool_findable(RailsAiContext::Tools::GetSchema)
+    end
+
+    it "passes with short name resolution" do
+      assert_tool_findable("schema")
+    end
+
+    it "fails for an unregistered tool" do
+      expect { assert_tool_findable("nonexistent_tool") }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+    end
+  end
+
+  describe "#assert_tool_response_includes" do
+    it "passes when text is present in response" do
+      response = execute_tool("rails_get_conventions")
+      assert_tool_response_includes(response, "Convention")
+    end
+  end
+
+  describe "#assert_tool_response_excludes" do
+    it "passes when text is absent from response" do
+      response = execute_tool("rails_get_schema", detail: "summary")
+      assert_tool_response_excludes(response, "XYZZY_NONEXISTENT_TABLE")
+    end
+  end
+
+  describe "#extract_response_text" do
+    it "extracts text content from a response" do
+      response = execute_tool("rails_get_conventions")
+      text = extract_response_text(response)
+      expect(text).to be_a(String)
+      expect(text).not_to be_empty
+    end
+  end
+end

--- a/spec/lib/rails_ai_context/tools/base_tool_spec.rb
+++ b/spec/lib/rails_ai_context/tools/base_tool_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiContext::Tools::BaseTool do
+  describe ".abstract?" do
+    it "is abstract (excluded from registry)" do
+      expect(described_class).to be_abstract
+    end
+  end
+
+  describe ".registered_tools" do
+    it "returns all 38 built-in tool classes" do
+      tools = described_class.registered_tools
+      expect(tools.size).to eq(38)
+    end
+
+    it "excludes BaseTool itself" do
+      expect(described_class.registered_tools).not_to include(described_class)
+    end
+
+    it "returns only MCP::Tool subclasses" do
+      described_class.registered_tools.each do |tool|
+        expect(tool).to be < MCP::Tool
+      end
+    end
+
+    it "includes core tools" do
+      tools = described_class.registered_tools
+      expect(tools).to include(RailsAiContext::Tools::GetSchema)
+      expect(tools).to include(RailsAiContext::Tools::GetRoutes)
+      expect(tools).to include(RailsAiContext::Tools::Query)
+    end
+
+    it "does not include abstract tools" do
+      described_class.registered_tools.each do |tool|
+        expect(tool).not_to be_abstract
+      end
+    end
+  end
+
+  describe ".descendants" do
+    it "tracks all subclasses" do
+      expect(described_class.descendants).to be_an(Array)
+      expect(described_class.descendants.size).to eq(38)
+    end
+  end
+
+  describe "Server.builtin_tools integration" do
+    it "returns the same tools as registered_tools" do
+      expect(RailsAiContext::Server.builtin_tools).to eq(described_class.registered_tools)
+    end
+  end
+
+  describe "const_missing backwards compatibility" do
+    it "Server::TOOLS still works" do
+      expect(RailsAiContext::Server::TOOLS).to be_an(Array)
+      expect(RailsAiContext::Server::TOOLS.size).to eq(38)
+    end
+  end
+end

--- a/spec/lib/rails_ai_context/tools/get_concern_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_concern_spec.rb
@@ -202,6 +202,33 @@ RSpec.describe RailsAiContext::Tools::GetConcern do
       end
     end
 
+    context "class_methods block closing" do
+      before do
+        File.write(File.join(model_concerns_dir, "mixed_methods.rb"), <<~RUBY)
+          module MixedMethods
+            extend ActiveSupport::Concern
+
+            class_methods do
+              def inside_block
+                # class method inside block
+              end
+            end
+
+            def self.after_block
+              # class method after block
+            end
+          end
+        RUBY
+      end
+
+      it "captures def self. methods defined after class_methods block" do
+        result = described_class.call(name: "MixedMethods", detail: "standard")
+        text = result.content.first[:text]
+        expect(text).to include("inside_block")
+        expect(text).to include("after_block")
+      end
+    end
+
     context "callbacks in concerns" do
       before do
         File.write(File.join(model_concerns_dir, "trackable.rb"), <<~RUBY)

--- a/spec/lib/rails_ai_context/tools/get_partial_interface_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_partial_interface_spec.rb
@@ -56,6 +56,24 @@ RSpec.describe RailsAiContext::Tools::GetPartialInterface do
       expect(text).to include("not found")
     end
 
+    it "returns helpful message when partial is nil" do
+      result = described_class.call(partial: nil)
+      text = result.content.first[:text]
+      expect(text).to include("`partial` parameter is required")
+    end
+
+    it "returns helpful message when partial is empty string" do
+      result = described_class.call(partial: "")
+      text = result.content.first[:text]
+      expect(text).to include("`partial` parameter is required")
+    end
+
+    it "returns helpful message when partial is whitespace only" do
+      result = described_class.call(partial: "   ")
+      text = result.content.first[:text]
+      expect(text).to include("`partial` parameter is required")
+    end
+
     it "prevents path traversal" do
       result = described_class.call(partial: "../../../etc/passwd")
       text = result.content.first[:text]

--- a/spec/lib/rails_ai_context/tools/query_spec.rb
+++ b/spec/lib/rails_ai_context/tools/query_spec.rb
@@ -391,20 +391,15 @@ RSpec.describe RailsAiContext::Tools::Query do
       end
     end
 
-    it "installs and cleans up progress handler for timeout enforcement" do
-      conn = ActiveRecord::Base.connection
-      raw = conn.raw_connection
+    it "executes queries successfully without progress handler support" do
+      raw = ActiveRecord::Base.connection.raw_connection
 
-      if raw.respond_to?(:set_progress_handler)
-        # The tool should install a progress handler for timeout and clean it up
-        described_class.call(sql: "SELECT 1 AS test")
-
-        # After execution, the progress handler should be cleared (no lingering handler)
-        # Verify by running a normal query — should succeed without interruption
-        expect { conn.execute("SELECT 1") }.not_to raise_error
-      else
-        skip "SQLite driver does not support set_progress_handler"
-      end
+      # sqlite3 gem 2.x removed set_progress_handler; verify the timeout
+      # enforcement path degrades gracefully (query still runs, no error)
+      expect(raw.respond_to?(:set_progress_handler)).to be false
+      response = described_class.call(sql: "SELECT 1 AS test")
+      expect(response).to be_a(MCP::Tool::Response)
+      expect(response.content.first[:text]).to include("test")
     end
 
     it "resets PRAGMA query_only after query execution" do

--- a/spec/lib/rails_ai_context/tools/query_spec.rb
+++ b/spec/lib/rails_ai_context/tools/query_spec.rb
@@ -436,8 +436,28 @@ RSpec.describe RailsAiContext::Tools::Query do
       expect(described_class.strip_sql_comments(sql)).to eq("SELECT 1")
     end
 
-    it "strips MySQL-style hash comments" do
-      expect(described_class.strip_sql_comments("SELECT 1 # evil comment")).to eq("SELECT 1")
+    it "strips MySQL-style hash comments at line start" do
+      expect(described_class.strip_sql_comments("# full line comment\nSELECT 1")).to eq("SELECT 1")
+    end
+
+    it "preserves hash characters inside SQL strings" do
+      sql = "SELECT '#'; DROP TABLE users"
+      result = described_class.strip_sql_comments(sql)
+      expect(result).to include("DROP TABLE")
+    end
+
+    it "preserves PostgreSQL JSONB operators" do
+      sql = "SELECT data #>> '{key}' FROM records"
+      result = described_class.strip_sql_comments(sql)
+      expect(result).to include("#>>")
+    end
+  end
+
+  describe "SQL validation with hash in string literals" do
+    it "blocks destructive SQL hidden after hash in string literal" do
+      valid, error = described_class.validate_sql("SELECT '#'; DROP TABLE users")
+      expect(valid).to be false
+      expect(error).to include("Blocked")
     end
   end
 

--- a/spec/lib/rails_ai_context/tools/runtime_info_spec.rb
+++ b/spec/lib/rails_ai_context/tools/runtime_info_spec.rb
@@ -63,6 +63,38 @@ RSpec.describe RailsAiContext::Tools::RuntimeInfo do
       expect(text).to include("not loaded")
     end
 
+    context "when ActiveRecord is not defined" do
+      before do
+        @original_ar = ActiveRecord
+        hide_const("ActiveRecord")
+      end
+
+      after do
+        # ActiveRecord is restored automatically by hide_const
+      end
+
+      it "degrades gracefully for connection pool section" do
+        result = described_class.call(section: "connections")
+        text = result.content.first[:text]
+        expect(text).to include("ActiveRecord not available")
+        expect(text).not_to include("Pool size")
+      end
+
+      it "degrades gracefully for database section" do
+        result = described_class.call(section: "database")
+        text = result.content.first[:text]
+        expect(text).to include("ActiveRecord not available")
+      end
+
+      it "still returns cache and jobs sections" do
+        result = described_class.call
+        text = result.content.first[:text]
+        expect(text).to include("Runtime Info")
+        expect(text).to include("Cache")
+        expect(text).to include("Background Jobs")
+      end
+    end
+
     it "has read-only annotations" do
       annotations = described_class.annotations_value
       expect(annotations.read_only_hint).to eq(true)


### PR DESCRIPTION
## Summary

- **Auto-registration via `BaseTool.inherited`** — replaces the manual 38-line `Server::TOOLS` constant. Tools are discovered dynamically with eager loading. Thread-safe via `@registry_mutex` with deadlock-free design. `Server::TOOLS` backwards-compatible via `const_missing`.
- **`abstract!` pattern** — `BaseTool.abstract!` excludes a class from the registry. BaseTool itself is abstract, subclasses concrete by default.
- **TestHelper module** — `execute_tool`, `assert_tool_findable`, `assert_tool_response_includes/excludes` for custom_tools testing. Works with RSpec and Minitest.
- **5 bug fixes**: SQL comment stripping bypass (HIGH), SHARED_CACHE thread safety (MEDIUM), McpController double-checked locking (MEDIUM), PG EXPLAIN bare rescue (LOW), GetConcern class_methods block (LOW)
- **Query spec fix** — replaced permanently-pending spec with graceful degradation test

## Verification

- 1,889 unit tests, 0 failures
- 496 e2e integration tests across 4 test apps, 0 failures
- 5 agents ran: test-and-lint, bug-finder, code-reviewer, doc-consistency, e2e-tester
- Thread safety verified with 10 concurrent threads
- All doc counts consistent (version, tools, introspectors, listeners, tests)

## Test plan

- [x] `bundle exec rspec` — 1,889 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses in gem source
- [x] E2E: all 4 test apps discover 38 tools via auto-registration
- [x] E2E: CLI tool execution, context generation, MCP server build all pass
- [x] Thread safety: no deadlocks, no duplicates, no race conditions
- [x] Backwards compat: `Server::TOOLS` still works via `const_missing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)