### PR TITLE
fix: broken GitHub Pages — Mermaid rendering + dead nav links

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -239,6 +239,6 @@ SHA256-based change detection:
 
 **[← AI Tool Setup](SETUP.md)** · **[Introspectors →](INTROSPECTORS.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -229,6 +229,6 @@ rails ai:context
 
 **[← Security](SECURITY.md)** · **[Standalone Mode →](STANDALONE.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -230,6 +230,6 @@ end
 
 **[← Custom Tools](CUSTOM_TOOLS.md)** · **[AI Tool Setup →](SETUP.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/CUSTOM_TOOLS.md
+++ b/docs/CUSTOM_TOOLS.md
@@ -209,6 +209,6 @@ end
 
 **[← Recipes](RECIPES.md)** · **[Configuration →](CONFIGURATION.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -235,6 +235,6 @@ config.generate_root_files = false
 
 **[← Troubleshooting](TROUBLESHOOTING.md)** · **[Full Guide →](GUIDE.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -11,7 +11,7 @@
 ---
 
 > [!NOTE]
-> This is the comprehensive single-file reference. For focused guides, see the docs below. For a quick overview, see the [README](../README.md).
+> This is the comprehensive single-file reference. For focused guides, see the docs below. For a quick overview, see the [Home](index.md).
 
 ## Focused guides
 

--- a/docs/INTROSPECTORS.md
+++ b/docs/INTROSPECTORS.md
@@ -206,6 +206,6 @@ The **Fingerprinter** computes a composite SHA256 from all watched directories (
 
 **[← Architecture](ARCHITECTURE.md)** · **[Security →](SECURITY.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -113,6 +113,6 @@ rails 'ai:tool[conventions]'
 
 **Next:** [Tools Reference →](TOOLS.md)
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -385,6 +385,6 @@ Your custom rules (coding style, PR conventions, team preferences) stay. The gem
 
 **[← Tools Reference](TOOLS.md)** · **[Custom Tools →](CUSTOM_TOOLS.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -233,6 +233,6 @@ Supported versions: 4.0.x and later (4.2.1+ includes security hardening). See th
 
 **[← Introspectors](INTROSPECTORS.md)** · **[CLI Reference →](CLI.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -354,6 +354,6 @@ rails ai:watch
 
 **[← Configuration](CONFIGURATION.md)** · **[Architecture →](ARCHITECTURE.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/STANDALONE.md
+++ b/docs/STANDALONE.md
@@ -164,6 +164,6 @@ The `serve` command waits for stdio input by design. Use `doctor` or `tool --lis
 
 **[← CLI Reference](CLI.md)** · **[Troubleshooting →](TROUBLESHOOTING.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -490,6 +490,6 @@ Plus 9 static resources (schema, routes, conventions, gems, controllers, config,
 
 **[← Quickstart](QUICKSTART.md)** · **[Recipes →](RECIPES.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -280,6 +280,6 @@ config.live_reload = false
 
 **[← Standalone](STANDALONE.md)** · **[FAQ →](FAQ.md)**
 
-[Back to README](../README.md)
+[Back to Home](index.md)
 
 </div>

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,16 @@
+<!-- Mermaid diagram rendering -->
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: false, theme: 'default' });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('pre > code.language-mermaid').forEach(el => {
+      const pre = el.parentElement;
+      const div = document.createElement('div');
+      div.className = 'mermaid';
+      div.textContent = el.textContent;
+      pre.parentElement.replaceChild(div, pre);
+    });
+    mermaid.run();
+  });
+</script>


### PR DESCRIPTION
## Summary
- **Mermaid diagrams rendering as raw text** — Added `docs/_includes/head-custom.html` that loads Mermaid JS and converts fenced code blocks into rendered diagrams
- **"Back to README" links 404ing** — All 14 doc pages linked to `../README.md` which doesn't exist on GitHub Pages (only `docs/` is served). Changed to `index.md` → docs home page

## Test plan
- [ ] Merge and wait for GitHub Pages rebuild
- [ ] Verify Mermaid diagrams render on SETUP, SECURITY, INTROSPECTORS, ARCHITECTURE pages
- [ ] Verify "Back to Home" link works on any doc page
- [ ] Verify all inter-page navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)