### PR TITLE
feat: add configurable framework association noise filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added — Framework Association Noise Filter
+
+- **`excluded_association_names` config option** — filters framework-generated associations (ActiveStorage, ActionText, ActionMailbox, Noticed) from model introspection output. 7 association names excluded by default. Configurable via initializer (`config.excluded_association_names += %w[...]`) or YAML. Closes #57.
+
 ## [5.7.1] — 2026-04-09
 
 ### Changed — SLOP Cleanup

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -94,6 +94,7 @@ preset: full
 | `excluded_filters` | Array | 3 framework filters | Controller filters to skip |
 | `excluded_middleware` | Array | 24 framework middleware | Middleware to skip in listing |
 | `excluded_paths` | Array | `["node_modules", "tmp", "log", "vendor", ".git", "doc", "docs"]` | Paths excluded from search |
+| `excluded_association_names` | Array | 7 framework associations | Association names to hide from model output |
 | `excluded_concerns` | Array of Regex | Framework concerns | Concerns to skip (supports regex) |
 
 ### File Size Limits

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1243,6 +1243,9 @@ if defined?(RailsAiContext)
     # Route prefixes hidden with app_only (e.g. admin frameworks)
     # config.excluded_route_prefixes += %w[admin/]
 
+    # Framework association names hidden from model output (ActiveStorage, ActionText, etc.)
+    # config.excluded_association_names += %w[my_custom_framework_assoc]
+
     # Regex patterns for concerns to hide from model output
     # config.excluded_concerns += [/MyInternal::/]
 
@@ -1342,6 +1345,7 @@ end
 | `max_validate_files` | Integer | `50` | Max files per validate call |
 | `excluded_controllers` | Array | `DeviseController`, etc. | Controller classes hidden from listings |
 | `excluded_route_prefixes` | Array | `action_mailbox/`, `active_storage/`, etc. | Route controller prefixes hidden with `app_only` |
+| `excluded_association_names` | Array | 7 framework associations | Framework association names hidden from model output |
 | `excluded_concerns` | Array | framework regex patterns | Regex patterns for concerns to hide from model output |
 | `excluded_filters` | Array | `verify_authenticity_token`, etc. | Framework filter names hidden from controller output |
 | `excluded_middleware` | Array | standard Rails middleware | Default middleware hidden from config output |

--- a/docs/STANDALONE.md
+++ b/docs/STANDALONE.md
@@ -77,6 +77,9 @@ allow_query_in_production: false
 # Filtering
 excluded_models:
   - ApplicationRecord
+excluded_association_names:
+  - active_storage_attachments
+  - active_storage_blobs
 excluded_paths:
   - node_modules
   - tmp

--- a/lib/generators/rails_ai_context/install/install_generator.rb
+++ b/lib/generators/rails_ai_context/install/install_generator.rb
@@ -203,6 +203,10 @@ module RailsAiContext
             # Models to exclude from introspection
             # config.excluded_models += %w[AdminUser InternalThing]
 
+            # Framework association names hidden from model output
+            # (ActiveStorage, ActionText, ActionMailbox, Noticed associations are excluded by default)
+            # config.excluded_association_names += %w[my_custom_framework_assoc]
+
             # Controllers to exclude from listings
             # config.excluded_controllers += %w[Admin::BaseController]
 

--- a/lib/rails_ai_context/configuration.rb
+++ b/lib/rails_ai_context/configuration.rb
@@ -17,7 +17,7 @@ module RailsAiContext
       server_name cache_ttl max_tool_response_chars
       live_reload live_reload_debounce auto_mount http_path http_bind http_port
       output_dir skip_tools excluded_models excluded_controllers
-      excluded_route_prefixes excluded_filters excluded_middleware excluded_paths
+      excluded_route_prefixes excluded_filters excluded_middleware excluded_association_names excluded_paths
       sensitive_patterns search_extensions concern_paths frontend_paths
       max_file_size max_test_file_size max_schema_file_size max_view_total_size
       max_view_file_size max_search_results max_validate_files
@@ -189,12 +189,20 @@ module RailsAiContext
       /\A(Devise::Models|Devise::Orm|Bullet::|Turbo::|GlobalID::|Rolify::)/
     ].freeze
 
+    DEFAULT_EXCLUDED_ASSOCIATION_NAMES = %w[
+      active_storage_attachments active_storage_blobs
+      rich_text_body rich_text_content
+      action_mailbox_inbound_emails
+      noticed_events noticed_notifications
+    ].freeze
+
     # Filtering — customize what's hidden from AI output
     attr_accessor :excluded_controllers   # Controller classes hidden from listings (e.g. DeviseController)
     attr_accessor :excluded_route_prefixes # Route controller prefixes hidden with app_only (e.g. action_mailbox/)
     attr_accessor :excluded_concerns      # Regex patterns for concerns to hide (e.g. /Devise::Models/)
     attr_accessor :excluded_filters       # Framework filter names hidden from controller output
     attr_accessor :excluded_middleware     # Default middleware hidden from config output
+    attr_accessor :excluded_association_names # Framework association names hidden from model output
 
     # Search and file discovery
     attr_accessor :search_extensions      # File extensions for Ruby fallback search (default: rb,js,erb,yml,yaml,json)
