### PR TITLE
fix: shorten server.json description for MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.crisnahine/rails-ai-context",
   "title": "Rails AI Context",
-  "description": "Stop AI from guessing your Rails app. 38 MCP tools give agents live schema, routes, conventions. Works with Claude Code, Cursor, GitHub Copilot, OpenCode, and Codex CLI.",
+  "description": "38 MCP tools give AI agents live Rails schema, routes, models, and conventions.",
   "repository": {
     "url": "https://github.com/crisnahine/rails-ai-context",
     "source": "github"


### PR DESCRIPTION
## Summary

- MCP Registry rejects descriptions > 100 chars
- Shortened from 157 chars to 79 chars

## Test plan

- [x] CI publish step should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)