### PR TITLE
chore: SLOP cleanup, deduplicate tool utilities, bump to v5.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.7.1] — 2026-04-09
+
+### Changed — SLOP Cleanup
+
+Internal code quality improvements — no API changes, no new features.
+
+- **Extract `safe_read`, `max_file_size`, `sensitive_file?` to BaseTool** — removed 16 duplicate one-liner methods across 8 tool files (get_env, get_job_pattern, get_service_pattern, get_turbo_map, get_partial_interface, get_view, get_edit_context, get_model_details, search_code)
+- **Extract `FullSerializerBehavior` module** — deduplicated identical `footer` and `architecture_summary` methods from FullClaudeSerializer and FullOpencodeSerializer
+- **Derive `tools_name_list` from `TOOL_ROWS`** — replaced hardcoded 38-tool name array with derivation from single source of truth in ToolGuideHelper
+- **Fix `notable_gems_list` bypass** — copilot_instructions_serializer and markdown_serializer now use the triple-fallback helper instead of raw hash access
+- **Narrow bare `rescue` to `rescue StandardError`** — 4 sites in get_config and i18n_introspector no longer catch `SignalException`/`NoMemoryError`
+- **Delete dead `SENSITIVE_PATTERNS = nil` constant** — vestigial from get_edit_context
+
 ## [5.7.0] — 2026-04-09
 
 ### Quickstart — Two commands. Problem gone.

--- a/lib/rails_ai_context/introspectors/i18n_introspector.rb
+++ b/lib/rails_ai_context/introspectors/i18n_introspector.rb
@@ -100,7 +100,7 @@ module RailsAiContext
           next 0 unless content
           data = YAML.safe_load(content, permitted_classes: [ Symbol ])
           count_nested_keys(data)
-        rescue
+        rescue StandardError
           0
         end
       rescue => e

--- a/lib/rails_ai_context/serializers/claude_serializer.rb
+++ b/lib/rails_ai_context/serializers/claude_serializer.rb
@@ -104,6 +104,8 @@ module RailsAiContext
 
     # Internal: full-mode Claude serializer (wraps MarkdownSerializer with behavioral rules)
     class FullClaudeSerializer < MarkdownSerializer
+      include FullSerializerBehavior
+
       private
 
       def header
@@ -118,27 +120,6 @@ module RailsAiContext
           structure, patterns, and conventions. Use it to write idiomatic code
           that matches this project's style.
         MD
-      end
-
-      def footer
-        rules = []
-        rules << "## Behavioral Rules"
-        rules << ""
-        rules << "When working in this codebase:"
-        rules << "- Follow existing patterns and conventions detected above"
-        rules << "- Use the database schema as the source of truth for column names and types"
-        rules << "- Respect existing associations and validations when modifying models"
-        rules << "- Match the project's architecture style (#{architecture_summary})" if architecture_summary
-        test_cmd = detect_test_command
-        rules << "- Run `#{test_cmd}` after making changes to verify correctness"
-        rules << ""
-        rules << super
-        rules.join("\n")
-      end
-
-      def architecture_summary
-        arch = context.dig(:conventions, :architecture)
-        arch&.any? ? arch.join(", ") : nil
       end
     end
   end

--- a/lib/rails_ai_context/serializers/copilot_instructions_serializer.rb
+++ b/lib/rails_ai_context/serializers/copilot_instructions_serializer.rb
@@ -56,7 +56,7 @@ module RailsAiContext
 
         gems = context[:gems]
         if gems.is_a?(Hash) && !gems[:error]
-          notable = gems[:notable_gems] || []
+          notable = notable_gems_list(gems)
           notable.group_by { |g| g[:category]&.to_s || "other" }.first(6).each do |cat, gem_list|
             lines << "- #{cat}: #{gem_list.map { |g| g[:name] }.join(', ')}"
           end

--- a/lib/rails_ai_context/serializers/markdown_serializer.rb
+++ b/lib/rails_ai_context/serializers/markdown_serializer.rb
@@ -153,7 +153,7 @@ module RailsAiContext
         gems = context[:gems]
         return if gems[:error]
 
