### PR TITLE
docs: comprehensive documentation with awesome-readme patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <a href="https://github.com/features/copilot"><img src="https://img.shields.io/badge/GitHub_Copilot-000000?style=for-the-badge&logo=githubcopilot&logoColor=white" alt="GitHub Copilot"></a>
 <a href="https://opencode.ai"><img src="https://img.shields.io/badge/OpenCode-4285F4?style=for-the-badge&logoColor=white" alt="OpenCode"></a>
 <a href="https://codex.openai.com"><img src="https://img.shields.io/badge/Codex_CLI-412991?style=for-the-badge&logo=openai&logoColor=white" alt="Codex CLI"></a>
-<a href="#-cli--works-everywhere"><img src="https://img.shields.io/badge/Any_Terminal-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white" alt="Any Terminal"></a>
+<a href="docs/CLI.md"><img src="https://img.shields.io/badge/Any_Terminal-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white" alt="Any Terminal"></a>
 
 
 
@@ -187,20 +187,18 @@ rails 'ai:tool[analyze_feature]' feature=billing
 <br>
 
 ```bash
-# Step 1: Check what exists
 rails 'ai:tool[schema]' table=users
-# → 20 columns, types, indexes, encrypted hints, defaults
-
-# Step 2: Understand the model
-rails 'ai:tool[model_details]' model=User
-# → associations, validations, scopes, enums, callbacks, Devise modules
-
-# Step 3: See the full feature
-rails 'ai:tool[analyze_feature]' feature=subscription
-# → models + controllers + routes + services + jobs + views + tests in one shot
+```
+```
+## Table: users
+| Column              | Type    | Null | Default |
+|---------------------|---------|------|---------|
+| email               | string  | NO   | [unique] |
+| subscription_status | string  | yes  | "free"   |
+| created_at          | datetime| NO   |          |
 ```
 
-AI writes a correct migration, model change, and controller update on the **first attempt**.
+AI sees `subscription_status` already exists. Checks the model, then generates a correct migration — **first attempt**.
 
 </details>
 
@@ -210,18 +208,17 @@ AI writes a correct migration, model change, and controller update on the **firs
 <br>
 
 ```bash
-# Trace what happens
 rails 'ai:tool[controllers]' controller=CooksController action=create
-# → source code + inherited filters + strong params + render map + side effects
-
-# Check the routes
-rails 'ai:tool[routes]' controller=cooks
-# → code-ready helpers (cook_path(@record)) + required params
-
-# Validate after fixing
-rails 'ai:tool[validate]' files=app/controllers/cooks_controller.rb level=rails
-# → syntax + semantics + Brakeman security scan
 ```
+```
+# CooksController#create
+
+Filters: before_action :authenticate_user!, before_action :set_cook (only: show, edit)
+Strong params: cook_params → name, specialty, bio
+Renders: redirect_to @cook | render :new
+```
+
+AI sees the inherited `authenticate_user!` filter, the actual strong params, and the render paths. No guessing.
 
 </details>
 
@@ -252,7 +249,7 @@ rails 'ai:tool[stimulus]' controller=chart
 
 Every tool is **read-only** and returns data verified against your actual app — not guesses, not training data.
 
-<details>
+<details open>
 <summary><strong>Search & Trace</strong></summary>
 
 | Tool | What it does |
@@ -262,7 +259,7 @@ Every tool is **read-only** and returns data verified against your actual app �
 
 </details>
 
-<details>
+<details open>
 <summary><strong>Understand</strong></summary>
 
 | Tool | What it does |
@@ -273,7 +270,7 @@ Every tool is **read-only** and returns data verified against your actual app �
 
 </details>
 
-<details>
+<details open>
 <summary><strong>Schema & Models</strong></summary>
 
 | Tool | What it does |
@@ -285,7 +282,7 @@ Every tool is **read-only** and returns data verified against your actual app �
 
 </details>
 
-<details>
+<details open>
 <summary><strong>Controllers & Routes</strong></summary>
 
 | Tool | What it does |
@@ -295,7 +292,7 @@ Every tool is **read-only** and returns data verified against your actual app �
 
 </details>
 
-<details>
+<details open>
 <summary><strong>Views & Frontend</strong></summary>
 
 | Tool | What it does |
@@ -308,7 +305,7 @@ Every tool is **read-only** and returns data verified against your actual app �
 
 </details>
 
-<details>
+<details open>
 <summary><strong>Testing & Quality</strong></summary>
 
 | Tool | What it does |
@@ -321,7 +318,7 @@ Every tool is **read-only** and returns data verified against your actual app �
 
 </details>
 
-<details>
+<details open>
 <summary><strong>App Config & Services</strong></summary>
 
 | Tool | What it does |
@@ -337,7 +334,7 @@ Every tool is **read-only** and returns data verified against your actual app �
 
 </details>
 
-<details>
+<details open>
 <summary><strong>Data & Debugging</strong></summary>
 
 | Tool | What it does |
@@ -354,7 +351,7 @@ Every tool is **read-only** and returns data verified against your actual app �
 
 </details>
 
-> **[Full parameter docs →](docs/GUIDE.md)**
+> **[All 38 tools with parameters →](docs/TOOLS.md)** &nbsp;|&nbsp; **[Real-world recipes →](docs/RECIPES.md)**
 
 <br>
 
@@ -398,26 +395,21 @@ Enabled by default. Disable with `config.anti_hallucination_rules = false` if yo
 
 ## How it works
 
-```
-┌─────────────────────────────────────────────────────────┐
-│  Your Rails App                                          │
-│  models + schema + routes + controllers + views + jobs   │
-└────────────────────────┬────────────────────────────────┘
-                         │ introspects (31 introspectors)
-                         ▼
-┌─────────────────────────────────────────────────────────┐
-│  rails-ai-context                                        │
-│  Prism AST parsing. Cached. Confidence-tagged results.    │
-│  VFS: rails-ai-context:// URIs introspected fresh.        │
-└────────┬──────────────────┬──────────────┬──────────────┘
-         │                  │              │
-         ▼                  ▼              ▼
-┌──────────────────┐ ┌────────────┐ ┌────────────────────┐
-│  Static Files     │ │  MCP Server │ │  CLI Tools          │
-│  CLAUDE.md        │ │  38 tools   │ │  Same 38 tools      │
-│  .cursor/rules/   │ │  5 templates│ │  No server needed   │
-│  .github/instr... │ │  stdio/HTTP │ │  rails 'ai:tool[X]' │
-└──────────────────┘ └────────────┘ └────────────────────┘
+```mermaid
+graph TD
+    A["Your Rails App\nmodels + schema + routes + controllers + views + jobs"] -->|"31 introspectors"| B
+
+    B["rails-ai-context\nPrism AST parsing · Cached · Confidence-tagged\nVFS: rails-ai-context:// URIs introspected fresh"]
+
+    B --> C["MCP Server\nstdio / HTTP\n38 tools · 5 templates"]
+    B --> D["CLI Tools\nRake / Thor\nSame 38 tools"]
+    B --> E["Static Files\nCLAUDE.md · .cursor/rules/\n.github/instructions/"]
+
+    style A fill:#4a9eff,stroke:#2d7ad4,color:#fff
+    style B fill:#2d2d2d,stroke:#555,color:#fff
+    style C fill:#0984e3,stroke:#0770c2,color:#fff
+    style D fill:#00cec9,stroke:#00b5b0,color:#fff
+    style E fill:#a29bfe,stroke:#8c83f0,color:#fff
 ```
 
 <br>
@@ -456,6 +448,58 @@ Both paths ask which AI tools you use (Claude Code, Cursor, GitHub Copilot, Open
 
 <br>
 
+## Documentation
+
+| | |
+|:------|:------------|
+| **[Quickstart](docs/QUICKSTART.md)** | 5-minute getting started |
+| **[Tools Reference](docs/TOOLS.md)** | All 38 tools with every parameter |
+| **[Recipes](docs/RECIPES.md)** | Real-world workflows and examples |
+| **[Custom Tools](docs/CUSTOM_TOOLS.md)** | Build and test your own MCP tools |
+| **[Configuration](docs/CONFIGURATION.md)** | 40+ config options with defaults |
+| **[AI Tool Setup](docs/SETUP.md)** | Claude, Cursor, Copilot, OpenCode, Codex |
+| **[Architecture](docs/ARCHITECTURE.md)** | System design and internals |
+| **[Introspectors](docs/INTROSPECTORS.md)** | All 31 introspectors and AST engine |
+| **[Security](docs/SECURITY.md)** | 4-layer SQL safety and file blocking |
+| **[CLI Reference](docs/CLI.md)** | Commands and argument syntax |
+| **[Standalone](docs/STANDALONE.md)** | Use without Gemfile entry |
+| **[Troubleshooting](docs/TROUBLESHOOTING.md)** | Common issues and fixes |
+| **[FAQ](docs/FAQ.md)** | Frequently asked questions |
+
+<br>
+
+## Build your own tools
+
+Register custom MCP tools alongside the 38 built-in ones:
+
+```ruby
+# app/mcp_tools/rails_get_business_metrics.rb
+class RailsGetBusinessMetrics < MCP::Tool
+  tool_name "rails_get_business_metrics"
+  description "Key business metrics for this app"
+
+  def call(period: "week")
+    MCP::Tool::Response.new([{ type: "text", text: "Users this #{period}: #{User.recent.count}" }])
+  end
+end
+
+# config/initializers/rails_ai_context.rb
+config.custom_tools = [RailsGetBusinessMetrics]
+```
+
+Test with the built-in `TestHelper` (works with RSpec and Minitest):
+
+```ruby
+include RailsAiContext::TestHelper
+
+response = execute_tool("business_metrics", period: "month")
+assert_tool_response_includes(response, "Users")
+```
+
+> **[Custom Tools Guide →](docs/CUSTOM_TOOLS.md)**
+
+<br>
+
 ## Configuration
 
 ```ruby