@@ -255,6 +263,7 @@ module RailsAiContext
       @excluded_concerns        = DEFAULT_EXCLUDED_CONCERNS.dup
       @excluded_filters         = DEFAULT_EXCLUDED_FILTERS.dup
       @excluded_middleware      = DEFAULT_EXCLUDED_MIDDLEWARE.dup
+      @excluded_association_names = DEFAULT_EXCLUDED_ASSOCIATION_NAMES.dup
       @custom_tools             = []
       @skip_tools               = []
       @ai_tools                 = nil

--- a/lib/rails_ai_context/introspectors/model_introspector.rb
+++ b/lib/rails_ai_context/introspectors/model_introspector.rb
@@ -135,7 +135,8 @@ module RailsAiContext
       # ── Reflection-based extraction (unchanged) ─────────────────────
 
       def extract_associations(model)
-        model.reflect_on_all_associations.map do |assoc|
+        excluded = config.excluded_association_names
+        model.reflect_on_all_associations.reject { |assoc| excluded.include?(assoc.name.to_s) }.map do |assoc|
           detail = {
             name: assoc.name.to_s,
             type: assoc.macro.to_s,

--- a/spec/lib/rails_ai_context/configuration_spec.rb
+++ b/spec/lib/rails_ai_context/configuration_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe RailsAiContext::Configuration do
     expect(config.excluded_models).to include("ActiveStorage::Blob")
   end
 
+  it "excludes framework association names by default" do
+    expect(config.excluded_association_names).to include("active_storage_attachments")
+    expect(config.excluded_association_names).to include("active_storage_blobs")
+    expect(config.excluded_association_names).to include("rich_text_body")
+    expect(config.excluded_association_names).to include("rich_text_content")
+    expect(config.excluded_association_names).to include("action_mailbox_inbound_emails")
+    expect(config.excluded_association_names).to include("noticed_events")
+    expect(config.excluded_association_names).to include("noticed_notifications")
+  end
+
+  it "allows adding custom excluded association names" do
+    config.excluded_association_names += %w[custom_assoc]
+    expect(config.excluded_association_names).to include("custom_assoc")
+    expect(config.excluded_association_names).to include("active_storage_attachments")
+  end
+
   it "is configurable" do
     config.server_name = "my-app"
     config.http_port = 8080

--- a/spec/lib/rails_ai_context/configuration_yaml_spec.rb
+++ b/spec/lib/rails_ai_context/configuration_yaml_spec.rb
@@ -96,6 +96,19 @@ RSpec.describe RailsAiContext::Configuration, "YAML loading" do
       end
     end
 
+    it "sets excluded_association_names from YAML" do
+      Dir.mktmpdir do |dir|
+        yaml_path = File.join(dir, ".rails-ai-context.yml")
+        File.write(yaml_path, YAML.dump({
+          "excluded_association_names" => %w[custom_assoc other_assoc]
+        }))
+
+        RailsAiContext::Configuration.load_from_yaml(yaml_path)
+
+        expect(config.excluded_association_names).to eq(%w[custom_assoc other_assoc])
+      end
+    end
+
     it "ignores unknown keys" do
       Dir.mktmpdir do |dir|
         yaml_path = File.join(dir, ".rails-ai-context.yml")

--- a/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe RailsAiContext::Introspectors::ModelIntrospector do
       expect(assocs).to include(a_hash_including(name: "user", type: "belongs_to"))
     end
 
+    it "filters associations listed in excluded_association_names" do
+      RailsAiContext.configuration.excluded_association_names += %w[comments]
+
+      filtered = introspector.call
+      user_assoc_names = filtered["User"][:associations].map { |a| a[:name] }
+      expect(user_assoc_names).to include("posts")
+      expect(user_assoc_names).not_to include("comments")
+    ensure
+      RailsAiContext.configuration = RailsAiContext::Configuration.new
+    end
+
     it "extracts validations" do
       vals = result["User"][:validations]
       expect(vals).to include(a_hash_including(kind: "presence", attributes: [ "email" ]))


### PR DESCRIPTION
## Summary

- Adds `config.excluded_association_names` to filter framework-generated associations from model introspection output
- 7 default exclusions: `active_storage_attachments`, `active_storage_blobs`, `rich_text_body`, `rich_text_content`, `action_mailbox_inbound_emails`, `noticed_events`, `noticed_notifications`
- Completes the filtering stack: models → concerns → methods → **associations** (the one remaining gap)

Closes #57.

## Changes

- `configuration.rb` — new `DEFAULT_EXCLUDED_ASSOCIATION_NAMES` constant, `attr_accessor`, default initialization, YAML key allowlist
- `model_introspector.rb` — `.reject` filter in `extract_associations`
- `install_generator.rb` — commented config option in Models & Filtering section
- 3 new specs (config defaults, YAML loading, introspector filtering) — all pass
- Docs: CONFIGURATION.md, GUIDE.md, STANDALONE.md, CHANGELOG.md

## Test plan

- [x] 1893 specs pass (4 new)
- [x] RuboCop clean (source files)
- [x] Config defaults include all 7 framework association names
- [x] YAML loading overrides defaults correctly
- [x] `extract_associations` filters excluded names from output
- [x] `+=` pattern works for additive customization