-        notable = gems[:notable_gems] || []
+        notable = notable_gems_list(gems)
         return if notable.empty?
 
         lines = [ "## Notable Gems" ]
@@ -526,6 +526,33 @@ module RailsAiContext
       def escape_markdown(text)
         return "" if text.nil?
         text.to_s.gsub(MARKDOWN_SPECIAL_CHARS, '\\\\\1')
+      end
+    end
+
+    # Shared behavior for full-mode serializers (FullClaudeSerializer, FullOpencodeSerializer).
+    # Provides behavioral rules footer and architecture summary.
+    module FullSerializerBehavior
+      private
+
+      def footer
+        rules = []
+        rules << "## Behavioral Rules"
+        rules << ""
+        rules << "When working in this codebase:"
+        rules << "- Follow existing patterns and conventions detected above"
+        rules << "- Use the database schema as the source of truth for column names and types"
+        rules << "- Respect existing associations and validations when modifying models"
+        rules << "- Match the project's architecture style (#{architecture_summary})" if architecture_summary
+        test_cmd = detect_test_command
+        rules << "- Run `#{test_cmd}` after making changes to verify correctness"
+        rules << ""
+        rules << super
+        rules.join("\n")
+      end
+
+      def architecture_summary
+        arch = context.dig(:conventions, :architecture)
+        arch&.any? ? arch.join(", ") : nil
       end
     end
   end

--- a/lib/rails_ai_context/serializers/opencode_serializer.rb
+++ b/lib/rails_ai_context/serializers/opencode_serializer.rb
@@ -73,6 +73,8 @@ module RailsAiContext
 
     # Internal: full-mode OpenCode serializer (wraps MarkdownSerializer)
     class FullOpencodeSerializer < MarkdownSerializer
+      include FullSerializerBehavior
+
       private
 
       def header
@@ -86,27 +88,6 @@ module RailsAiContext
           This file gives OpenCode deep context about this Rails application's
           structure, patterns, and conventions.
         MD
-      end
-
-      def footer
-        rules = []
-        rules << "## Behavioral Rules"
-        rules << ""
-        rules << "When working in this codebase:"
-        rules << "- Follow existing patterns and conventions detected above"
-        rules << "- Use the database schema as the source of truth for column names and types"
-        rules << "- Respect existing associations and validations when modifying models"
-        rules << "- Match the project's architecture style (#{architecture_summary})" if architecture_summary
-        test_cmd = detect_test_command
-        rules << "- Run `#{test_cmd}` after making changes to verify correctness"
-        rules << ""
-        rules << super
-        rules.join("\n")
-      end
-
-      def architecture_summary
-        arch = context.dig(:conventions, :architecture)
-        arch&.any? ? arch.join(", ") : nil
       end
     end
   end

--- a/lib/rails_ai_context/serializers/tool_guide_helper.rb
+++ b/lib/rails_ai_context/serializers/tool_guide_helper.rb
@@ -289,22 +289,9 @@ module RailsAiContext
         lines
       end
 
-      # Dense one-line-per-tool listing — fits in compact mode without the table overhead
+      # Dense one-line-per-tool listing — derived from TOOL_ROWS (single source of truth)
       def tools_name_list