@@ -469,39 +513,19 @@ if defined?(RailsAiContext)
 end
 ```
 
-<details>
-<summary><strong>All configuration options</strong></summary>
-
-<br>
-
-| Option | Default | Description |
-|:-------|:--------|:------------|
-| `preset` | `:full` | `:full` (31 introspectors) or `:standard` (17) |
-| `context_mode` | `:compact` | `:compact` (150 lines) or `:full` |
-| `generate_root_files` | `true` | Set `false` for split rules only |
-| `anti_hallucination_rules` | `true` | Embed 6-rule verification protocol in generated context files |
-| `cache_ttl` | `60` | Cache TTL in seconds |
-| `max_tool_response_chars` | `200_000` | Safety cap for tool responses |
-| `live_reload` | `:auto` | `:auto`, `true`, or `false` |
-| `custom_tools` | `[]` | Additional MCP tool classes |
-| `skip_tools` | `[]` | Built-in tools to exclude |
-| `excluded_models` | `[]` | Models to skip during introspection |
-
-</details>
+> **[All 40+ configuration options →](docs/CONFIGURATION.md)**
 
 <br>
 
 ## Observability
 
-Every MCP tool call and resource read fires an `ActiveSupport::Notifications` event. Subscribe with standard Rails patterns:
+Every MCP tool call fires an `ActiveSupport::Notifications` event:
 
 ```ruby
 ActiveSupport::Notifications.subscribe("rails_ai_context.tools.call") do |event|
   Rails.logger.info "[MCP] #{event.payload[:method]} — #{event.duration}ms"
 end
 ```
-
-Events: `rails_ai_context.tools.call`, `rails_ai_context.resources.read`, and more. All 38 tools declare `output_schema` in the MCP protocol, so clients know the response format before calling.
 
 <br>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,244 @@
+<div align="center">
+
+# Architecture
+
+**How rails-ai-context is built, and why.**
+
+[Tools Reference](TOOLS.md) · [Introspectors](INTROSPECTORS.md) · [Security](SECURITY.md) · [Custom Tools](CUSTOM_TOOLS.md)
+
+</div>
+
+---
+
+## System overview
+
+```mermaid
+graph TD
+    subgraph app["Your Rails App"]
+        A["models + schema + routes + controllers + views + jobs + config"]
+    end
+
+    A -->|"31 introspectors"| gem
+
+    subgraph gem["rails-ai-context"]
+        direction TB
+
+        subgraph engine["Introspection Engine"]
+            direction LR
+            I["Introspectors\n31 modules\nPresets\nCached"]
+            AST["AST Engine\nPrism\n7 listeners\nConfidence tags"]
+            H["Hydration Layer\nSchema hints\ninjected into\ntool responses"]
+        end
+
+        engine --> R["Tool Registry\n38 tools auto-discovered via inherited\n+ custom_tools - skip_tools = active tools"]
+    end
+
+    R --> MCP
+    R --> CLI
+    R --> S
+
+    subgraph outputs["Output"]
+        direction LR
+        MCP["MCP Server\nstdio / HTTP\nResources\nVFS URIs"]
+        CLI["CLI Runner\nRake / Thor\nSame 38 tools\nNo server needed"]
+        S["Serializers\n14 modules\nStatic files\nPer-AI-tool"]
+    end
+
+    style app fill:#4a9eff,stroke:#2d7ad4,color:#fff
+    style gem fill:#2d2d2d,stroke:#555,color:#fff
+    style engine fill:#3a3a3a,stroke:#666,color:#fff
+    style outputs fill:#1a1a1a,stroke:#444,color:#fff
+    style I fill:#6c5ce7,stroke:#5a4bd1,color:#fff
+    style AST fill:#e17055,stroke:#c0392b,color:#fff
+    style H fill:#00b894,stroke:#00a381,color:#fff
+    style R fill:#fdcb6e,stroke:#f0b429,color:#333
+    style MCP fill:#0984e3,stroke:#0770c2,color:#fff
+    style CLI fill:#00cec9,stroke:#00b5b0,color:#fff
+    style S fill:#a29bfe,stroke:#8c83f0,color:#fff
+```
+
+### Data flow
+
+```mermaid
+sequenceDiagram
+    participant AI as AI Assistant
+    participant MCP as MCP Server
+    participant TR as Tool Registry
+    participant Cache as Cache Layer
+    participant App as Rails App
+
+    AI->>MCP: rails_get_schema(table: "users")
+    MCP->>TR: resolve tool + execute
+    TR->>Cache: check introspection cache
+    alt cache hit (TTL + fingerprint valid)
+        Cache-->>TR: cached context
+    else cache miss
+        Cache->>App: introspect (31 modules)
+        App-->>Cache: structured data
+        Cache-->>TR: fresh context
+    end
+    TR-->>MCP: MCP::Tool::Response
+    MCP-->>AI: schema with columns, indexes, hints
+```
+
+### Request lifecycle
+
+```mermaid
+flowchart LR
+    A[Tool Call] --> B{Registered?}
+    B -->|Yes| C{Cache Valid?}
+    B -->|No| E[ToolNotFoundError]
+    C -->|Hit| D[Return Cached]
+    C -->|Miss| F[Introspect]
+    F --> G[Cache Result]
+    G --> D
+    D --> H[Hydrate\nSchema Hints]
+    H --> I[Truncate\nmax_chars]
+    I --> J[MCP::Tool::Response]
+```
+
+## Core modules
+
+### Introspectors (`lib/rails_ai_context/introspectors/`)
+
+31 modules that extract structured data from your Rails app. Each introspector:
+
+- Returns a Hash (never raises — wraps errors in `{ error: msg }`)
+- Is registered in `INTROSPECTOR_MAP` with a symbol key
+- Belongs to one or both presets (`:standard`, `:full`)
+- Results are cached with TTL + fingerprint invalidation
+
+The `Introspector` orchestrator runs configured introspectors and merges results.
+
+### AST Engine
+
+**Prism AST parsing** replaced all regex-based Ruby source parsing in v5.2.0.
+
+- **AstCache** — Thread-safe parse cache (`Concurrent::Map`), keyed by path + SHA256 + mtime
+- **SourceIntrospector** — Single-pass Prism Dispatcher walks the AST once, feeds events to all 7 listeners simultaneously
+- **7 Listeners** — Associations, Validations, Scopes, Enums, Callbacks, Macros, Methods
+- **Confidence** — Every result carries `[VERIFIED]` (static literals) or `[INFERRED]` (dynamic expressions)
+
+### Tool Registry (`lib/rails_ai_context/tools/base_tool.rb`)
+
+Auto-registration via Ruby's `inherited` hook:
+
+1. `BaseTool.inherited(subclass)` fires when any file in `tools/` defines a subclass
+2. Subclass is appended to `@descendants` (protected by `@registry_mutex`)
+3. `BaseTool.registered_tools` eager-loads all tool files and returns non-abstract classes
+4. `BaseTool` itself is marked `abstract!` — excluded from the registry
+
+**Deadlock-free design**: `eager_load!` collects constants to load inside the mutex, loads them outside (because `const_get` triggers Zeitwerk autoloading which calls `inherited` which needs the mutex), then sets the flag inside the mutex.
+
+### MCP Server (`lib/rails_ai_context/server.rb`)
+
+Built on the official `mcp` Ruby SDK:
+
+- **Transports**: stdio (default) or HTTP (Streamable HTTP via `MCP::Server::Transports::StreamableHTTPTransport`)
+- **Tools**: all active tools (builtin + custom − skip_tools)
+- **Resources**: 9 static resources + 5 dynamic VFS resource templates
+- **Instrumentation**: bridges to `ActiveSupport::Notifications`
+- **Live Reload**: watches files, invalidates caches, notifies clients
+
+### VFS (`lib/rails_ai_context/vfs.rb`)
+
+Virtual File System for `rails-ai-context://` URIs:
+
+```
+rails-ai-context://models/Post         → model details + schema
+rails-ai-context://controllers/Posts   → actions, filters, params
+rails-ai-context://controllers/Posts/index → action source
+rails-ai-context://views/posts/show.html.erb → template content
+rails-ai-context://routes/posts        → filtered routes
+```
+
+Every resolve call introspects fresh — zero stale data.
+
+### Hydration Layer (`lib/rails_ai_context/hydrators/`)
+
+Cross-tool semantic hydration (v5.3.0):
+
+- **ControllerHydrator** — Parses controller source via Prism AST to detect model references, injects schema hints
+- **ViewHydrator** — Maps `@post` → `Post` by convention, injects schema hints
+- **SchemaHintBuilder** — Resolves model names to `SchemaHint` value objects from cached context
+- **HydrationFormatter** — Renders hints as compact Markdown sections
+
+Result: controller and view tools automatically include relevant schema information without extra tool calls.
+
+### Serializers (`lib/rails_ai_context/serializers/`)
+
+14 modules that format introspection output for different AI tools:
+
+| Serializer | Output |
+|:-----------|:-------|
+| `ClaudeSerializer` | `CLAUDE.md` |
+| `ClaudeRulesSerializer` | `.claude/rules/*.md` |
+| `CursorRulesSerializer` | `.cursor/rules/*.mdc` |
+| `CopilotSerializer` | `.github/copilot-instructions.md` |
+| `CopilotInstructionsSerializer` | `.github/instructions/*.instructions.md` |
+| `OpencodeSerializer` | `AGENTS.md` (root) |
+| `OpencodeRulesSerializer` | `app/*/AGENTS.md` |
+| `JsonSerializer` | `.ai-context.json` |
+| `MarkdownSerializer` | Base formatting |
+| `ContextFileSerializer` | Atomic file writes with section markers |
+| `CompactSerializerHelper` | Compact mode (≤150 lines) |
+| `StackOverviewHelper` | Stack overview sections |
+| `ToolGuideHelper` | MCP/CLI tool reference sections |
+| `TestCommandDetection` | Test framework detection |
+
+### CLI (`exe/rails-ai-context`, `lib/rails_ai_context/cli/`)
+
+Thor-based CLI that works standalone (no Gemfile entry):
+
+- `ToolRunner` — Parses CLI args, resolves tool names, executes tools, formats output
+- Supports `--json` mode for machine-readable output
+- Same 38 tools available as MCP and CLI
+
+### Caching
+
+Three cache layers:
+
+1. **Introspection cache** (`BaseTool.SHARED_CACHE`) — Mutex-protected, TTL + fingerprint invalidation
+2. **AST cache** (`AstCache`) — `Concurrent::Map`, SHA256 fingerprint per file
+3. **Session cache** (`BaseTool.SESSION_CONTEXT`) — Mutex-protected call history, resets on server restart
+
+`LiveReload` watches files and calls `reset_all_caches!` when changes are detected.
+
+### Fingerprinter (`lib/rails_ai_context/fingerprinter.rb`)
+
+SHA256-based change detection:
+
+- Watches: `app/`, `config/`, `db/`, `lib/tasks/`, Gemfile.lock
+- Computes a composite fingerprint from all watched files
+- Used by introspection cache and live reload to detect actual changes
+
+## Key design decisions
+
+1. **Official MCP SDK** — Not a custom protocol. Uses `mcp` gem's `MCP::Tool`, `MCP::Server`, transports.
+2. **Read-only tools** — All 38 tools annotated as non-destructive. Defense-in-depth for query tool.
+3. **Graceful degradation** — Works without database (parses schema.rb as text), without Brakeman, without ripgrep, without listen gem.
+4. **Zeitwerk autoloading** — Files loaded on-demand. No `require_relative` in the gem.
+5. **Diff-aware generation** — Context file regeneration skips unchanged files using fingerprinting.
+6. **Section markers** — Root file content wrapped in `<!-- BEGIN/END rails-ai-context -->` to preserve user-added content.
+
+## Dependencies
+
+| Gem | Purpose | Required? |
+|:----|:--------|:----------|
+| `mcp` | MCP SDK — server, tools, transports | Yes |
+| `prism` | AST parsing (stdlib in Ruby 3.3+) | Yes |
+| `concurrent-ruby` | Thread-safe caches | Yes |
+| `zeitwerk` | Autoloading | Yes |
+| `thor` | CLI framework | Yes |
+| `brakeman` | Security scanning | Optional |
+| `listen` | File watching for live reload | Optional |
+
+---
+
+<div align="center">
+
+**[← AI Tool Setup](SETUP.md)** · **[Introspectors →](INTROSPECTORS.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,234 @@
+<div align="center">
+
+# CLI Reference
+
+**All commands available from the terminal.**
+
+[Quickstart](QUICKSTART.md) · [Tools Reference](TOOLS.md) · [Standalone](STANDALONE.md) · [Configuration](CONFIGURATION.md)
+
+</div>
+
+---
+
+## Two CLI interfaces
+
+| Context | Command prefix | Example |
+|:--------|:---------------|:--------|
+| In-Gemfile (Rake) | `rails ai:` | `rails 'ai:tool[schema]' table=users` |
+| Standalone (Thor) | `rails-ai-context` | `rails-ai-context tool schema --table users` |
+
+Both provide the same 38 tools and functionality.
+
+---
+
+## Commands
+
+### `serve`
+
+Start the MCP server.
+
+```bash
+rails ai:serve                                        # stdio (default)
+rails-ai-context serve                                # stdio (default)
+rails-ai-context serve --transport http --port 6029   # HTTP transport
+```
+
+| Option | Default | Description |
+|:-------|:--------|:------------|
+| `--transport` | `stdio` | `stdio` or `http` |
+| `--port` | `6029` | HTTP listen port |
+
+### `tool`
+
+Run any of the 38 MCP tools from the terminal.
+
+```bash
+# Rake syntax
+rails 'ai:tool[schema]' table=users detail=full
+rails 'ai:tool[search_code]' pattern="can_cook?" match_type=trace
+rails 'ai:tool[model_details]' model=User
+
+# Thor syntax
+rails-ai-context tool schema --table users --detail full
+rails-ai-context tool search_code --pattern "can_cook?" --match-type trace
+rails-ai-context tool model_details --model User
+```
+
+| Option | Description |
+|:-------|:------------|
+| `--list` | List all available tools |
+| `--json` | Output as JSON |
+
+### Tool name resolution
+
+All of these resolve to the same tool:
+
+```bash
+rails 'ai:tool[schema]'
+rails 'ai:tool[get_schema]'
+rails 'ai:tool[rails_get_schema]'
+```
+
+Resolution order: exact match → `rails_` prefix → `rails_get_` prefix → `get_` prefix.
+
+### `context`
+
+Generate static context files.
+
+```bash
+rails ai:context              # All configured formats
+rails ai:context:claude       # Claude only
+rails ai:context:cursor       # Cursor only
+rails ai:context:copilot      # Copilot only
+rails ai:context:opencode     # OpenCode only
+rails ai:context:json         # JSON export
+
+rails-ai-context context                # All
+rails-ai-context context --format claude # Specific format
+```
+
+| Option | Default | Description |
+|:-------|:--------|:------------|
+| `--format` | all configured | `claude`, `cursor`, `copilot`, `opencode`, `codex`, `json`, `all` |
+
+### `doctor`
+
+Run 23 diagnostic checks and report AI readiness score.
+
+```bash
+rails ai:doctor
+rails-ai-context doctor
+```
+
+Checks include: schema existence, pending migrations, model files, routes, MCP config validity, introspector health, ripgrep availability, Prism gem, Brakeman gem, listen gem, gitignore security, auto_mount security, schema size, view count, and more.
+
+### `watch`
+
+Watch for file changes and auto-regenerate context files.
+
+```bash
+rails ai:watch
+rails-ai-context watch
+```
+
+Requires the `listen` gem. Watches `app/`, `config/`, `db/`, `lib/tasks/`.
+
+### `init` (standalone only)
+
+Interactive setup for standalone mode.
+
+```bash
+rails-ai-context init
+```
+
+Asks which AI tools to configure and whether to use MCP or CLI mode. Creates `.rails-ai-context.yml` and MCP config files.
+
+### `version`
+
+```bash
+rails-ai-context version
+```
+
+### `inspect`
+
+Print introspection summary as JSON.
+
+```bash
+rails-ai-context inspect
+```
+
+---
+
+## Rake tasks (in-Gemfile only)
+
+| Task | Description |
+|:-----|:------------|
+| `rails ai:context` | Generate context for all configured formats |
+| `rails ai:context:claude` | Generate Claude context |
+| `rails ai:context:cursor` | Generate Cursor context |
+| `rails ai:context:copilot` | Generate Copilot context |
+| `rails ai:context:opencode` | Generate OpenCode context |
+| `rails ai:context:json` | Generate JSON export |
+| `rails ai:serve` | Start MCP server (stdio) |
+| `rails ai:tool` | List tools or run a tool |
+| `rails ai:doctor` | Run diagnostics |
+| `rails ai:watch` | Watch mode |
+| `rails ai:setup` | Interactive setup (alternative to generator) |
+
+---
+
+## Tool argument syntax
+
+### Rake format
+
+```bash
+rails 'ai:tool[tool_name]' key=value key2=value2
+```
+
+- Strings: `table=users`
+- Booleans: `explain=true` or `explain=false`
+- Enums: `detail=full`
+- Spaces: `pattern="has_many :posts"`
+
+### Thor format
+
+```bash
+rails-ai-context tool tool_name --key value --key2 value2
+```
+
+- Strings: `--table users` or `--table=users`
+- Booleans: `--explain` (true) or `--no-explain` (false)
+- Enums: `--detail full`
+- Spaces: `--pattern "has_many :posts"`
+
+### JSON output
+
+Add `--json` for machine-readable output:
+
+```bash
+rails-ai-context tool schema --table users --json
+```
+
+---
+
+## Common workflows
+
+### Quick schema check
+
+```bash
+rails 'ai:tool[schema]' table=users
+```
+
+### Trace a method
+
+```bash
+rails 'ai:tool[search_code]' pattern="process_payment" match_type=trace
+```
+
+### Full feature analysis
+
+```bash
+rails 'ai:tool[analyze_feature]' feature=billing
+```
+
+### Check AI readiness
+
+```bash
+rails ai:doctor
+```
+
+### Regenerate after changes
+
+```bash
+rails ai:context
+```
+
+---
+
+<div align="center">
+
+**[← Security](SECURITY.md)** · **[Standalone Mode →](STANDALONE.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,235 @@
+<div align="center">
+
+# Configuration
+
+**Every option, every default, every validation rule.**
+
+[Quickstart](QUICKSTART.md) · [Custom Tools](CUSTOM_TOOLS.md) · [AI Tool Setup](SETUP.md) · [FAQ](FAQ.md)
+
+</div>
+
+---
+
+## Configuration methods
+
+### Ruby initializer (recommended for in-Gemfile)
+
+```ruby
+# config/initializers/rails_ai_context.rb
+if defined?(RailsAiContext)
+  RailsAiContext.configure do |config|
+    config.ai_tools  = %i[claude cursor copilot opencode codex]
+    config.tool_mode = :mcp
+    config.preset    = :full
+  end
+end
+```
+
+### YAML config (recommended for standalone)
+
+```yaml
+# .rails-ai-context.yml
+ai_tools:
+  - claude
+  - cursor
+tool_mode: mcp
+preset: full
+```
+
+### Precedence
+
+> [!IMPORTANT]
+> Initializer > YAML > Defaults. If the initializer runs, YAML is skipped entirely. Corrupted YAML degrades gracefully with a warning.
+
+---
+
+## All options
+
+### AI Tools & Mode
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `ai_tools` | Array of symbols | `[:claude]` | Which AI tools to generate context for. Options: `:claude`, `:cursor`, `:copilot`, `:opencode`, `:codex` |
+| `tool_mode` | Symbol | `:mcp` | `:mcp` (MCP server primary, CLI fallback) or `:cli` (CLI only, no MCP server) |
+
+### Introspection
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `preset` | Symbol | `:full` | `:full` (31 introspectors) or `:standard` (13 introspectors) |
+| `context_mode` | Symbol | `:compact` | `:compact` (context files capped at ~150 lines) or `:full` (no line cap) |
+| `introspectors` | Array of symbols | (from preset) | Override the introspector list directly |
+| `generate_root_files` | Boolean | `true` | Set `false` to generate split rules only, no root CLAUDE.md/AGENTS.md |
+| `anti_hallucination_rules` | Boolean | `true` | Embed 6-rule verification protocol in generated context files |
+| `claude_max_lines` | Integer | `150` | Max lines for compact context files |
+
+### MCP Server
+
+| Option | Type | Default | Validation | Description |
+|:-------|:-----|:--------|:-----------|:------------|
+| `server_name` | String | `"rails-ai-context"` | — | MCP server name |
+| `cache_ttl` | Integer | `60` | Must be positive | Cache time-to-live in seconds |
+| `max_tool_response_chars` | Integer | `200_000` | Must be positive | Safety cap for tool response length |
+| `live_reload` | Symbol/Boolean | `:auto` | — | `:auto` (uses `listen` gem if available), `true`, or `false` |
+| `live_reload_debounce` | Float | `1.5` | — | Seconds to wait before processing file changes |
+| `auto_mount` | Boolean | `false` | — | Auto-mount Rack middleware for HTTP transport |
+| `http_path` | String | `"/mcp"` | — | HTTP endpoint path |
+| `http_bind` | String | `"127.0.0.1"` | — | HTTP bind address |
+| `http_port` | Integer | `6029` | 1–65535 | HTTP listen port |
+
+### Cross-Tool Hydration
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `hydration_enabled` | Boolean | `true` | Auto-inject schema hints into controller/view tool responses |
+| `hydration_max_hints` | Integer | `5` | Maximum schema hints per tool response |
+
+### Filtering
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `excluded_models` | Array | 8 framework models | Models to skip during introspection |
+| `excluded_controllers` | Array | 2 framework controllers | Controllers to skip |
+| `excluded_route_prefixes` | Array | 6 framework prefixes | Route prefixes to skip |
+| `excluded_filters` | Array | 3 framework filters | Controller filters to skip |
+| `excluded_middleware` | Array | 24 framework middleware | Middleware to skip in listing |
+| `excluded_paths` | Array | `["node_modules", "tmp", "log", "vendor", ".git", "doc", "docs"]` | Paths excluded from search |
+| `excluded_concerns` | Array of Regex | Framework concerns | Concerns to skip (supports regex) |
+
+### File Size Limits
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `max_file_size` | Integer | `5_000_000` (5 MB) | General file read limit |
+| `max_test_file_size` | Integer | `1_000_000` (1 MB) | Test file read limit |
+| `max_schema_file_size` | Integer | `10_000_000` (10 MB) | Schema file read limit |
+| `max_view_total_size` | Integer | `10_000_000` (10 MB) | Total view file size limit |
+| `max_view_file_size` | Integer | `1_000_000` (1 MB) | Single view file limit |
+
+### Search
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `max_search_results` | Integer | `200` | Maximum search results |
+| `max_validate_files` | Integer | `50` | Maximum files for validation |
+| `search_extensions` | Array | `["rb", "js", "erb", "yml", "yaml", "json", "ts", "tsx", "vue", "svelte", "haml", "slim"]` | File extensions to search |
+| `concern_paths` | Array | `["app/models/concerns", "app/controllers/concerns"]` | Paths to scan for concerns |
+| `frontend_paths` | Array | `nil` (auto-detect) | Override frontend file paths |
+
+### Database Query Safety
+
+| Option | Type | Default | Validation | Description |
+|:-------|:-----|:--------|:-----------|:------------|
+| `query_timeout` | Integer | `5` | — | SQL query timeout in seconds |
+| `query_row_limit` | Integer | `100` | 1–1000 | Maximum rows returned |
+| `query_redacted_columns` | Array | 10+ patterns | — | Column names/suffixes to redact |
+| `allow_query_in_production` | Boolean | `false` | — | Allow `rails_query` tool in production |
+
+### Logs
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `log_lines` | Integer | `50` | Default log lines to return |
+
+### Security
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `sensitive_patterns` | Array | 8 patterns | File patterns blocked from search/read (`.env*`, `*.key`, `*.pem`, `credentials.yml.enc`, etc.) |
+
+### Extensibility
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `custom_tools` | Array | `[]` | Additional MCP::Tool classes to register |
+| `skip_tools` | Array | `[]` | Built-in tool names to exclude (e.g., `%w[rails_security_scan]`) |
+
+### Output
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `output_dir` | String | Rails.root | Directory for generated context files |
+
+---
+
+## Presets
+
+### `:full` (default) — 31 introspectors
+
+All available introspectors. Best for comprehensive context.
+
+### `:standard` — 17 introspectors
+
+Lightweight subset for faster generation:
+
+`schema`, `models`, `routes`, `jobs`, `gems`, `conventions`, `controllers`, `tests`, `migrations`, `stimulus`, `view_templates`, `config`, `components`, `turbo`, `auth`, `performance`, `i18n`
+
+---
+
+## Generated files by AI tool
+
+| AI Tool | Root File | Split Rules | MCP Config |
+|:--------|:----------|:------------|:-----------|
+| Claude Code | `CLAUDE.md` | `.claude/rules/*.md` | `.mcp.json` |
+| Cursor | — | `.cursor/rules/*.mdc` | `.cursor/mcp.json` |
+| GitHub Copilot | `.github/copilot-instructions.md` | `.github/instructions/*.instructions.md` | `.vscode/mcp.json` |
+| OpenCode | `AGENTS.md` | `app/*/AGENTS.md` | `opencode.json` |
+| Codex CLI | (shares `AGENTS.md`) | (shares OpenCode rules) | `.codex/config.toml` |
+
+---
+
+## Examples
+
+### Minimal config
+
+```ruby
+RailsAiContext.configure do |config|
+  config.ai_tools = %i[claude]
+end
+```
+
+### Full config
+
+```ruby
+RailsAiContext.configure do |config|
+  # AI tools
+  config.ai_tools  = %i[claude cursor copilot opencode codex]
+  config.tool_mode = :mcp
+
+  # Introspection
+  config.preset       = :full
+  config.context_mode = :compact
+
+  # MCP Server
+  config.cache_ttl              = 120
+  config.max_tool_response_chars = 300_000
+  config.live_reload            = true
+  config.http_port              = 6029
+
+  # Hydration
+  config.hydration_enabled   = true
+  config.hydration_max_hints = 5
+
+  # Query safety
+  config.query_timeout  = 10
+  config.query_row_limit = 200
+  config.allow_query_in_production = false
+
+  # Extensibility
+  config.custom_tools = [MyCustomTool]
+  config.skip_tools   = %w[rails_security_scan]
+
+  # Filtering
+  config.excluded_models = %w[ApplicationRecord SolidQueue::Job]
+end
+```
+
+---
+
+<div align="center">
+
+**[← Custom Tools](CUSTOM_TOOLS.md)** · **[AI Tool Setup →](SETUP.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/CUSTOM_TOOLS.md
+++ b/docs/CUSTOM_TOOLS.md
@@ -1,0 +1,214 @@
+<div align="center">
+
+# Custom Tools
+
+**Build your own MCP tools that run alongside the 38 built-in ones.**
+
+[Tools Reference](TOOLS.md) · [Configuration](CONFIGURATION.md) · [Architecture](ARCHITECTURE.md) · [FAQ](FAQ.md)
+
+</div>
+
+---
+
+> [!NOTE]
+> Custom tools have full access to your Rails environment — ActiveRecord, services, mailers, everything. They appear alongside the 38 built-in tools in both MCP and CLI.
+
+## Creating a custom tool
+
+Custom tools are subclasses of `MCP::Tool` that you register in your configuration.
+
+```ruby
+# app/mcp_tools/rails_get_business_metrics.rb
+class RailsGetBusinessMetrics < MCP::Tool
+  tool_name "rails_get_business_metrics"
+  description "Returns key business metrics for the current environment"
+
+  input_schema(
+    properties: {
+      period: {
+        type: "string",
+        description: "Time period: day, week, month",
+        enum: %w[day week month]
+      }
+    }
+  )
+
+  def call(period: "week")
+    # Your logic here — full access to Rails models, services, etc.
+    stats = {
+      users: User.where("created_at > ?", period_start(period)).count,
+      orders: Order.where("created_at > ?", period_start(period)).count,
+      revenue: Order.where("created_at > ?", period_start(period)).sum(:total)
+    }
+
+    MCP::Tool::Response.new([
+      { type: "text", text: format_stats(stats) }
+    ])
+  end
+
+  private
+
+  def period_start(period)
+    case period
+    when "day" then 1.day.ago
+    when "week" then 1.week.ago
+    when "month" then 1.month.ago
+    end
+  end
+
+  def format_stats(stats)
+    <<~TEXT
+      ## Business Metrics
+      - New users: #{stats[:users]}
+      - New orders: #{stats[:orders]}
+      - Revenue: $#{stats[:revenue]}
+    TEXT
+  end
+end
+```
+
+## Registering custom tools
+
+Add your tool classes to the configuration:
+
+```ruby
+# config/initializers/rails_ai_context.rb
+if defined?(RailsAiContext)
+  RailsAiContext.configure do |config|
+    config.custom_tools = [RailsGetBusinessMetrics]
+  end
+end
+```
+
+Custom tools appear alongside built-in tools in the MCP server and CLI.
+
+## Using BaseTool features
+
+For access to caching, pagination, and helper methods, you can use `RailsAiContext::Tools::BaseTool` utilities directly:
+
+```ruby
+class RailsGetDeployStatus < MCP::Tool
+  tool_name "rails_get_deploy_status"
+  description "Returns current deployment status"
+
+  def call
+    # Use SafeFile for safe reading
+    version = RailsAiContext::SafeFile.read(Rails.root.join("REVISION"))
+    deployed_at = File.mtime(Rails.root.join("tmp/restart.txt")) rescue nil
+
+    MCP::Tool::Response.new([
+      { type: "text", text: "Version: #{version&.strip}\nDeployed: #{deployed_at}" }
+    ])
+  end
+end
+```
+
+## Naming conventions
+
+- Prefix tool names with `rails_` per MCP best practices
+- Use `rails_get_` for data retrieval tools
+- Use `rails_` without `get_` for action tools (e.g., `rails_validate`)
+
+## Testing custom tools
+
+Use the built-in `TestHelper` module:
+
+### With RSpec
+
+```ruby
+# spec/mcp_tools/rails_get_business_metrics_spec.rb
+require "rails_helper"
+require "rails_ai_context/test_helper"
+
+RSpec.describe RailsGetBusinessMetrics do
+  include RailsAiContext::TestHelper
+
+  it "is registered as an MCP tool" do
+    assert_tool_findable("rails_get_business_metrics")
+  end
+
+  it "returns metrics for the default period" do
+    response = execute_tool("rails_get_business_metrics")
+    assert_tool_response_includes(response, "Business Metrics")
+  end
+
+  it "accepts a period parameter" do
+    response = execute_tool("rails_get_business_metrics", period: "month")
+    assert_tool_response_includes(response, "Revenue")
+  end
+
+  it "does not expose sensitive data" do
+    response = execute_tool("rails_get_business_metrics")
+    assert_tool_response_excludes(response, "password")
+  end
+end
+```
+
+### With Minitest
+
+```ruby
+# test/mcp_tools/rails_get_business_metrics_test.rb
+require "test_helper"
+require "rails_ai_context/test_helper"
+
+class RailsGetBusinessMetricsTest < ActiveSupport::TestCase
+  include RailsAiContext::TestHelper
+
+  test "is registered as an MCP tool" do
+    assert_tool_findable("rails_get_business_metrics")
+  end
+
+  test "returns metrics" do
+    response = execute_tool("rails_get_business_metrics")
+    assert_tool_response_includes(response, "Business Metrics")
+  end
+end
+```
+
+## TestHelper API
+
+| Method | Description |
+|:-------|:------------|
+| `execute_tool(name_or_class, **args)` | Execute a tool by name, short name, or class. Returns `MCP::Tool::Response`. |
+| `execute_tool_with_error(name_or_class, **args)` | Execute a tool expecting an error response. |
+| `assert_tool_findable(name_or_class)` | Assert the tool is registered and discoverable. |
+| `assert_tool_response_includes(response, text)` | Assert response contains the given text. |
+| `assert_tool_response_excludes(response, text)` | Assert response does NOT contain the given text. |
+| `extract_response_text(response)` | Extract plain text from an `MCP::Tool::Response`. |
+
+**Name resolution** is fuzzy — all of these resolve to the same tool:
+
+```ruby
+execute_tool("rails_get_schema")
+execute_tool("get_schema")
+execute_tool("schema")
+execute_tool(RailsAiContext::Tools::GetSchema)
+```
+
+## Excluding built-in tools
+
+If a custom tool replaces a built-in one, exclude the original:
+
+```ruby
+RailsAiContext.configure do |config|
+  config.custom_tools = [MyBetterSecurityScan]
+  config.skip_tools   = %w[rails_security_scan]
+end
+```
+
+## Tips
+
+- Custom tools have access to the full Rails environment — ActiveRecord, services, mailers, etc.
+- Keep tools read-only when possible. MCP tools annotated as non-destructive build more trust with AI clients.
+- Return `MCP::Tool::Response` objects with `type: "text"` content blocks.
+- Tool responses are automatically truncated at `config.max_tool_response_chars` (default: 200,000).
+
+---
+
+<div align="center">
+
+**[← Recipes](RECIPES.md)** · **[Configuration →](CONFIGURATION.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,240 @@
+<div align="center">
+
+# FAQ
+
+**Frequently asked questions about rails-ai-context.**
+
+[Quickstart](QUICKSTART.md) · [Recipes](RECIPES.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Configuration](CONFIGURATION.md)
+
+</div>
+
+---
+
+## General
+
+### What does this gem do?
+
+It gives AI coding assistants verified, real-time access to your Rails app's structure — schema, models, routes, controllers, views, conventions, and more. Instead of guessing from training data, AI queries your actual app.
+
+### Which AI tools are supported?
+
+Claude Code, Cursor, GitHub Copilot, OpenCode, and Codex CLI. Each gets tailored context files and MCP auto-discovery config.
+
+### Do I need MCP support in my AI tool?
+
+No. The gem works three ways:
+1. **MCP server** — AI calls tools via the protocol (best experience)
+2. **Static files** — Generated context files (CLAUDE.md, .cursor/rules/, etc.)
+3. **CLI** — Same 38 tools from the terminal, no server needed
+
+### Is this safe for production?
+
+The gem is designed for development environments. All tools are read-only. The query tool is disabled in production by default. Sensitive files (.env, *.key, credentials) are blocked.
+
+### Does it work without a database?
+
+Yes. The gem gracefully degrades — it parses `db/schema.rb` as text when no database connection is available.
+
+---
+
+## Installation
+
+### Gemfile or standalone — which should I use?
+
+**In-Gemfile** is recommended if you own the project. Gives you the install generator, rake tasks, and initializer config.
+
+**Standalone** is for when you can't modify the Gemfile (client projects, quick exploration, CI).
+
+### Can I switch between Gemfile and standalone?
+
+Yes, freely. Both generate identical context files and provide the same 38 tools. Just re-run the install/init to update MCP config files.
+
+### Do I need to commit the generated files?
+
+**Yes, commit these:**
+- `.mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json`, `opencode.json`, `.codex/config.toml` — so teammates get MCP auto-discovery
+- `CLAUDE.md`, `.cursor/rules/`, `.github/instructions/`, `AGENTS.md` — so AI has context
+- `config/initializers/rails_ai_context.rb`, `.rails-ai-context.yml` — so config is shared
+
+**Don't commit:**
+- `.ai-context.json` — auto-added to .gitignore by the install generator
+
+---
+
+## MCP & Tools
+
+### How do I know which tool to use?
+
+Start with `rails_onboard` for an app overview, `rails_analyze_feature` for feature work, and `rails_search_code` with `match_type: "trace"` for code investigation. Your AI will learn to pick the right tools.
+
+### Can I add my own tools?
+
+Yes. See [Custom Tools](CUSTOM_TOOLS.md). Create an `MCP::Tool` subclass, register it via `config.custom_tools`, and it appears alongside the 38 built-in tools.
+
+### Can I remove built-in tools?
+
+Yes. Use `config.skip_tools`:
+
+```ruby
+config.skip_tools = %w[rails_security_scan rails_query]
+```
+
+### What's the `detail` parameter?
+
+Most tools accept `detail`: `summary` (compact), `standard` (default), `full` (everything). Start with summary and drill down as needed. This keeps AI context windows lean.
+
+### What are `[VERIFIED]` and `[INFERRED]` tags?
+
+Confidence tags from Prism AST parsing:
+- **`[VERIFIED]`** — all arguments are static literals. This is ground truth.
+- **`[INFERRED]`** — arguments contain dynamic expressions. Needs runtime verification.
+
+### Does the query tool support all databases?
+
+PostgreSQL, MySQL, and SQLite. Each gets database-specific safety mechanisms (read-only transactions, timeouts). See [Security](SECURITY.md).
+
+---
+
+## Configuration
+
+### What's the difference between `:full` and `:standard` preset?
+
+- **`:full`** (default) — 31 introspectors. Comprehensive context for every aspect of your app.
+- **`:standard`** — 17 introspectors. Faster, covers the essentials (schema, models, routes, controllers, tests, etc.).
+
+### What's `:compact` vs `:full` context mode?
+
+- **`:compact`** (default) — context files capped at ~150 lines. Optimized for AI context windows.
+- **`:full`** — no line cap. All introspection data included.
+
+### Can I use YAML config with the Gemfile approach?
+
+Yes, but the initializer takes priority. If `config/initializers/rails_ai_context.rb` exists and runs, `.rails-ai-context.yml` is skipped.
+
+### What's `generate_root_files`?
+
+When `true` (default), generates root files like CLAUDE.md, AGENTS.md. Set to `false` to only generate split rules (.claude/rules/, .cursor/rules/, etc.).
+
+---
+
+## Context Files
+
+### What files get generated?
+
+Depends on your `ai_tools` config. For all tools:
+
+| AI Tool | Files |
+|:--------|:------|
+| Claude | CLAUDE.md, .claude/rules/*.md |
+| Cursor | .cursor/rules/*.mdc |
+| Copilot | .github/copilot-instructions.md, .github/instructions/*.instructions.md |
+| OpenCode | AGENTS.md, app/*/AGENTS.md |
+| Codex | Shares AGENTS.md and OpenCode rules |
+
+### How do I regenerate context files?
+
+```bash
+rails ai:context          # All formats
+rails ai:context:claude   # Claude only
+```
+
+### Do context files update automatically?
+
+Only if you run watch mode:
+
+```bash
+rails ai:watch
+```
+
+Otherwise, regenerate manually after significant changes.
+
+### Can I add my own content to CLAUDE.md?
+
+Yes. Add content outside the `<!-- BEGIN/END rails-ai-context -->` markers. The gem preserves content outside these markers during regeneration.
+
+---
+
+## Performance
+
+### Is introspection slow?
+
+Introspection results are cached with TTL (default: 60s) and fingerprint invalidation. The first call is slower; subsequent calls use cache. Prism AST parsing uses a single-pass Dispatcher — all 7 listeners run in one tree walk.
+
+### Does this affect my app's performance?
+
+No. The gem only runs in development. Tools execute on demand (not continuously). The MCP server is a separate process (stdio) or a development-only endpoint (HTTP).
+
+### How does live reload work?
+
+The `listen` gem watches `app/`, `config/`, `db/`, `lib/tasks/`. When files change, caches are invalidated and MCP clients are notified. Debounce interval: 1.5s (configurable).
+
+---
+
+## Security
+
+### Can tools modify my database?
+
+No. The query tool uses `SET TRANSACTION READ ONLY` + rollback. Even if SQL validation were bypassed, the database layer prevents writes.
+
+### Can tools read my .env or credentials?
+
+No. Sensitive files (`.env*`, `*.key`, `*.pem`, `credentials.yml.enc`) are blocked by default. The pattern list is configurable.
+
+### Is the Anti-Hallucination Protocol necessary?
+
+It's enabled by default and targets real AI failure modes. If you prefer your own prompting rules, disable it:
+
+```ruby
+config.anti_hallucination_rules = false
+```
+
+---
+
+## How does this compare to...
+
+### ...a hand-written CLAUDE.md?
+
+A manual CLAUDE.md goes stale the moment someone adds a column or changes a route. rails-ai-context reads your app live — schema, models, routes, controllers are always current. You can still add your own rules alongside the generated content. See [Recipes: Migrating](RECIPES.md#migrating-from-manual-ai-context).
+
+### ...cursor-rules repos / awesome-cursorrules?
+
+Community cursor rules are generic Rails patterns. rails-ai-context generates rules from *your* app — your actual schema, your associations, your conventions. Generic rules say "Rails uses `before_action`"; this gem tells AI which specific filters your `ApplicationController` applies.
+
+### ...pasting schema.rb into the prompt?
+
+Pasting works once, then goes stale. It also burns context window on tables AI doesn't need. The `get_schema` tool returns only the requested table, on demand, always current.
+
+### ...Copilot Workspace / Cursor Composer / Windsurf?
+
+Those are AI coding interfaces. This gem is a data layer that makes *any* of them better. It provides the ground truth they're missing. Works with Claude Code, Cursor, Copilot, OpenCode, and Codex simultaneously.
+
+---
+
+## Troubleshooting
+
+### My AI tool doesn't see the MCP server
+
+Run `rails ai:doctor` — it checks MCP config files for all configured tools. See [Troubleshooting](TROUBLESHOOTING.md) for detailed steps.
+
+### Tools return empty results
+
+Check that your Rails app boots (`rails runner "puts 'ok'"`) and that schema/models exist. Run `rails ai:doctor`.
+
+### Context files are too large
+
+Use compact mode (default) or disable root files:
+
+```ruby
+config.context_mode = :compact
+config.generate_root_files = false
+```
+
+---
+
+<div align="center">
+
+**[← Troubleshooting](TROUBLESHOOTING.md)** · **[Full Guide →](GUIDE.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,13 +1,35 @@
+<div align="center">
+
 # rails-ai-context — Complete Guide
 
-> Full documentation for [rails-ai-context](https://github.com/crisnahine/rails-ai-context).
-> For a quick overview, see the [README](../README.md).
->
-> **Why this gem exists:** AI coding assistants guess your Rails app. They invent columns,
-> use wrong association names, miss inherited filters, and scaffold tests that don't match
-> your patterns. This gem turns your running app into the source of truth — so agents query
-> real schema, real associations, and real conventions on demand, and write correct code
-> on the first try.
+**The all-in-one reference. Everything in one file.**
+
+[Quickstart](QUICKSTART.md) · [Tools](TOOLS.md) · [Recipes](RECIPES.md) · [FAQ](FAQ.md)
+
+</div>
+
+---
+
+> [!NOTE]
+> This is the comprehensive single-file reference. For focused guides, see the docs below. For a quick overview, see the [README](../README.md).
+
+## Focused guides
+
+| Guide | Description |
+|:------|:------------|
+| [Quickstart](QUICKSTART.md) | Get running in 5 minutes |
+| [Tools Reference](TOOLS.md) | All 38 MCP tools with parameters |
+| [Recipes](RECIPES.md) | Real-world workflows and examples |
+| [Custom Tools](CUSTOM_TOOLS.md) | Build your own MCP tools |
+| [Configuration](CONFIGURATION.md) | Every config option |
+| [AI Tool Setup](SETUP.md) | Per-editor setup |
+| [Architecture](ARCHITECTURE.md) | System design and internals |
+| [Introspectors](INTROSPECTORS.md) | All 31 introspectors |
+| [Security](SECURITY.md) | Security model and SQL safety |
+| [CLI Reference](CLI.md) | All commands and argument syntax |
+| [Standalone Mode](STANDALONE.md) | Use without Gemfile |
+| [Troubleshooting](TROUBLESHOOTING.md) | Common issues and fixes |
+| [FAQ](FAQ.md) | Frequently asked questions |
 
 ---
 

--- a/docs/INTROSPECTORS.md
+++ b/docs/INTROSPECTORS.md
@@ -1,0 +1,211 @@
+<div align="center">
+
+# Introspectors
+
+**31 modules that extract structured data from your Rails application.**
+
+[Architecture](ARCHITECTURE.md) · [Configuration](CONFIGURATION.md) · [Tools Reference](TOOLS.md) · [Security](SECURITY.md)
+
+</div>
+
+---
+
+## How introspectors work
+
+Each introspector:
+
+1. Examines a specific aspect of your Rails app (schema, models, routes, etc.)
+2. Returns a Hash with structured data (never raises — wraps errors in `{ error: msg }`)
+3. Results are cached with TTL + SHA256 fingerprint invalidation
+4. Runs as part of a preset (`:standard` or `:full`) or can be configured individually
+
+## Presets
+
+### `:full` (default) — all 31 introspectors
+
+Best for comprehensive AI context. Covers every aspect of your app.
+
+### `:standard` — 17 introspectors
+
+Lightweight subset for faster generation:
+
+```
+schema, models, routes, jobs, gems, conventions, controllers,
+tests, migrations, stimulus, view_templates, config, components,
+turbo, auth, performance, i18n
+```
+
+### Preset comparison
+
+```mermaid
+graph LR
+    subgraph standard["Standard Preset — 17 introspectors"]
+        direction TB
+        S1["schema"] ~~~ S2["models"] ~~~ S3["routes"]
+        S4["controllers"] ~~~ S5["jobs"] ~~~ S6["gems"]
+        S7["conventions"] ~~~ S8["tests"] ~~~ S9["migrations"]
+        S10["stimulus"] ~~~ S11["view_templates"] ~~~ S12["config"]
+        S13["components"] ~~~ S14["turbo"] ~~~ S15["auth"]
+        S16["performance"] ~~~ S17["i18n"]
+    end
+
+    subgraph full_only["Full Preset adds +14"]
+        direction TB
+        F1["views"] ~~~ F2["database_stats"] ~~~ F3["api"]
+        F4["active_storage"] ~~~ F5["action_text"] ~~~ F6["action_mailbox"]
+        F7["rake_tasks"] ~~~ F8["assets"] ~~~ F9["devops"]
+        F10["seeds"] ~~~ F11["middleware"] ~~~ F12["engines"]
+        F13["multi_database"] ~~~ F14["frontend_frameworks"]
+    end
+
+    standard --> full_only
+
+    style standard fill:#3498db,stroke:#2980b9,color:#fff
+    style full_only fill:#9b59b6,stroke:#8e44ad,color:#fff
+```
+
+### Custom list
+
+```ruby
+RailsAiContext.configure do |config|
+  config.introspectors = %i[schema models routes controllers views]
+end
+```
+
+---
+
+## All 31 introspectors
+
+### Core
+
+| Introspector | Key | What it extracts |
+|:-------------|:----|:-----------------|
+| SchemaIntrospector | `:schema` | Database tables, columns, types, indexes, defaults, encrypted hints |
+| ModelIntrospector | `:models` | Associations, validations, scopes, enums, concerns (AST-based) |
+| RouteIntrospector | `:routes` | Routes with helpers, HTTP methods, constraints |
+| ControllerIntrospector | `:controllers` | Actions, filters, strong params, render paths |
+| ViewIntrospector | `:views` | View files, layouts, partials |
+| ViewTemplateIntrospector | `:view_templates` | Template content with ivars, Turbo frames, Stimulus refs |
+
+### Models & Data
+
+| Introspector | Key | What it extracts |
+|:-------------|:----|:-----------------|
+| SourceIntrospector | `:source` | Prism AST: associations, validations, scopes, enums, callbacks, macros, methods |
+| MigrationIntrospector | `:migrations` | Migration files, versions, reversibility |
+| SeedsIntrospector | `:seeds` | Seed file analysis |
+| DatabaseStatsIntrospector | `:database_stats` | Table sizes, row counts, index stats |
+| MultiDatabaseIntrospector | `:multi_database` | Multi-database configuration |
+
+### Frontend
+
+| Introspector | Key | What it extracts |
+|:-------------|:----|:-----------------|
+| StimulusIntrospector | `:stimulus` | Controllers, targets, values, actions |
+| TurboIntrospector | `:turbo` | Turbo Frames, Streams, broadcasts |
+| AssetPipelineIntrospector | `:assets` | Asset pipeline configuration, manifests |
+| FrontendFrameworkIntrospector | `:frontend_frameworks` | React/Vue/Svelte/Angular detection |
+| ComponentIntrospector | `:components` | ViewComponent/Phlex: props, slots, previews |
+
+### Config & Infrastructure
+
+| Introspector | Key | What it extracts |
+|:-------------|:----|:-----------------|
+| ConfigIntrospector | `:config` | Database, cache, queue, Action Cable config |
+| GemIntrospector | `:gems` | Notable gems with versions and categories |
+| ConventionIntrospector | `:conventions` | Auth patterns, flash messages, test patterns |
+| I18nIntrospector | `:i18n` | Locale files, translation keys |
+| MiddlewareIntrospector | `:middleware` | Rack middleware stack |
+| EngineIntrospector | `:engines` | Mounted engines |
+| DevopsIntrospector | `:devops` | Dockerfile, CI config, deployment |
+
+### Jobs & Services
+
+| Introspector | Key | What it extracts |
+|:-------------|:----|:-----------------|
+| JobIntrospector | `:jobs` | Background jobs: queue, retries, schedules |
+| RakeTaskIntrospector | `:rake_tasks` | Custom rake tasks |
+
+### Security & Auth
+
+| Introspector | Key | What it extracts |
+|:-------------|:----|:-----------------|
+| AuthIntrospector | `:auth` | Authentication framework (Devise, etc.) |
+| ApiIntrospector | `:api` | API configuration, versioning, serializers |
+
+### Rails Features
+
+| Introspector | Key | What it extracts |
+|:-------------|:----|:-----------------|
+| ActiveStorageIntrospector | `:active_storage` | Attachments, variants, services |
+| ActionTextIntrospector | `:action_text` | Rich text attributes |
+| ActionMailboxIntrospector | `:action_mailbox` | Mailbox routing rules |
+
+### Analysis
+
+| Introspector | Key | What it extracts |
+|:-------------|:----|:-----------------|
+| TestIntrospector | `:tests` | Test framework, file counts, coverage hints |
+| PerformanceIntrospector | `:performance` | N+1 risks, missing indexes, counter_cache hints |
+
+---
+
+## AST-based introspection
+
+The **SourceIntrospector** uses Prism AST parsing for model analysis. It runs a single-pass Dispatcher that walks the AST once and feeds events to 7 listeners simultaneously:
+
+### 7 Prism listeners
+
+| Listener | What it detects |
+|:---------|:---------------|
+| AssociationsListener | `belongs_to`, `has_many`, `has_one`, `has_and_belongs_to_many` |
+| ValidationsListener | `validates`, `validates_*_of`, custom `validate :method` |
+| ScopesListener | `scope :name, -> { ... }` |
+| EnumsListener | Rails 7+ and legacy enum syntax, prefix/suffix options |
+| CallbacksListener | All AR callback types, `after_commit` with `on:` resolution |
+| MacrosListener | `encrypts`, `normalizes`, `delegate`, `has_secure_password`, `serialize`, `store`, `has_one_attached`, `has_many_attached`, `has_rich_text`, `generates_token_for`, `attribute` |
+| MethodsListener | `def`/`def self.`, visibility tracking, parameter extraction, `class << self` |
+
+### Confidence tagging
+
+Every AST result carries a confidence tag:
+
+- **`[VERIFIED]`** — All arguments are static literals (strings, symbols, numbers). Ground truth.
+- **`[INFERRED]`** — Arguments contain dynamic expressions (variables, method calls). Requires runtime verification.
+
+```
+has_many :posts                    → [VERIFIED]
+has_many :posts, class_name: name  → [INFERRED]  (name is a variable)
+```
+
+### AstCache
+
+Thread-safe parse cache using `Concurrent::Map`:
+
+- Keyed by: file path + SHA256 content hash + mtime
+- Invalidates automatically when file changes
+- Shared by all AST-based introspectors
+- Cleared on `reset_all_caches!` (triggered by live reload)
+
+---
+
+## Cache invalidation
+
+Introspection results are cached at two levels:
+
+1. **Introspection cache** — Full context hash, invalidated by TTL (`config.cache_ttl`, default: 60s) and fingerprint change
+2. **AST cache** — Per-file parse results, invalidated by file content change (SHA256)
+
+The **Fingerprinter** computes a composite SHA256 from all watched directories (`app/`, `config/`, `db/`, `lib/tasks/`, `Gemfile.lock`). When the fingerprint changes, the introspection cache is invalidated even if TTL hasn't expired.
+
+**Live Reload** watches these directories and calls `reset_all_caches!` when changes are detected, then notifies connected MCP clients via `notify_resources_list_changed`.
+
+---
+
+<div align="center">
+
+**[← Architecture](ARCHITECTURE.md)** · **[Security →](SECURITY.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,118 @@
+<div align="center">
+
+# Quickstart
+
+**Get AI context for your Rails app in under 5 minutes.**
+
+[Tools Reference](TOOLS.md) · [Recipes](RECIPES.md) · [Configuration](CONFIGURATION.md) · [FAQ](FAQ.md)
+
+</div>
+
+---
+
+## Option A: In your Gemfile (recommended)
+
+```bash
+# 1. Add the gem
+bundle add rails-ai-context --group development
+
+# 2. Run the install generator
+rails generate rails_ai_context:install
+```
+
+The generator asks two questions:
+
+1. **Which AI tools do you use?** — Claude Code, Cursor, GitHub Copilot, OpenCode, Codex CLI, or all
+2. **Do you want MCP server support?** — Yes (MCP mode) or No (CLI-only mode)
+
+That's it. Your AI tool now has live access to your schema, models, routes, controllers, views, and conventions.
+
+> [!TIP]
+> The generator is idempotent — re-running it preserves existing config and only adds new sections.
+
+## Option B: Standalone (no Gemfile entry)
+
+```bash
+# 1. Install the gem globally
+gem install rails-ai-context
+
+# 2. Navigate to your Rails app
+cd your-rails-app
+
+# 3. Run interactive setup
+rails-ai-context init
+
+# 4. Start the MCP server
+rails-ai-context serve
+```
+
+Works with every Ruby version manager (rbenv, rvm, asdf, mise, chruby, system). [Learn more about standalone mode →](STANDALONE.md)
+
+## What just happened?
+
+The install generator created:
+
+| File | Purpose |
+|:-----|:--------|
+| `.mcp.json` / `.cursor/mcp.json` / `.vscode/mcp.json` / `opencode.json` / `.codex/config.toml` | MCP auto-discovery — your AI tool detects these on project open |
+| `CLAUDE.md` / `.cursor/rules/` / `.github/instructions/` | Static context rules your AI reads |
+| `config/initializers/rails_ai_context.rb` | All configuration options |
+| `.rails-ai-context.yml` | Config for standalone mode |
+
+## Verify it works
+
+```bash
+# Check AI readiness (23 diagnostic checks)
+rails ai:doctor          # In-Gemfile
+rails-ai-context doctor  # Standalone
+
+# Try a tool
+rails 'ai:tool[schema]' table=users
+rails 'ai:tool[model_details]' model=User
+rails 'ai:tool[routes]' controller=users
+```
+
+## See it work
+
+> [!IMPORTANT]
+> These are CLI commands. When MCP is connected, your AI calls the same tools automatically — you never type these manually.
+
+Three commands that show immediate value:
+
+```bash
+# 1. Trace a method across your entire codebase — one call
+rails 'ai:tool[search_code]' pattern="your_method_name" match_type=trace
+
+# 2. Full-stack feature analysis — models + controllers + routes + tests
+rails 'ai:tool[analyze_feature]' feature=auth
+
+# 3. Get your app's actual conventions — not generic Rails patterns
+rails 'ai:tool[conventions]'
+```
+
+## What to do next
+
+1. **Open your project** in your AI tool — MCP auto-discovery kicks in
+2. **Ask your AI** to describe your User model — it will call `rails_get_model_details` instead of guessing
+3. **Read [Recipes](RECIPES.md)** for real-world workflows that show the tools in action
+
+## Quick reference
+
+| In-Gemfile | Standalone | What it does |
+|:-----------|:-----------|:------------|
+| `rails ai:serve` | `rails-ai-context serve` | Start MCP server |
+| `rails 'ai:tool[NAME]'` | `rails-ai-context tool NAME` | Run any tool |
+| `rails ai:tool` | `rails-ai-context tool --list` | List all tools |
+| `rails ai:doctor` | `rails-ai-context doctor` | Diagnostics |
+| `rails ai:watch` | `rails-ai-context watch` | Auto-regenerate on change |
+| `rails ai:context` | `rails-ai-context context` | Regenerate context files |
+
+---
+
+<div align="center">
+
+**Next:** [Tools Reference →](TOOLS.md)
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -1,0 +1,390 @@
+<div align="center">
+
+# Recipes
+
+**Real-world workflows that show how AI + ground truth changes everything.**
+
+[Quickstart](QUICKSTART.md) · [Tools Reference](TOOLS.md) · [Custom Tools](CUSTOM_TOOLS.md) · [FAQ](FAQ.md)
+
+</div>
+
+---
+
+## Table of Contents
+
+- [Adding a column](#adding-a-column-to-an-existing-table)
+- [Fixing a controller action](#fixing-a-broken-controller-action)
+- [Building a new feature](#building-a-new-feature-from-scratch)
+- [Tracing a method](#tracing-a-method-across-the-codebase)
+- [Understanding someone else's code](#understanding-someone-elses-code)
+- [Writing tests](#writing-tests-that-match-your-patterns)
+- [Debugging views](#debugging-a-view-rendering-issue)
+- [Reviewing a PR](#reviewing-a-pr)
+- [Safe database queries](#safe-database-queries)
+- [Working with concerns](#working-with-concerns)
+- [Checking components](#checking-component-patterns)
+- [Diagnosing production](#diagnosing-production-issues)
+- [Session context](#session-context-across-multiple-questions)
+- [Migrating from manual context](#migrating-from-manual-ai-context)
+- [Tips](#tips)
+
+---
+
+## Adding a column to an existing table
+
+> [!TIP]
+> This is the #1 place AI goes wrong. Without schema access, it guesses column names and types.
+
+**Ask your AI:** "Add a `subscription_tier` column to the users table"
+
+**What happens:**
+
+```
+→ rails_get_schema(table: "users")
+```
+
+<details>
+<summary>Example output</summary>
+
+```
+## Table: users
+
+| Column | Type | Null | Default |
+|--------|------|------|---------|
+| id | integer | NO | |
+| email | string | NO | [unique] |
+| subscription_status | string | yes | "free" |
+| created_at | datetime | NO | |
+
+### Indexes
+- index_users_on_email (unique)
+```
+
+</details>
+
+AI sees `subscription_status` already exists — asks before proceeding instead of creating a duplicate column.
+
+```
+→ rails_get_model_details(model: "User")
+→ rails_migration_advisor(action: "add_column", table: "users", columns: "subscription_tier:string")
+```
+
+**Without ground truth:** AI writes a migration blindly, possibly duplicating a column or missing an index.
+
+---
+
+## Fixing a broken controller action
+
+**Ask your AI:** "The create action in CooksController is failing"
+
+```bash
+rails_get_controllers(controller: "CooksController", action: "create")
+# → Source code + inherited before_action filters + strong params + render paths
+
+rails_get_routes(controller: "cooks")
+# → Code-ready helpers: cook_path(@record), new_cook_path
+
+rails_get_schema(table: "cooks")
+# → Actual column names, types, constraints
+
+rails_diagnose(error: "ActiveRecord::RecordInvalid", file: "app/controllers/cooks_controller.rb")
+# → Classification + context + git blame + log correlation
+```
+
+AI sees the full picture: the parent controller's `authenticate_user!` filter, the actual strong params whitelist, and the real column names. No guessing.
+
+---
+
+## Building a new feature from scratch
+
+**Ask your AI:** "Build a notifications system"
+
+```
+→ rails_analyze_feature(feature: "notifications")
+```
+
+<details>
+<summary>Example output</summary>
+
+```
+# Feature Analysis: notifications
+
+## Models (1)
+### Notification
+Table: notifications
+Columns: user_id:bigint, title:string, read_at:datetime
+Associations: belongs_to :user
+
+## Controllers (1)
+### NotificationsController
+Actions: index, mark_read
+Filters: before_action authenticate_user!
+
+## Jobs (1)
+### NotificationBroadcastJob
+Queue: default | Retries: 3
+
+## Routes (2)
+GET  /notifications     → notifications#index
+POST /notifications/:id → notifications#mark_read
+```
+
+</details>
+
+AI sees what already exists before building anything. Then:
+
+```
+→ rails_get_conventions()   # Your app's patterns, not generic Rails
+→ rails_get_gems()          # Sees ActionMailer, Sidekiq, etc.
+→ rails_get_schema()        # Picks the right foreign keys and types
+```
+
+AI scaffolds the feature matching your app's actual patterns — not generic Rails conventions from training data.
+
+---
+
+## Tracing a method across the codebase
+
+> [!TIP]
+> `search_code` with `match_type: "trace"` is the single most powerful tool. Use it first when investigating anything.
+
+**Ask your AI:** "Where is `can_cook?` used?"
+
+```
+→ rails_search_code(pattern: "can_cook?", match_type: "trace")
+```
+
+<details open>
+<summary>Example output</summary>
+
+```
+# Trace: can_cook?
+
+## Definition
+app/models/user.rb:45 in User
+  def can_cook?
+    role.in?(%w[chef sous_chef]) && active?
+  end
+
+## Called from (4 sites)
+
+**Controllers** (2)
+  app/controllers/cooks_controller.rb:12  before_action :ensure_can_cook
+  app/controllers/recipes_controller.rb:8  if current_user.can_cook?
+
+**Views** (1)
+  app/views/cooks/show.html.erb:8  <% if @user.can_cook? %>
+
+**Tests** (1)
+  spec/models/user_spec.rb:92  expect(chef.can_cook?).to be true
+```
+
+</details>
+
+One call. Definition + source + every caller grouped by type + tests. **Replaces 4-5 sequential file reads.**
+
+---
+
+## Understanding someone else's code
+
+**Ask your AI:** "Walk me through this app"
+
+```bash
+rails_onboard(detail: "full")
+# → Narrative walkthrough: stack, models, key patterns, conventions, deployment
+
+rails_dependency_graph(format: "mermaid")
+# → Visual model relationship graph
+
+rails_get_gems(detail: "full")
+# → Every notable gem with version, category, and config location
+```
+
+---
+
+## Writing tests that match your patterns
+
+**Ask your AI:** "Write tests for the Order model"
+
+```bash
+rails_get_test_info(model: "Order")
+# → Existing test files, fixtures, factory definitions
+
+rails_get_model_details(model: "Order")
+# → Associations, validations, scopes, callbacks to test
+
+rails_generate_test(file: "app/models/order.rb")
+# → Test scaffolding using YOUR framework (RSpec/Minitest) and YOUR patterns (fixtures/factories)
+```
+
+AI generates tests that actually run, using your test helper setup, your factory definitions, your assertion style.
+
+---
+
+## Debugging a view rendering issue
+
+**Ask your AI:** "The dashboard view is broken"
+
+```bash
+rails_get_view(controller: "dashboard", action: "index")
+# → Template source with ivars, Turbo frames, Stimulus controllers, partial locals
+
+rails_get_partial_interface(partial: "dashboard/stats_card")
+# → Required locals and methods called on them
+
+rails_get_stimulus(controller: "chart")
+# → Correct data-attributes with dashes (not underscores)
+```
+
+---
+
+## Reviewing a PR
+
+**Ask your AI:** "Review the changes in this branch"
+
+```bash
+rails_review_changes(ref: "HEAD~3..HEAD")
+# → Per-file context + structural warnings
+
+rails_validate(files: "app/controllers/users_controller.rb,app/models/user.rb", level: "security")
+# → Syntax + semantic + Brakeman scan
+
+rails_performance_check()
+# → N+1 risks, missing indexes on changed models
+```
+
+---
+
+## Safe database queries
+
+**Ask your AI:** "How many users signed up this month?"
+
+```bash
+rails_query(sql: "SELECT COUNT(*) FROM users WHERE created_at > '2026-04-01'")
+# → Runs with: regex pre-filter, SET TRANSACTION READ ONLY, 5s timeout, row limit, column redaction
+# → Password columns automatically redacted
+```
+
+**Ask your AI:** "Explain why this query is slow"
+
+```bash
+rails_query(sql: "SELECT * FROM orders JOIN users ON ...", explain: true)
+# → Query plan with index usage, full table scan warnings
+```
+
+---
+
+## Working with concerns
+
+**Ask your AI:** "What does the Searchable concern do?"
+
+```bash
+rails_get_concern(concern: "Searchable")
+# → Methods (including class_methods block), source code, which models include it
+
+rails_search_code(pattern: "include Searchable", match_type: "any")
+# → Every file that includes this concern
+```
+
+---
+
+## Checking component patterns
+
+**Ask your AI:** "What components do we have?"
+
+```bash
+rails_get_component_catalog(detail: "standard")
+# → ViewComponent/Phlex: props, slots, previews, sidecar assets, usage examples
+
+rails_get_frontend_stack()
+# → React/Vue/Svelte, Hotwire, TypeScript, Vite/Webpacker
+```
+
+---
+
+## Diagnosing production issues
+
+**Ask your AI:** "Check the app health"
+
+```bash
+rails_runtime_info(detail: "full")
+# → DB pool stats, table sizes, pending migrations, cache stats, queue depth
+
+rails_read_logs(level: "error", lines: 100)
+# → Recent errors with sensitive data redacted
+
+rails_security_scan()
+# → Brakeman: SQL injection, XSS, mass assignment vulnerabilities
+```
+
+---
+
+## Session context across multiple questions
+
+When AI makes multiple tool calls in a conversation, `rails_session_context` tracks what's been queried:
+
+```bash
+# First question: "Tell me about users"
+rails_get_schema(table: "users")
+rails_get_model_details(model: "User")
+
+# Follow-up: "What context do I have so far?"
+rails_session_context()
+# → Lists all prior tool calls with params and summaries
+```
+
+This prevents redundant queries and helps AI maintain conversation context.
+
+---
+
+## Migrating from manual AI context
+
+If you've been maintaining a hand-written CLAUDE.md, `.cursorrules`, or similar:
+
+**Step 1: Install**
+
+```bash
+rails generate rails_ai_context:install
+```
+
+**Step 2: Move your custom content**
+
+The gem wraps its generated content in section markers:
+
+```markdown
+<!-- BEGIN rails-ai-context -->
+... generated content ...
+<!-- END rails-ai-context -->
+```
+
+Add your custom rules **outside** these markers — they're preserved on regeneration.
+
+**Step 3: Remove manual maintenance**
+
+You no longer need to manually update:
+- Schema documentation (the tool reads it live)
+- Model association lists (Prism AST parses them)
+- Route documentation (introspected from `routes.rb`)
+- Controller filter lists (read from the inheritance chain)
+
+Your custom rules (coding style, PR conventions, team preferences) stay. The gem handles the facts.
+
+---
+
+## Tips
+
+1. **Start with `detail:"summary"`** — get the lay of the land before drilling down
+2. **Use `analyze_feature` first** — it's the best starting point for any feature work
+3. **`search_code` with `match_type:"trace"`** — the single most powerful tool for understanding code flow
+4. **Don't read files directly** — let tools give you the structured, verified data
+5. **Re-query after edits** — earlier tool output may be stale after you make changes
+
+---
+
+<div align="center">
+
+**[← Tools Reference](TOOLS.md)** · **[Custom Tools →](CUSTOM_TOOLS.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,238 @@
+<div align="center">
+
+# Security Model
+
+**Read-only by design. Defense in depth. Every tool is non-destructive.**
+
+[Architecture](ARCHITECTURE.md) · [Configuration](CONFIGURATION.md) · [Tools Reference](TOOLS.md) · [FAQ](FAQ.md)
+
+</div>
+
+---
+
+> [!CAUTION]
+> This gem is designed for **development environments**. The query tool is disabled in production by default. Sensitive files are blocked. All 38 tools are read-only.
+
+## Design principles
+
+1. **Read-only by design** — All 38 tools are annotated as non-destructive in the MCP protocol
+2. **Defense in depth** — Multiple security layers, not single points of failure
+3. **Sensitive data blocking** — Configurable patterns prevent access to secrets
+4. **Offline by default** — No network calls except optional `rails_search_docs` with `fetch: true`
+5. **Graceful degradation** — Missing optional dependencies don't expose errors or state
+
+---
+
+## SQL query safety (4 layers)
+
+The `rails_query` tool uses a 4-layer security model:
+
+```mermaid
+flowchart LR
+    Q[SQL Query] --> L1{Layer 1\nRegex Validation}
+    L1 -->|"Blocked:\nINSERT, DROP,\nUNION SELECT..."| R1[Rejected]
+    L1 -->|SELECT only| L2{Layer 2\nDatabase Read-Only}
+    L2 -->|"SET TRANSACTION\nREAD ONLY\n+ timeout"| L3{Layer 3\nRow Limit}
+    L3 -->|"Cap: 1000 rows\nDefault: 100"| L4{Layer 4\nColumn Redaction}
+    L4 -->|"password_digest\napi_key → [REDACTED]"| OK[Safe Result]
+
+    style R1 fill:#e74c3c,stroke:#c0392b,color:#fff
+    style OK fill:#27ae60,stroke:#1e8449,color:#fff
+    style L1 fill:#e67e22,stroke:#d35400,color:#fff
+    style L2 fill:#f39c12,stroke:#e67e22,color:#fff
+    style L3 fill:#3498db,stroke:#2980b9,color:#fff
+    style L4 fill:#9b59b6,stroke:#8e44ad,color:#fff
+```
+
+### Layer 1 — SQL validation (regex-based)
+
+Before any query reaches the database:
+
+- Strips comments: block (`/* */`), line (`--`), MySQL (`#` at line start)
+- **Blocks write keywords**: INSERT, UPDATE, DELETE, DROP, ALTER, TRUNCATE, CREATE, GRANT, REVOKE, SET, COPY, MERGE, REPLACE
+- **Blocks lock clauses**: FOR UPDATE, FOR SHARE, FOR NO KEY UPDATE
+- **Blocks dangerous SHOW**: GRANTS, PROCESSLIST, BINLOG, SLAVE, MASTER, REPLICAS
+- **Blocks SELECT INTO**: prevents table creation via SELECT
+- **Blocks multi-statements**: multiple semicolons
+- **Blocks injection patterns**: OR 1=1, OR true, OR ''='', UNION SELECT
+- **Allows only**: SELECT, WITH, SHOW, EXPLAIN, DESCRIBE, DESC
+
+### Layer 2 — Database-level read-only
+
+After validation, the query runs inside a transaction:
+
+| Database | Mechanism |
+|:---------|:----------|
+| PostgreSQL | `SET TRANSACTION READ ONLY` + `SET LOCAL statement_timeout` |
+| MySQL | `SET TRANSACTION READ ONLY` + `MAX_EXECUTION_TIME` hint |
+| SQLite | `PRAGMA query_only = ON` + progress handler for timeout |
+
+All queries execute inside a transaction, then rollback (even if they could write, they can't).
+
+### Layer 3 — Row limit
+
+- Default: 100 rows
+- Configurable: `config.query_row_limit` (hard cap: 1000)
+- Applied as `LIMIT` clause appended to query
+
+### Layer 4 — Column redaction
+
+Sensitive column values are replaced with `[REDACTED]`:
+
+**Default redacted patterns:** `password_digest`, `encrypted_password`, `password_hash`, `reset_password_token`, `confirmation_token`, `unlock_token`, `otp_secret`, `session_data`, `secret_key`, `api_key`, `api_secret`, `access_token`, `refresh_token`, `jti`
+
+Redaction matches by **name** and **suffix** — `SELECT password_digest AS pd` still redacts `pd` because the column name is tracked through the query result.
+
+### Environment guard
+
+> [!WARNING]
+> Disabled in production by default. Only enable with `config.allow_query_in_production = true` if you understand the implications.
+
+---
+
+## Sensitive file blocking
+
+The `rails_search_code` and file-reading tools block access to sensitive files:
+
+### Default patterns
+
+```
+.env*
+*.key
+*.pem
+credentials.yml.enc
+master.key
+secret_key_base
+config/secrets.yml
+config/credentials/*
+```
+
+### AI context file exclusions
+
+Search also excludes generated AI context files to prevent circular references:
+
+```
+CLAUDE.md, .claude/, .mcp.json
+.cursor/, .cursorrules
+.github/copilot-instructions.md, .github/instructions/, .vscode/mcp.json
+AGENTS.md, opencode.json
+.codex/
+.ai-context.json
+```
+
+### Configuration
+
+```ruby
+config.sensitive_patterns = %w[.env* *.key *.pem credentials.yml.enc]
+```
+
+---
+
+## Path traversal protection
+
+All file-reading operations validate paths against `Rails.root`:
+
+```ruby
+real_path = File.realpath(requested_path)
+raise unless real_path.start_with?(Rails.root.to_s)
+```
+
+The VFS (`rails-ai-context://views/{path}`) applies the same protection for view template reads.
+
+---
+
+## Command injection prevention
+
+Search tools use array-based command execution (never shell strings):
+
+```ruby
+# Safe: array form
+Open3.capture2("rg", "--no-heading", pattern, "--", directory)
+
+# Pattern injection prevented by -- separator
+```
+
+File type parameters accept only alphanumeric characters.
+
+---
+
+## Regex injection prevention
+
+User-supplied regex patterns have a 1-second timeout:
+
+```ruby
+Regexp.new(pattern, timeout: 1)
+```
+
+Complex patterns that would cause catastrophic backtracking raise `RegexpError` instead of hanging.
+
+---
+
+## Safe file reading
+
+`SafeFile.read` provides drop-in safety for all file reads:
+
+- Size limit enforcement (`config.max_file_size`, default: 5 MB)
+- Returns `nil` on any failure (no exceptions leak)
+- UTF-8 encoding with invalid/undefined byte replacement
+- Handles: ENOENT, EACCES, EISDIR, ENAMETOOLONG, SystemCallError
+
+---
+
+## Log redaction
+
+The `rails_read_logs` tool redacts sensitive data from log output:
+
+- Passwords and tokens
+- Email addresses
+- Secret values
+- API keys
+
+---
+
+## Migration safety
+
+The `rails_migration_advisor` tool validates input:
+
+- Table and column names must be safe identifiers
+- Warns about duplicate columns
+- Warns about nonexistent tables
+- Checks reversibility
+
+---
+
+## MCP HTTP transport
+
+When using HTTP transport (Rack middleware or McpController):
+
+- **Default bind**: `127.0.0.1` (localhost only — not exposed to network)
+- **`auto_mount` is `false` by default** — must be explicitly enabled
+- **Doctor checks** warn if `auto_mount` is true (security flag)
+
+The McpController uses thread-safe transport initialization with mutex synchronization.
+
+---
+
+## Credential handling
+
+- `rails_get_env` returns credential **keys**, never values
+- Environment variable values are not exposed
+- `config/credentials/*.yml.enc` is in the sensitive patterns list
+
+---
+
+## Reporting vulnerabilities
+
+Email crisjosephnahine@gmail.com. Response within 48 hours.
+
+Supported versions: 4.0.x and later (4.2.1+ includes security hardening). See the repo root `SECURITY.md` for the full policy.
+
+---
+
+<div align="center">
+
+**[← Introspectors](INTROSPECTORS.md)** · **[CLI Reference →](CLI.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,359 @@
+<div align="center">
+
+# AI Tool Setup
+
+**Per-editor setup for Claude Code, Cursor, Copilot, OpenCode, and Codex CLI.**
+
+[Quickstart](QUICKSTART.md) · [Configuration](CONFIGURATION.md) · [Standalone](STANDALONE.md) · [Troubleshooting](TROUBLESHOOTING.md)
+
+</div>
+
+---
+
+## Table of Contents
+
+- [Which path is right for you?](#which-path-is-right-for-you)
+- [Claude Code](#claude-code)
+- [Cursor](#cursor)
+- [GitHub Copilot](#github-copilot)
+- [OpenCode](#opencode)
+- [Codex CLI](#codex-cli)
+- [Verify MCP is connected](#verify-mcp-is-connected)
+- [HTTP Transport](#http-transport-alternative)
+- [Regenerating context files](#regenerating-context-files)
+
+---
+
+## Which path is right for you?
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Can you modify\nthe Gemfile?}
+    B -->|Yes| C[In-Gemfile]
+    B -->|No| D[Standalone]
+    C --> E{Need MCP\nserver?}
+    D --> E
+    E -->|"Yes — best experience"| F[MCP Mode]
+    E -->|"No — terminal only"| G[CLI Mode]
+    F --> H{Which AI tools?}
+    G --> H
+    H --> I["Claude Code"]
+    H --> J["Cursor"]
+    H --> K["GitHub Copilot"]
+    H --> L["OpenCode"]
+    H --> M["Codex CLI"]
+    H --> N["All of them"]
+
+    style C fill:#27ae60,stroke:#1e8449,color:#fff
+    style D fill:#3498db,stroke:#2980b9,color:#fff
+    style F fill:#e67e22,stroke:#d35400,color:#fff
+    style G fill:#9b59b6,stroke:#8e44ad,color:#fff
+```
+
+## Claude Code
+
+### Auto-setup (recommended)
+
+```bash
+rails generate rails_ai_context:install  # Select "Claude Code"
+```
+
+This creates:
+- `.mcp.json` — MCP auto-discovery config (auto-detected on project open)
+- `CLAUDE.md` — Root context file
+- `.claude/rules/rails-schema.md` — Schema rules (loaded when editing `db/` files)
+- `.claude/rules/rails-models.md` — Model rules (loaded when editing `app/models/`)
+- `.claude/rules/rails-context.md` — General context rules (always loaded)
+- `.claude/rules/rails-mcp-tools.md` — Tool reference (always loaded)
+
+### Manual MCP config
+
+If you need to configure manually, create `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rails-ai-context": {
+      "command": "bundle",
+      "args": ["exec", "rails", "ai:serve"]
+    }
+  }
+}
+```
+
+### Split rules with `paths:` frontmatter
+
+Claude Code loads `.claude/rules/` files conditionally based on YAML frontmatter:
+
+```yaml
+---
+paths:
+  - db/**
+  - app/models/**
+---
+```
+
+Schema and model rules use this to only load when relevant files are being edited.
+
+---
+
+## Cursor
+
+### Auto-setup (recommended)
+
+```bash
+rails generate rails_ai_context:install  # Select "Cursor"
+```
+
+This creates:
+- `.cursor/mcp.json` — MCP auto-discovery config
+- `.cursor/rules/rails-project.mdc` — Project overview
+- `.cursor/rules/rails-models.mdc` — Model rules
+- `.cursor/rules/rails-controllers.mdc` — Controller rules
+- `.cursor/rules/rails-mcp-tools.mdc` — Tool reference (agent-requested, Type 3)
+
+### Manual MCP config
+
+Create `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rails-ai-context": {
+      "command": "bundle",
+      "args": ["exec", "rails", "ai:serve"]
+    }
+  }
+}
+```
+
+### Agent-requested tool loading
+
+The MCP tools rule uses `alwaysApply: false` with a descriptive `description:` field. Cursor's agent loads it when relevant rather than on every request:
+
+```markdown
+---
+description: 38 MCP tools for Rails introspection — schema, models, routes, controllers, views
+alwaysApply: false
+---
+```
+
+---
+
+## GitHub Copilot
+
+### Auto-setup (recommended)
+
+```bash
+rails generate rails_ai_context:install  # Select "GitHub Copilot"
+```
+
+This creates:
+- `.vscode/mcp.json` — MCP auto-discovery config (VS Code format)
+- `.github/copilot-instructions.md` — Root instructions
+- `.github/instructions/rails-models.instructions.md` — Model rules
+- `.github/instructions/rails-controllers.instructions.md` — Controller rules
+- `.github/instructions/rails-context.instructions.md` — Context rules
+- `.github/instructions/rails-mcp-tools.instructions.md` — Tool reference
+
+### Manual MCP config
+
+Create `.vscode/mcp.json` (note: `servers` key, not `mcpServers`):
+
+```json
+{
+  "servers": {
+    "rails-ai-context": {
+      "command": "bundle",
+      "args": ["exec", "rails", "ai:serve"]
+    }
+  }
+}
+```
+
+### Frontmatter for agent discovery
+
+Copilot instruction files include `name:` and `description:` YAML frontmatter:
+
+```markdown
+---
+name: Rails Models
+description: Model associations, validations, and schema for this Rails app
+---
+```
+
+---
+
+## OpenCode
+
+### Auto-setup (recommended)
+
+```bash
+rails generate rails_ai_context:install  # Select "OpenCode"
+```
+
+This creates:
+- `opencode.json` — MCP auto-discovery config
+- `AGENTS.md` — Root context file
+- `app/models/AGENTS.md` — Model-level rules
+- `app/controllers/AGENTS.md` — Controller-level rules
+
+### Manual MCP config
+
+Create `opencode.json`:
+
+```json
+{
+  "mcp": {
+    "rails-ai-context": {
+      "type": "local",
+      "command": ["bundle", "exec", "rails", "ai:serve"]
+    }
+  }
+}
+```
+
+Note: OpenCode uses an array for the command, not a string.
+
+---
+
+## Codex CLI
+
+### Auto-setup (recommended)
+
+```bash
+rails generate rails_ai_context:install  # Select "Codex CLI"
+```
+
+This creates:
+- `.codex/config.toml` — MCP config (TOML format) with Ruby environment snapshot
+- Shares `AGENTS.md` and OpenCode rules files
+
+### Manual MCP config
+
+Create `.codex/config.toml`:
+
+```toml
+[mcp_servers.rails-ai-context]
+command = "bundle"
+args = ["exec", "rails", "ai:serve"]
+
+[mcp_servers.rails-ai-context.env]
+PATH = "/Users/you/.rbenv/shims:/usr/local/bin:/usr/bin"
+GEM_HOME = "/Users/you/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0"
+GEM_PATH = "/Users/you/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0"
+```
+
+### Why the env section?
+
+Codex CLI `env_clear()`s the process before spawning MCP servers. Without the env section, Ruby/Bundler can't find gems. The install generator snapshots your current Ruby environment variables automatically — works with rbenv, rvm, asdf, mise, chruby, and system Ruby.
+
+### Checking for stale env
+
+```bash
+rails ai:doctor  # Includes check_codex_env_staleness
+```
+
+If you change Ruby versions, re-run the install generator to update the env snapshot.
+
+---
+
+## HTTP Transport (alternative)
+
+Instead of stdio, you can mount the MCP server inside your Rails app:
+
+```ruby
+# config/routes.rb
+mount RailsAiContext::Engine, at: "/mcp"
+```
+
+Then point your AI tool's MCP config to the HTTP endpoint instead of a command:
+
+```json
+{
+  "mcpServers": {
+    "rails-ai-context": {
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}
+```
+
+Benefits: inherits Rails routing, authentication, and middleware stack. No separate process needed.
+
+---
+
+## Verify MCP is connected
+
+After setup, confirm your AI tool can reach the MCP server.
+
+### Claude Code
+
+Type in Claude Code's prompt:
+
+```
+What MCP tools do you have access to?
+```
+
+You should see `rails_get_schema`, `rails_search_code`, and the other 36 tools listed.
+
+### Cursor
+
+Open the command palette (`Cmd+Shift+P`) and search "MCP". You should see "rails-ai-context" listed as a connected server. Or ask the Cursor agent:
+
+```
+List your available MCP tools
+```
+
+### GitHub Copilot
+
+In VS Code with Copilot Chat, ask:
+
+```
+@workspace What MCP servers are available?
+```
+
+### OpenCode / Codex CLI
+
+```bash
+# OpenCode: check the status bar for MCP connection indicator
+# Codex: run with verbose output
+codex --verbose "list your tools"
+```
+
+### All tools — CLI verification
+
+If MCP isn't connecting, verify the server works standalone:
+
+```bash
+rails ai:doctor   # Check everything
+rails ai:serve    # Should start without errors (Ctrl+C to stop)
+```
+
+---
+
+## Regenerating context files
+
+After configuration changes:
+
+```bash
+rails ai:context         # Regenerate for all configured tools
+rails ai:context:claude  # Regenerate for Claude only
+rails ai:context:cursor  # Regenerate for Cursor only
+```
+
+Or use watch mode for automatic regeneration:
+
+```bash
+rails ai:watch
+```
+
+---
+
+<div align="center">
+
+**[← Configuration](CONFIGURATION.md)** · **[Architecture →](ARCHITECTURE.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/STANDALONE.md
+++ b/docs/STANDALONE.md
@@ -1,0 +1,169 @@
+<div align="center">
+
+# Standalone Mode
+
+**Use rails-ai-context without adding it to your Gemfile.**
+
+[Quickstart](QUICKSTART.md) · [CLI Reference](CLI.md) · [Configuration](CONFIGURATION.md) · [Troubleshooting](TROUBLESHOOTING.md)
+
+</div>
+
+---
+
+## Install
+
+```bash
+gem install rails-ai-context
+```
+
+## Setup
+
+```bash
+cd your-rails-app
+rails-ai-context init
+```
+
+Interactive setup asks:
+1. Which AI tools? (Claude, Cursor, Copilot, OpenCode, Codex, or all)
+2. MCP or CLI mode?
+
+Creates:
+- `.rails-ai-context.yml` — YAML configuration
+- MCP config files for selected AI tools
+- Context files for selected AI tools
+
+## Usage
+
+```bash
+rails-ai-context serve              # Start MCP server (stdio)
+rails-ai-context serve --transport http --port 6029  # HTTP transport
+rails-ai-context tool schema --table users           # Run a tool
+rails-ai-context tool --list        # List all tools
+rails-ai-context context            # Generate context files
+rails-ai-context doctor             # Run diagnostics
+rails-ai-context watch              # Auto-regenerate on changes
+rails-ai-context version            # Show version
+```
+
+## How standalone mode works
+
+1. **Pre-loads the gem** before Rails boots — the CLI loads `rails-ai-context` before `Bundler.setup`
+2. **Restores `$LOAD_PATH`** entries that `Bundler.setup` strips (since the gem isn't in the Gemfile)
+3. **YAML config** — uses `.rails-ai-context.yml` instead of a Ruby initializer
+
+This means you get the same 38 tools, same MCP server, same context generation — without touching the project's Gemfile.
+
+## Configuration via YAML
+
+```yaml
+# .rails-ai-context.yml
+ai_tools:
+  - claude
+  - cursor
+tool_mode: mcp
+preset: full
+context_mode: compact
+
+# MCP Server
+cache_ttl: 60
+max_tool_response_chars: 200000
+http_port: 6029
+
+# Query safety
+query_timeout: 5
+query_row_limit: 100
+allow_query_in_production: false
+
+# Filtering
+excluded_models:
+  - ApplicationRecord
+excluded_paths:
+  - node_modules
+  - tmp
+  - log
+
+# Skip tools
+skip_tools:
+  - rails_security_scan
+```
+
+### YAML limitations
+
+Two config options are Ruby-only and can't be set via YAML:
+
+- `custom_tools` — requires Ruby class references
+- `excluded_concerns` — requires Regex objects
+
+For these, use the initializer approach (in-Gemfile mode).
+
+### Precedence
+
+If both exist, the initializer takes priority over YAML:
+
+1. `config/initializers/rails_ai_context.rb` (highest)
+2. `.rails-ai-context.yml`
+3. Defaults
+
+## Ruby version manager compatibility
+
+Standalone mode works with all Ruby version managers:
+
+| Manager | Supported |
+|:--------|:----------|
+| rbenv | Yes |
+| rvm | Yes |
+| asdf | Yes |
+| mise | Yes |
+| chruby | Yes |
+| System Ruby | Yes |
+
+### Codex CLI env snapshot
+
+Codex CLI is special — it `env_clear()`s the process before spawning MCP servers. The install generator snapshots your Ruby environment variables (PATH, GEM_HOME, GEM_PATH, GEM_ROOT, RUBY_VERSION, BUNDLE_PATH) into `.codex/config.toml` so Codex can find Ruby and gems.
+
+If you switch Ruby versions, re-run `rails-ai-context init` to update the snapshot.
+
+## Switching between standalone and in-Gemfile
+
+You can switch freely:
+
+```bash
+# To switch to in-Gemfile:
+bundle add rails-ai-context --group development
+rails generate rails_ai_context:install
+
+# To switch to standalone:
+bundle remove rails-ai-context
+rails-ai-context init
+```
+
+The MCP config files are updated automatically. Both modes generate identical context files and provide the same 38 tools.
+
+## Troubleshooting
+
+### "Bundler::GemNotFound" on `rails-ai-context serve`
+
+The gem's `$LOAD_PATH` restoration may have failed. Check:
+
+```bash
+gem list rails-ai-context    # Is it installed?
+ruby -v                       # Right Ruby version?
+```
+
+### "YAML config not loading"
+
+Check that no initializer exists — if `config/initializers/rails_ai_context.rb` runs, YAML is skipped.
+
+### Commands hang
+
+The `serve` command waits for stdio input by design. Use `doctor` or `tool --list` to verify the gem works, then let your AI tool connect to the server.
+
+---
+
+<div align="center">
+
+**[← CLI Reference](CLI.md)** · **[Troubleshooting →](TROUBLESHOOTING.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,0 +1,495 @@
+<div align="center">
+
+# MCP Tools Reference
+
+**All 38 read-only tools, with every parameter.**
+
+[Quickstart](QUICKSTART.md) · [Recipes](RECIPES.md) · [Custom Tools](CUSTOM_TOOLS.md) · [CLI Reference](CLI.md)
+
+</div>
+
+---
+
+## Table of Contents
+
+- [Calling tools](#calling-tools)
+- [Quick navigation](#quick-navigation)
+- [Search & Trace](#search--trace)
+- [Understand](#understand)
+- [Schema & Models](#schema--models)
+- [Controllers & Routes](#controllers--routes)
+- [Views & Frontend](#views--frontend)
+- [Testing & Quality](#testing--quality)
+- [App Config & Services](#app-config--services)
+- [Data & Debugging](#data--debugging)
+- [Live Resources (VFS)](#live-resources-vfs)
+
+---
+
+## Calling tools
+
+```bash
+# MCP — AI calls automatically via protocol
+# CLI — you call from terminal:
+rails 'ai:tool[schema]' table=users detail=full
+rails-ai-context tool schema --table users --detail full
+```
+
+Tool name resolution is flexible — all of these work:
+
+| You type | Resolves to |
+|:---------|:------------|
+| `schema` | `rails_get_schema` |
+| `get_schema` | `rails_get_schema` |
+| `rails_get_schema` | `rails_get_schema` |
+
+Most tools accept a **`detail`** parameter: `summary` (compact), `standard` (default), or `full` (everything). Start with summary, drill down as needed.
+
+<p align="right"><a href="#table-of-contents">↑ back to top</a></p>
+
+---
+
+## Quick navigation
+
+| Category | Tools |
+|:---------|:------|
+| [Search & Trace](#search--trace) | `search_code`, `get_edit_context` |
+| [Understand](#understand) | `analyze_feature`, `get_context`, `onboard` |
+| [Schema & Models](#schema--models) | `get_schema`, `get_model_details`, `get_callbacks`, `get_concern` |
+| [Controllers & Routes](#controllers--routes) | `get_controllers`, `get_routes` |
+| [Views & Frontend](#views--frontend) | `get_view`, `get_stimulus`, `get_partial_interface`, `get_turbo_map`, `get_frontend_stack` |
+| [Testing & Quality](#testing--quality) | `get_test_info`, `generate_test`, `validate`, `security_scan`, `performance_check` |
+| [App Config & Services](#app-config--services) | `get_conventions`, `get_config`, `get_gems`, `get_env`, `get_helper_methods`, `get_service_pattern`, `get_job_pattern`, `get_component_catalog` |
+| [Data & Debugging](#data--debugging) | `dependency_graph`, `migration_advisor`, `search_docs`, `query`, `read_logs`, `diagnose`, `review_changes`, `runtime_info`, `session_context` |
+
+<p align="right"><a href="#table-of-contents">↑ back to top</a></p>
+
+---
+
+## Search & Trace
+
+### `rails_search_code`
+
+Search your codebase with regex, ripgrep acceleration, and sensitive file blocking.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `pattern` | string | *required* | Regex pattern to search for |
+| `path` | string | — | Subdirectory to search in (relative to Rails root) |
+| `match_type` | enum | `any` | `any`, `definition`, `class`, `call`, `trace` |
+| `file_type` | string | — | Filter by extension (`rb`, `erb`, `js`, etc.) |
+| `exact_match` | boolean | `false` | Word boundary matching |
+| `exclude_tests` | boolean | `false` | Skip test/spec directories |
+| `group_by_file` | boolean | `false` | Group results by file with counts |
+
+> **Trace mode** returns definition + source code + every caller grouped by type + tests — replaces 4-5 sequential file reads.
+
+### `rails_get_edit_context`
+
+Method-aware code extraction with surrounding class context.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `file` | string | *required* | File path relative to Rails root |
+| `method_name` | string | — | Extract a specific method |
+| `line` | integer | — | Center extraction around a line number |
+
+<p align="right"><a href="#table-of-contents">↑ back to top</a></p>
+
+---
+
+## Understand
+
+### `rails_analyze_feature`
+
+Full-stack feature analysis: models + controllers + routes + services + jobs + views + tests in one call.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `feature` | string | *required* | Feature name (e.g., `billing`, `auth`, `subscription`) |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_context`
+
+Composite context: schema + model + controller + routes + views for a resource.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `resource` | string | *required* | Resource name (e.g., `users`, `Post`) |
+| `action` | string | — | Specific controller action |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_onboard`
+
+Narrative app walkthrough for getting up to speed.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `quick`, `standard`, `full` |
+
+<p align="right"><a href="#table-of-contents">↑ back to top</a></p>
+
+---
+
+## Schema & Models
+
+### `rails_get_schema`
+
+Database schema with column types, indexes, defaults, encrypted hints.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `table` | string | — | Specific table (omit for overview) |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_model_details`
+
+AST-parsed model internals. Every result carries `[VERIFIED]` or `[INFERRED]` confidence tag.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `model` | string | — | Model name (e.g., `User`, `Post`) |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+Returns: associations, validations, scopes, enums, callbacks, macros, methods, concerns.
+
+### `rails_get_callbacks`
+
+All callbacks in Rails execution order with source code.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `model` | string | *required* | Model name |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_concern`
+
+Concern methods, source code, and which models include it.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `concern` | string | *required* | Concern name (e.g., `Trackable`, `Searchable`) |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+<p align="right"><a href="#table-of-contents">↑ back to top</a></p>
+
+---
+
+## Controllers & Routes
+
+### `rails_get_controllers`
+
+Controller actions with inherited filters, render map, strong params. Includes schema hints for referenced models.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `controller` | string | — | Controller name (e.g., `UsersController`) |
+| `action` | string | — | Specific action |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_routes`
+
+Routes with code-ready helpers (`cook_path(@record)`) and required params.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `controller` | string | — | Filter by controller |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+<p align="right"><a href="#table-of-contents">↑ back to top</a></p>
+
+---
+
+## Views & Frontend
+
+### `rails_get_view`
+
+View templates with instance variables, Turbo frames, Stimulus controllers, partial locals. Includes schema hints for detected ivars.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `controller` | string | — | Controller name |
+| `action` | string | — | Specific action view |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_stimulus`
+
+Stimulus controller data-attributes (with dashes, not underscores) + targets + values + actions + reverse view lookup.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `controller` | string | — | Stimulus controller name |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_partial_interface`
+
+What locals to pass to a partial and what methods are called on them.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `partial` | string | *required* | Partial path (e.g., `users/form`) |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_turbo_map`
+
+Turbo Stream broadcast-to-subscription wiring with mismatch warnings.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_frontend_stack`
+
+Auto-detects React/Vue/Svelte/Angular, Hotwire, TypeScript, Vite/Shakapacker, package manager, monorepo layout.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+<p align="right"><a href="#table-of-contents">↑ back to top</a></p>
+
+---
+
+## Testing & Quality
+
+### `rails_get_test_info`
+
+Test fixtures, relationships, and template matching your project's patterns.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `model` | string | — | Model to find tests for |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_generate_test`
+
+Test scaffolding that matches your project's patterns (fixtures vs factories, RSpec vs Minitest).
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `file` | string | *required* | File to generate tests for |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_validate`
+
+Syntax + semantic + Brakeman security validation in one call.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `files` | string | — | Comma-separated file paths |
+| `level` | enum | `syntax` | `syntax`, `rails`, `security` |
+
+### `rails_security_scan`
+
+Brakeman static analysis: SQL injection, XSS, mass assignment, command injection.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+> Requires the `brakeman` gem. Gracefully reports "not installed" if missing.
+
+### `rails_performance_check`
+
+N+1 query risks, missing indexes, missing counter_cache, eager load candidates.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+<p align="right"><a href="#table-of-contents">↑ back to top</a></p>
+
+---
+
+## App Config & Services
+
+### `rails_get_conventions`
+
+Auth checks, flash messages, create action template, test patterns.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_config`
+
+Database config, auth framework, assets, cache, queue, Action Cable.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_gems`
+
+Notable gems with versions, categories, and config file locations.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_env`
+
+Environment variables + credentials keys (values are never exposed).
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_helper_methods`
+
+Application and framework helpers with view cross-references.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_service_pattern`
+
+Service object interface, dependencies, side effects, callers.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `service` | string | *required* | Service class name |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_job_pattern`
+
+Background job queue, retries, guard clauses, broadcasts, schedules.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `job` | string | — | Specific job name |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_get_component_catalog`
+
+ViewComponent/Phlex components: props, slots, previews, sidecar assets, usage examples.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `component` | string | — | Specific component name |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+<p align="right"><a href="#table-of-contents">↑ back to top</a></p>
+
+---
+
+## Data & Debugging
+
+### `rails_dependency_graph`
+
+Model/service dependency graph in Mermaid or text format.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `root` | string | — | Starting node |
+| `format` | enum | `text` | `text`, `mermaid` |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_migration_advisor`
+
+Migration code generation with duplicate/nonexistent column warnings, reversibility flags, table name normalization.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `action` | string | *required* | Migration action (e.g., `add_column`, `create_table`) |
+| `table` | string | *required* | Table name |
+| `columns` | string | — | Column definitions |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_search_docs`
+
+Bundled topic index with weighted keyword search. Optional on-demand GitHub fetch.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `query` | string | *required* | Search query |
+| `fetch` | boolean | `false` | Fetch from GitHub if not found locally |
+
+### `rails_query`
+
+Safe read-only SQL with 4-layer security: regex validation, `SET TRANSACTION READ ONLY`, timeout, column redaction. [Learn about the security model →](SECURITY.md)
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `sql` | string | *required* | SQL query (SELECT only) |
+| `limit` | integer | `100` | Maximum rows to return (hard cap: 1000) |
+| `format` | enum | `table` | `table`, `csv` |
+| `explain` | boolean | `false` | Show query plan instead of results |
+
+> Disabled in production by default.
+
+### `rails_read_logs`
+
+Reverse file tail with level filtering and sensitive data redaction.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `file` | string | `development.log` | Log file name |
+| `lines` | integer | `50` | Number of lines |
+| `level` | enum | — | Filter: `debug`, `info`, `warn`, `error`, `fatal` |
+
+### `rails_diagnose`
+
+One-call error diagnosis with classification, context, git blame, and log correlation.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `error` | string | *required* | Error message or class |
+| `file` | string | — | File where error occurred |
+| `line` | integer | — | Line number |
+
+### `rails_review_changes`
+
+PR/commit review with per-file context and warnings.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `ref` | string | `HEAD` | Git ref to review |
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_runtime_info`
+
+Live database pool stats, table sizes, pending migrations, cache stats, queue depth.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+### `rails_session_context`
+
+Session-aware context tracking across tool calls within a conversation.
+
+| Parameter | Type | Default | Description |
+|:----------|:-----|:--------|:------------|
+| `detail` | enum | `standard` | `summary`, `standard`, `full` |
+
+<p align="right"><a href="#table-of-contents">↑ back to top</a></p>
+
+---
+
+## Live Resources (VFS)
+
+In addition to tools, AI clients can read structured data through **resource templates** — `rails-ai-context://` URIs introspected fresh on every request. Zero stale data.
+
+| URI Pattern | Returns |
+|:------------|:--------|
+| `rails-ai-context://controllers/{name}` | Actions, inherited filters, strong params |
+| `rails-ai-context://controllers/{name}/{action}` | Action source with applicable filters |
+| `rails-ai-context://views/{path}` | View template content |
+| `rails-ai-context://routes/{controller}` | Live route map for controller |
+| `rails://models/{name}` | Model details: associations, validations, schema |
+
+Plus 9 static resources (schema, routes, conventions, gems, controllers, config, tests, migrations, engines).
+
+<p align="right"><a href="#table-of-contents">↑ back to top</a></p>
+
+---
+
+<div align="center">
+
+**[← Quickstart](QUICKSTART.md)** · **[Recipes →](RECIPES.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,285 @@
+<div align="center">
+
+# Troubleshooting
+
+**Common issues and how to fix them.**
+
+[Quickstart](QUICKSTART.md) · [Configuration](CONFIGURATION.md) · [AI Tool Setup](SETUP.md) · [FAQ](FAQ.md)
+
+</div>
+
+---
+
+> [!TIP]
+> Always start with `rails ai:doctor`. It runs 23 checks and catches most issues automatically.
+
+## Diagnostics first
+
+```bash
+rails ai:doctor          # In-Gemfile
+rails-ai-context doctor  # Standalone
+```
+
+This runs 23 checks and returns an AI readiness score (0-100). Each failed check includes a fix suggestion.
+
+---
+
+## Installation issues
+
+### "Could not find gem 'rails-ai-context'"
+
+```bash
+gem install rails-ai-context
+# or
+bundle update rails-ai-context
+```
+
+### Generator fails with "uninitialized constant RailsAiContext"
+
+The gem is likely in a `:development` group but you're running in another environment:
+
+```ruby
+# config/initializers/rails_ai_context.rb
+if defined?(RailsAiContext)
+  RailsAiContext.configure do |config|
+    # ...
+  end
+end
+```
+
+The `if defined?` guard prevents crashes when the gem isn't loaded.
+
+### "Permission denied" during install
+
+File system permissions. Check that your user can write to the project directory:
+
+```bash
+ls -la .mcp.json .cursor/ .vscode/ .github/
+```
+
+---
+
+## MCP server issues
+
+### AI tool doesn't detect the MCP server
+
+1. Check the config file exists:
+   - Claude Code: `.mcp.json`
+   - Cursor: `.cursor/mcp.json`
+   - Copilot: `.vscode/mcp.json`
+   - OpenCode: `opencode.json`
+   - Codex: `.codex/config.toml`
+
+2. Verify the command works:
+   ```bash
+   bundle exec rails ai:serve
+   # Should output nothing (waiting for stdio input)
+   # Ctrl+C to stop
+   ```
+
+3. Re-run the install generator:
+   ```bash
+   rails generate rails_ai_context:install
+   ```
+
+### "MCP server fails to start"
+
+Check for Bundler/Ruby path issues:
+
+```bash
+which bundle
+which rails
+ruby -v
+```
+
+For Codex CLI specifically, the env section in `.codex/config.toml` must match your current Ruby environment. Re-run install if you changed Ruby versions.
+
+### "Tools return empty results"
+
+1. Check that your Rails app boots: `rails runner "puts 'ok'"`
+2. Check schema exists: `ls db/schema.rb` or `ls db/structure.sql`
+3. Run doctor: `rails ai:doctor`
+
+### MCP server responds slowly
+
+- Check `config.cache_ttl` — lower values mean more frequent re-introspection
+- Check `config.preset` — `:standard` is faster than `:full`
+- Large schema files (>10MB) slow down schema introspection
+- Run `rails ai:doctor` — it checks schema size and view count
+
+---
+
+## Context file issues
+
+### "Context files are empty or minimal"
+
+1. Check that models exist: `ls app/models/`
+2. Check that schema exists: `ls db/schema.rb`
+3. Try full mode: `config.context_mode = :full`
+4. Regenerate: `rails ai:context`
+
+### "Context files don't update after code changes"
+
+Regeneration is not automatic unless you're running watch mode:
+
+```bash
+rails ai:watch
+```
+
+Or regenerate manually:
+
+```bash
+rails ai:context
+```
+
+### "My custom content in CLAUDE.md was overwritten"
+
+The gem uses section markers (`<!-- BEGIN/END rails-ai-context -->`) to preserve user content. Content outside these markers is preserved. If markers were removed, the gem may overwrite.
+
+### "Generated files are too large"
+
+Use compact mode (default):
+
+```ruby
+config.context_mode = :compact
+config.claude_max_lines = 150
+```
+
+Or disable root files and use only split rules:
+
+```ruby
+config.generate_root_files = false
+```
+
+---
+
+## Query tool issues
+
+### "Query tool disabled in production"
+
+By design. Override if needed:
+
+```ruby
+config.allow_query_in_production = true
+```
+
+### "Query blocked: potentially unsafe SQL"
+
+The 4-layer SQL validator blocks write operations and injection patterns. Ensure you're only running SELECT queries.
+
+Common false positives:
+- Hash characters in strings → write the hash outside a comment position
+- JSONB operators (`#>>`) → preserved correctly since v5.6.0
+
+### "Column values show [REDACTED]"
+
+Columns matching sensitive patterns are redacted. Configure:
+
+```ruby
+config.query_redacted_columns = %w[password_digest encrypted_password]
+```
+
+---
+
+## Search issues
+
+### "Search returns no results"
+
+1. Check file extensions: `config.search_extensions` defaults to common web types
+2. Check excluded paths: `config.excluded_paths` excludes `node_modules`, `tmp`, `log`, etc.
+3. Check sensitive patterns: some files are blocked by design
+
+### "ripgrep not found" warning
+
+Install ripgrep for faster search:
+
+```bash
+# macOS
+brew install ripgrep
+
+# Ubuntu
+apt install ripgrep
+```
+
+The gem falls back to Ruby regex if ripgrep isn't available. Search still works, just slower on large codebases.
+
+---
+
+## Standalone mode issues
+
+### "Bundler can't find the gem"
+
+Standalone mode pre-loads the gem before Rails boot and restores `$LOAD_PATH` entries stripped by `Bundler.setup`. If this fails:
+
+1. Check the gem is installed: `gem list rails-ai-context`
+2. Check Ruby version matches: `ruby -v`
+3. Try with Gemfile entry instead of standalone
+
+### "YAML config not loading"
+
+YAML config (`.rails-ai-context.yml`) is skipped if an initializer runs. Check precedence:
+
+1. Initializer (`config/initializers/rails_ai_context.rb`) — highest priority
+2. YAML (`.rails-ai-context.yml`)
+3. Defaults
+
+Corrupted YAML degrades gracefully with a warning.
+
+---
+
+## Security scan issues
+
+### "Brakeman not installed"
+
+The `rails_security_scan` tool requires Brakeman:
+
+```bash
+gem install brakeman
+# or
+bundle add brakeman --group development
+```
+
+Without it, the tool reports "not installed" but the gem works fine otherwise.
+
+---
+
+## Performance issues
+
+### "Introspection is slow"
+
+1. Use `:standard` preset (17 introspectors vs 31)
+2. Increase cache TTL: `config.cache_ttl = 300`
+3. Check schema file size: `rails ai:doctor` warns if too large
+4. Check view count: many views slow down view introspection
+
+### "Live reload fires too often"
+
+Increase the debounce:
+
+```ruby
+config.live_reload_debounce = 3.0  # seconds (default: 1.5)
+```
+
+Or disable:
+
+```ruby
+config.live_reload = false
+```
+
+---
+
+## Getting help
+
+1. Run `rails ai:doctor` first — it catches most issues
+2. Check [GitHub issues](https://github.com/crisnahine/rails-ai-context/issues)
+3. Open a new issue with doctor output and error details
+
+---
+
+<div align="center">
+
+**[← Standalone](STANDALONE.md)** · **[FAQ →](FAQ.md)**
+
+[Back to README](../README.md)
+
+</div>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,15 @@
+title: rails-ai-context
+description: 38 MCP tools that give AI agents live access to your Rails schema, models, routes & conventions.
+theme: jekyll-theme-minimal
+plugins:
+  - jekyll-relative-links
+
+relative_links:
+  enabled: true
+  collections: true
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,54 @@
+---
+title: Home
+---
+
+# rails-ai-context Documentation
+
+**38 MCP tools that give AI agents live access to your Rails app.**
+
+Works with Claude Code, Cursor, GitHub Copilot, OpenCode, and Codex CLI.
+
+---
+
+## Getting Started
+
+| Guide | Description |
+|:------|:------------|
+| **[Quickstart](QUICKSTART.md)** | Get running in 5 minutes |
+| **[AI Tool Setup](SETUP.md)** | Claude, Cursor, Copilot, OpenCode, Codex |
+| **[Standalone Mode](STANDALONE.md)** | Use without Gemfile entry |
+
+## Reference
+
+| Guide | Description |
+|:------|:------------|
+| **[Tools Reference](TOOLS.md)** | All 38 tools with every parameter |
+| **[Configuration](CONFIGURATION.md)** | 40+ config options with defaults |
+| **[CLI Reference](CLI.md)** | Commands and argument syntax |
+| **[Introspectors](INTROSPECTORS.md)** | All 31 introspectors and AST engine |
+
+## Learn
+
+| Guide | Description |
+|:------|:------------|
+| **[Recipes](RECIPES.md)** | Real-world workflows and examples |
+| **[Custom Tools](CUSTOM_TOOLS.md)** | Build and test your own MCP tools |
+| **[Architecture](ARCHITECTURE.md)** | System design and internals |
+| **[FAQ](FAQ.md)** | Frequently asked questions |
+
+## Safety & Support
+
+| Guide | Description |
+|:------|:------------|
+| **[Security](SECURITY.md)** | 4-layer SQL safety and file blocking |
+| **[Troubleshooting](TROUBLESHOOTING.md)** | Common issues and fixes |
+
+## Complete Reference
+
+| Guide | Description |
+|:------|:------------|
+| **[Full Guide](GUIDE.md)** | Everything in one file |
+
+---
+
+[GitHub Repository](https://github.com/crisnahine/rails-ai-context) · [RubyGems](https://rubygems.org/gems/rails-ai-context) · [MCP Registry](https://registry.modelcontextprotocol.io)

--- a/docs/social-preview.html
+++ b/docs/social-preview.html
@@ -1,0 +1,164 @@
+<!--
+  Social Preview Image for GitHub
+  ================================
+  1. Open this file in a browser
+  2. Screenshot at 1280x640px (GitHub's recommended OG image size)
+  3. Upload at: GitHub repo → Settings → General → Social preview
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 1280px;
+    height: 640px;
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    color: white;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .bg-pattern {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    opacity: 0.05;
+    background-image:
+      repeating-linear-gradient(0deg, transparent, transparent 50px, rgba(255,255,255,0.1) 50px, rgba(255,255,255,0.1) 51px),
+      repeating-linear-gradient(90deg, transparent, transparent 50px, rgba(255,255,255,0.1) 50px, rgba(255,255,255,0.1) 51px);
+  }
+
+  .content {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    padding: 0 80px;
+  }
+
+  .gem-icon {
+    font-size: 48px;
+    margin-bottom: 16px;
+    background: linear-gradient(135deg, #e74c3c, #c0392b);
+    width: 72px;
+    height: 72px;
+    border-radius: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 20px;
+    box-shadow: 0 4px 20px rgba(231, 76, 60, 0.3);
+  }
+
+  h1 {
+    font-size: 56px;
+    font-weight: 800;
+    letter-spacing: -1px;
+    margin-bottom: 16px;
+    background: linear-gradient(135deg, #ffffff 0%, #e0e0e0 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .tagline {
+    font-size: 24px;
+    color: #a0aec0;
+    margin-bottom: 40px;
+    font-weight: 400;
+  }
+
+  .stats {
+    display: flex;
+    gap: 48px;
+    justify-content: center;
+    margin-bottom: 40px;
+  }
+
+  .stat {
+    text-align: center;
+  }
+
+  .stat-number {
+    font-size: 40px;
+    font-weight: 800;
+    color: #63b3ed;
+  }
+
+  .stat-label {
+    font-size: 14px;
+    color: #718096;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    margin-top: 4px;
+  }
+
+  .tools {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .tool-badge {
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 14px;
+    font-weight: 600;
+    border: 1px solid rgba(255,255,255,0.15);
+    background: rgba(255,255,255,0.08);
+  }
+
+  .tool-badge.claude { border-color: rgba(238, 139, 74, 0.4); color: #ee8b4a; }
+  .tool-badge.cursor { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
+  .tool-badge.copilot { border-color: rgba(110, 198, 255, 0.4); color: #6ec6ff; }
+  .tool-badge.opencode { border-color: rgba(66, 133, 244, 0.4); color: #4285f4; }
+  .tool-badge.codex { border-color: rgba(116, 100, 255, 0.4); color: #7464ff; }
+</style>
+</head>
+<body>
+  <div class="bg-pattern"></div>
+  <div class="content">
+    <div class="gem-icon">
+      <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2">
+        <polygon points="12,2 22,8.5 22,15.5 12,22 2,15.5 2,8.5"/>
+        <polyline points="12,22 12,15.5"/>
+        <polyline points="22,8.5 12,15.5 2,8.5"/>
+        <polyline points="2,15.5 12,8.5 22,15.5"/>
+        <polyline points="12,2 12,8.5"/>
+      </svg>
+    </div>
+    <h1>rails-ai-context</h1>
+    <p class="tagline">Your AI stops guessing your Rails app.</p>
+    <div class="stats">
+      <div class="stat">
+        <div class="stat-number">38</div>
+        <div class="stat-label">MCP Tools</div>
+      </div>
+      <div class="stat">
+        <div class="stat-number">31</div>
+        <div class="stat-label">Introspectors</div>
+      </div>
+      <div class="stat">
+        <div class="stat-number">1889</div>
+        <div class="stat-label">Tests</div>
+      </div>
+      <div class="stat">
+        <div class="stat-number">0</div>
+        <div class="stat-label">Config Required</div>
+      </div>
+    </div>
+    <div class="tools">
+      <span class="tool-badge claude">Claude Code</span>
+      <span class="tool-badge cursor">Cursor</span>
+      <span class="tool-badge copilot">GitHub Copilot</span>
+      <span class="tool-badge opencode">OpenCode</span>
+      <span class="tool-badge codex">Codex CLI</span>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Added **13 new documentation files** covering every aspect of the gem
- Applied **awesome-readme patterns** inspired by [matiassingers/awesome-readme](https://github.com/matiassingers/awesome-readme)
- Updated README with documentation table, custom tools section, and Mermaid diagrams

## New docs

| File | What it covers |
|:-----|:---------------|
| `docs/QUICKSTART.md` | 5-minute getting started |
| `docs/TOOLS.md` | All 38 MCP tools with every parameter |
| `docs/RECIPES.md` | 13 real-world workflows with output examples |
| `docs/CUSTOM_TOOLS.md` | Build and test custom MCP tools |
| `docs/CONFIGURATION.md` | 40+ config options with defaults |
| `docs/SETUP.md` | Per-editor setup (Claude, Cursor, Copilot, OpenCode, Codex) |
| `docs/ARCHITECTURE.md` | System design with Mermaid diagrams |
| `docs/INTROSPECTORS.md` | All 31 introspectors and AST engine |
| `docs/SECURITY.md` | 4-layer SQL safety model |
| `docs/CLI.md` | Commands and argument syntax |
| `docs/STANDALONE.md` | No-Gemfile mode |
| `docs/TROUBLESHOOTING.md` | Common issues and fixes |
| `docs/FAQ.md` | 25+ questions with comparison section |

## Awesome-readme patterns applied

- **Centered headers** with tagline and nav breadcrumbs on every doc
- **GitHub alert callouts** (`[!TIP]`, `[!WARNING]`, `[!NOTE]`, `[!IMPORTANT]`, `[!CAUTION]`) — 10 across 7 docs
- **Mermaid diagrams** — architecture overview, data flow, request lifecycle, SQL safety, preset comparison, setup decision tree
- **Tool output examples** — expandable `<details>` showing what tools actually return
- **Back-to-top links** after every section in long docs
- **Prev/Next footer navigation** on all 13 docs
- **Table of Contents** on TOOLS, RECIPES, and SETUP
- **All tool categories expanded** by default in README (`<details open>`)

## README changes

- Documentation table moved up (after Commands)
- New "Build your own tools" section with code example
- ASCII diagram replaced with Mermaid
- Inline tool output examples in "Real-world examples"
- Configuration section trimmed (links to full docs)
- Broken "Any Terminal" badge link fixed

## Test plan

- [ ] Verify all Mermaid diagrams render on GitHub
- [ ] Verify all `[!TIP]` / `[!WARNING]` callouts render as colored boxes
- [ ] Check all cross-links between docs resolve correctly
- [ ] Confirm `<details open>` sections expand by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)