### PR TITLE
fix: nav links not clickable on GitHub Pages

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # Architecture
 
@@ -235,7 +235,7 @@ SHA256-based change detection:
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← AI Tool Setup](SETUP.md)** · **[Introspectors →](INTROSPECTORS.md)**
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # CLI Reference
 
@@ -225,7 +225,7 @@ rails ai:context
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← Security](SECURITY.md)** · **[Standalone Mode →](STANDALONE.md)**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # Configuration
 
@@ -226,7 +226,7 @@ end
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← Custom Tools](CUSTOM_TOOLS.md)** · **[AI Tool Setup →](SETUP.md)**
 

--- a/docs/CUSTOM_TOOLS.md
+++ b/docs/CUSTOM_TOOLS.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # Custom Tools
 
@@ -205,7 +205,7 @@ end
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← Recipes](RECIPES.md)** · **[Configuration →](CONFIGURATION.md)**
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # FAQ
 
@@ -231,7 +231,7 @@ config.generate_root_files = false
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← Troubleshooting](TROUBLESHOOTING.md)** · **[Full Guide →](GUIDE.md)**
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # rails-ai-context — Complete Guide
 

--- a/docs/INTROSPECTORS.md
+++ b/docs/INTROSPECTORS.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # Introspectors
 
@@ -202,7 +202,7 @@ The **Fingerprinter** computes a composite SHA256 from all watched directories (
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← Architecture](ARCHITECTURE.md)** · **[Security →](SECURITY.md)**
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # Quickstart
 
@@ -109,7 +109,7 @@ rails 'ai:tool[conventions]'
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **Next:** [Tools Reference →](TOOLS.md)
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # Recipes
 
@@ -381,7 +381,7 @@ Your custom rules (coding style, PR conventions, team preferences) stay. The gem
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← Tools Reference](TOOLS.md)** · **[Custom Tools →](CUSTOM_TOOLS.md)**
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # Security Model
 
@@ -229,7 +229,7 @@ Supported versions: 4.0.x and later (4.2.1+ includes security hardening). See th
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← Introspectors](INTROSPECTORS.md)** · **[CLI Reference →](CLI.md)**
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # AI Tool Setup
 
@@ -350,7 +350,7 @@ rails ai:watch
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← Configuration](CONFIGURATION.md)** · **[Architecture →](ARCHITECTURE.md)**
 

--- a/docs/STANDALONE.md
+++ b/docs/STANDALONE.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # Standalone Mode
 
@@ -160,7 +160,7 @@ The `serve` command waits for stdio input by design. Use `doctor` or `tool --lis
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← CLI Reference](CLI.md)** · **[Troubleshooting →](TROUBLESHOOTING.md)**
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # MCP Tools Reference
 
@@ -486,7 +486,7 @@ Plus 9 static resources (schema, routes, conventions, gems, controllers, config,
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← Quickstart](QUICKSTART.md)** · **[Recipes →](RECIPES.md)**
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # Troubleshooting
 
@@ -276,7 +276,7 @@ config.live_reload = false
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **[← Standalone](STANDALONE.md)** · **[FAQ →](FAQ.md)**
 


### PR DESCRIPTION
## Summary
- Jekyll's Kramdown parser doesn't render Markdown inside raw HTML blocks
- All `<div align="center">` wrappers (27 across 14 files) were causing nav links to display as plain text instead of clickable links
- Added `markdown="1"` attribute to enable Markdown parsing inside these divs

## Test plan
- [ ] Merge and wait for GitHub Pages rebuild
- [ ] Verify top nav links are clickable on any doc page (e.g. QUICKSTART)
- [ ] Verify bottom prev/next nav links are clickable
- [ ] Verify "Back to Home" link works