-        all_tools = %w[
-          rails_get_context rails_analyze_feature rails_search_code rails_get_controllers
-          rails_validate rails_get_schema rails_get_model_details rails_get_routes
-          rails_get_view rails_get_stimulus rails_get_test_info
-          rails_get_concern rails_get_callbacks rails_get_edit_context
-          rails_get_service_pattern rails_get_job_pattern rails_get_env
-          rails_get_partial_interface rails_get_turbo_map rails_get_helper_methods
-          rails_get_config rails_get_gems rails_get_conventions rails_security_scan
-          rails_get_component_catalog rails_performance_check rails_dependency_graph
-          rails_migration_advisor rails_get_frontend_stack rails_search_docs
-          rails_query rails_read_logs rails_generate_test rails_diagnose
-          rails_review_changes rails_onboard
-          rails_runtime_info rails_session_context
-        ]
+        all_tools = TOOL_ROWS.map { |row| row[0][/^(rails_\w+)/, 1] }
         [
           "### All #{all_tools.size} tools",
           "`#{all_tools.join('` `')}`",

--- a/lib/rails_ai_context/tools/base_tool.rb
+++ b/lib/rails_ai_context/tools/base_tool.rb
@@ -336,6 +336,27 @@ module RailsAiContext
           param_str = params.is_a?(Hash) ? params.sort_by { |k, _| k.to_s }.map { |k, v| "#{k}:#{v}" }.join(",") : params.to_s
           "#{normalized}:#{param_str}"
         end
+
+        # Shared utility: safe file reading with size limits.
+        def safe_read(path)
+          RailsAiContext::SafeFile.read(path)
+        end
+
+        # Shared utility: max file size from configuration.
+        def max_file_size
+          RailsAiContext.configuration.max_file_size
+        end
+
+        # Shared utility: check if a relative path matches sensitive file patterns.
+        def sensitive_file?(relative_path)
+          patterns = RailsAiContext.configuration.sensitive_patterns
+          basename = File.basename(relative_path)
+          flags = File::FNM_DOTMATCH | File::FNM_CASEFOLD
+          patterns.any? do |pattern|
+            File.fnmatch(pattern, relative_path, flags) ||
+              File.fnmatch(pattern, basename, flags)
+          end
+        end
       end
     end
   end

--- a/lib/rails_ai_context/tools/get_config.rb
+++ b/lib/rails_ai_context/tools/get_config.rb
@@ -162,7 +162,7 @@ module RailsAiContext
 
         adapter = content.match(/adapter:\s*(\w+)/)&.captures&.first
         adapter || "configured"
-      rescue
+      rescue StandardError
         nil
       end
 
@@ -173,7 +173,7 @@ module RailsAiContext
         return nil unless service_name
 
         service_name.to_s
-      rescue
+      rescue StandardError
         nil
       end
 
@@ -182,7 +182,7 @@ module RailsAiContext
         return nil unless method
 
         method.to_s
-      rescue
+      rescue StandardError
         nil
       end
     end

--- a/lib/rails_ai_context/tools/get_edit_context.rb
+++ b/lib/rails_ai_context/tools/get_edit_context.rb
@@ -8,10 +8,6 @@ module RailsAiContext
         "Use when: you need to edit a specific method or section without reading the entire file. " \
         "Requires file:\"app/models/user.rb\" and near:\"def activate\" to locate the code region."
 
-      def self.max_file_size
-        RailsAiContext.configuration.max_file_size
-      end
-
       input_schema(
         properties: {
           file: {
@@ -31,9 +27,6 @@ module RailsAiContext
       )
 
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
-
-      # Sensitive file patterns that should not be readable
-      SENSITIVE_PATTERNS = nil # uses configuration.sensitive_patterns
 
       def self.call(file:, near:, context_lines: 5, server_context: nil)
         # Reject empty parameters
@@ -143,15 +136,6 @@ module RailsAiContext
         text_response(output.join("\n"))
       end
 
-      private_class_method def self.sensitive_file?(relative_path)
-        patterns = RailsAiContext.configuration.sensitive_patterns
-        basename = File.basename(relative_path)
-        flags = File::FNM_DOTMATCH | File::FNM_CASEFOLD
-        patterns.any? do |pattern|
-          File.fnmatch(pattern, relative_path, flags) ||
-            File.fnmatch(pattern, basename, flags)
-        end
-      end
 
       private_class_method def self.extract_methods(source_lines)
         methods = []

--- a/lib/rails_ai_context/tools/get_env.rb
+++ b/lib/rails_ai_context/tools/get_env.rb
@@ -246,7 +246,7 @@ module RailsAiContext
           next unless Dir.exist?(dir)
           Dir.glob(File.join(dir, "**", "*.rb")).each do |file|
             next if File.size(file) > max_file_size
-            next if sensitive_file?(file, root)
+            next if sensitive_file?(file.sub("#{root}/", ""))
 
             source = safe_read(file)
             next unless source
@@ -626,26 +626,6 @@ module RailsAiContext
         else
           stripped
         end
-      end
-
-      private_class_method def self.sensitive_file?(file, root)
-        relative = file.sub("#{root}/", "")
-        basename = File.basename(relative)
-        patterns = RailsAiContext.configuration.sensitive_patterns
-        flags = File::FNM_DOTMATCH | File::FNM_CASEFOLD
-
-        patterns.any? do |pattern|
-          File.fnmatch(pattern, relative, flags) ||
-            File.fnmatch(pattern, basename, flags)
-        end
-      end
-
-      private_class_method def self.safe_read(path)
-        RailsAiContext::SafeFile.read(path)
-      end
-
-      private_class_method def self.max_file_size
-        RailsAiContext.configuration.max_file_size
       end
     end
   end

--- a/lib/rails_ai_context/tools/get_job_pattern.rb
+++ b/lib/rails_ai_context/tools/get_job_pattern.rb
@@ -404,14 +404,6 @@ module RailsAiContext
 
         enqueuers.to_a.sort.first(20)
       end
-
-      private_class_method def self.safe_read(path)
-        RailsAiContext::SafeFile.read(path)
-      end
-
-      private_class_method def self.max_file_size
-        RailsAiContext.configuration.max_file_size
-      end
     end
   end
 end

--- a/lib/rails_ai_context/tools/get_model_details.rb
+++ b/lib/rails_ai_context/tools/get_model_details.rb
@@ -471,10 +471,6 @@ module RailsAiContext
         nil
       end
 
-      def self.max_file_size
-        RailsAiContext.configuration.max_file_size
-      end
-
       private_class_method def self.extract_model_structure(model_name)
         path = "app/models/#{model_name.underscore}.rb"
         full_path = Rails.root.join(path)

--- a/lib/rails_ai_context/tools/get_partial_interface.rb
+++ b/lib/rails_ai_context/tools/get_partial_interface.rb
@@ -470,14 +470,6 @@ module RailsAiContext
         $stderr.puts "[rails-ai-context] find_available_partials failed: #{e.message}" if ENV["DEBUG"]
         []
       end
-
-      private_class_method def self.safe_read(path)
-        RailsAiContext::SafeFile.read(path)
-      end
-
-      private_class_method def self.max_file_size
-        RailsAiContext.configuration.max_file_size
-      end
     end
   end
 end

--- a/lib/rails_ai_context/tools/get_service_pattern.rb
+++ b/lib/rails_ai_context/tools/get_service_pattern.rb
@@ -316,14 +316,6 @@ module RailsAiContext
 
         parts.any? ? parts.join(", ") : "mixed/no dominant pattern"
       end
-
-      private_class_method def self.safe_read(path)
-        RailsAiContext::SafeFile.read(path)
-      end
-
-      private_class_method def self.max_file_size
-        RailsAiContext.configuration.max_file_size
-      end
     end
   end
 end

--- a/lib/rails_ai_context/tools/get_turbo_map.rb
+++ b/lib/rails_ai_context/tools/get_turbo_map.rb
@@ -680,14 +680,6 @@ module RailsAiContext
         $stderr.puts "[rails-ai-context] extract_class_name failed: #{e.message}" if ENV["DEBUG"]
         nil
       end
-
-      private_class_method def self.safe_read(path)
-        RailsAiContext::SafeFile.read(path)
-      end
-
-      private_class_method def self.max_file_size
-        RailsAiContext.configuration.max_file_size
-      end
     end
   end
 end

--- a/lib/rails_ai_context/tools/get_view.rb
+++ b/lib/rails_ai_context/tools/get_view.rb
@@ -223,10 +223,6 @@ module RailsAiContext
         text_response(lines.join("\n"))
       end
 
-      def self.max_file_size
-        RailsAiContext.configuration.max_file_size
-      end
-
       private_class_method def self.read_view_file(path)
         # Reject path traversal attempts before any filesystem operation
         if path.include?("..") || path.start_with?("/")

--- a/lib/rails_ai_context/tools/search_code.rb
+++ b/lib/rails_ai_context/tools/search_code.rb
@@ -233,10 +233,9 @@ module RailsAiContext
         cmd << pattern
         cmd << search_path
 
-        sensitive = RailsAiContext.configuration.sensitive_patterns
         output, _status = Open3.capture2(*cmd, err: File::NULL)
         parse_rg_output(output, root)
-          .reject { |r| sensitive_file?(r[:file], sensitive) }
+          .reject { |r| sensitive_file?(r[:file]) }
           .first(max_results)
       rescue => e
         [ { file: "error", line_number: 0, content: e.message } ]
@@ -252,14 +251,13 @@ module RailsAiContext
         extensions = RailsAiContext.configuration.search_extensions.join(",")
         glob = file_type ? "**/*.#{file_type}" : "**/*.{#{extensions}}"
         excluded = RailsAiContext.configuration.excluded_paths
-        sensitive = RailsAiContext.configuration.sensitive_patterns
         test_dirs = %w[test/ spec/ features/]
         ai_context_files = %w[CLAUDE.md AGENTS.md .claude/ .cursor/ .cursorrules .github/copilot-instructions.md .github/instructions/ .vscode/mcp.json .codex/ .mcp.json opencode.json .ai-context.json]
 
         Dir.glob(File.join(search_path, glob)).each do |file|
           relative = file.sub("#{root}/", "")
           next if excluded.any? { |ex| relative.start_with?(ex) }
-          next if sensitive_file?(relative, sensitive)
+          next if sensitive_file?(relative)
           next if ai_context_files.any? { |p| relative.start_with?(p) || relative == p }
           next if exclude_tests && test_dirs.any? { |td| relative.start_with?(td) }
 
@@ -276,14 +274,6 @@ module RailsAiContext
         results
       end
 
-      private_class_method def self.sensitive_file?(relative_path, patterns)
-        basename = File.basename(relative_path)
-        flags = File::FNM_DOTMATCH | File::FNM_CASEFOLD
-        patterns.any? do |pattern|
-          File.fnmatch(pattern, relative_path, flags) ||
-            File.fnmatch(pattern, basename, flags)
-        end
-      end
 
       # Group results by file for cleaner output
       private_class_method def self.format_grouped(results)

--- a/lib/rails_ai_context/version.rb
+++ b/lib/rails_ai_context/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiContext
-  VERSION = "5.7.0"
+  VERSION = "5.7.1"
 end

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/crisnahine/rails-ai-context",
     "source": "github"
   },
-  "version": "5.7.0",
+  "version": "5.7.1",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/crisnahine/rails-ai-context/releases/download/v5.7.0/rails-ai-context-mcp.mcpb",
+      "identifier": "https://github.com/crisnahine/rails-ai-context/releases/download/v5.7.1/rails-ai-context-mcp.mcpb",
       "fileSha256": "0000000000000000000000000000000000000000000000000000000000000000",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Internal code quality cleanup — no API changes, no new features, no breaking changes.

- **Extract `safe_read`, `max_file_size`, `sensitive_file?` to BaseTool** — removed 16 duplicate one-liner methods across 8 tool files
- **Extract `FullSerializerBehavior` module** — deduplicated identical `footer` and `architecture_summary` from FullClaudeSerializer/FullOpencodeSerializer
- **Derive `tools_name_list` from `TOOL_ROWS`** — replaced hardcoded 38-tool name array with derivation from single source of truth
- **Fix `notable_gems_list` bypass** — 2 serializers now use the triple-fallback helper
- **Narrow bare `rescue` to `rescue StandardError`** — 4 sites no longer catch `SignalException`/`NoMemoryError`
- **Delete dead `SENSITIVE_PATTERNS = nil` constant**

20 files changed, +79/-155 (net -76 lines).

## Test plan

- [x] Full RSpec suite: 1889 examples, 0 failures (before and after)
- [x] RuboCop: 70 offenses unchanged from baseline (all pre-existing in test_apps/)
- [x] Verified each finding against actual code before fixing
- [x] Smoke-tested after each individual fix (S1/S2, S3, S4, S5, S7, S8, S10)