### PR TITLE
docs: clarify detail param does not apply to composite tools

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -81,7 +81,7 @@ config.skip_tools = %w[rails_security_scan rails_query]
 
 ### What's the `detail` parameter?
 
-Most tools accept `detail`: `summary` (compact), `standard` (default), `full` (everything). Start with summary and drill down as needed. This keeps AI context windows lean.
+Individual lookup tools accept `detail`: `summary` (compact), `standard` (default), `full` (everything). Start with summary and drill down as needed. This keeps AI context windows lean. Composite tools (`rails_get_context`, `rails_analyze_feature`) do not accept `detail` — they always return their full bundled output.
 
 ### What are `[VERIFIED]` and `[INFERRED]` tags?
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -43,7 +43,7 @@ Tool name resolution is flexible — all of these work:
 | `get_schema` | `rails_get_schema` |
 | `rails_get_schema` | `rails_get_schema` |
 
-Most tools accept a **`detail`** parameter: `summary` (compact), `standard` (default), or `full` (everything). Start with summary, drill down as needed.
+Individual lookup tools accept a **`detail`** parameter: `summary` (compact), `standard` (default), or `full` (everything). Start with summary, drill down as needed. Composite tools (`rails_get_context`, `rails_analyze_feature`) do not accept `detail`.
 
 <p align="right"><a href="#table-of-contents">↑ back to top</a></p>
 


### PR DESCRIPTION
## Summary
- Mirrors the helper-text fix from #70 (osbre) in the two hand-maintained docs files
- `docs/TOOLS.md` and `docs/FAQ.md` both said "Most tools accept `detail`" — the same inaccuracy #70 corrects in `tool_guide_helper.rb`
- Composite tools (`rails_get_context`, `rails_analyze_feature`) do not declare a `detail` property in their `input_schema` and will return `Unknown param: 'detail'` if one is passed

## Test plan
- [x] Verified `tools/get_context.rb` and `tools/analyze_feature.rb` `input_schema` does not include `detail`
- [x] No code references the old wording — these are static docs, not generated