### PR TITLE
fix: remove default output_schema rejected by strict MCP clients (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.7.2] — 2026-04-14
+
+### Fixed — MCP Tool Responses Rejected by Strict Clients (#69)
+
+- **Removed default `output_schema` from all 38 tools.** Since v5.4.0, `BaseTool.inherited` automatically assigned a `DEFAULT_OUTPUT_SCHEMA` to every tool. The schema described the response wire envelope (`{content: [...]}`) rather than app-level structured data, and tools never returned matching `structured_content`. Per MCP spec, when a tool declares `outputSchema`, it MUST return `structuredContent` matching it. Strict MCP clients (e.g. Copilot CLI) reject responses that don't, with `MCP error -32600: Tool ... has an output schema but did not return structured content`. Lenient clients (Claude Code, Cursor) silently ignored the missing field, which is why the bug went unnoticed since v5.4.0.
+- **Why this happened.** The MCP Ruby SDK does not enforce `output_schema` server-side (no `validate_result` call in `MCP::Server`), so the test suite passed end-to-end. Validation happens client-side, and only strict clients caught it. Reported by @pardeyke.
+- **What changed.** Deleted `DEFAULT_OUTPUT_SCHEMA` constant and the `inherited` hook line that set it (`lib/rails_ai_context/tools/base_tool.rb`). Tools now ship with no `outputSchema` by default — matching what they actually return (text-only). Individual tools can still declare their own `output_schema` via the MCP::Tool DSL, provided they also return matching `structured_content`.
+- **Regression spec added.** `spec/lib/rails_ai_context/tools_spec.rb` now asserts (a) no tool advertises a default `outputSchema`, and (b) any tool that *does* declare one must also have `structured_content:` in its source — preventing the v5.4.0 misuse from sneaking back in.
+- **Future enhancement.** Per-tool structured output (returning parseable JSON alongside the Markdown text via `structured_content:`) is a future feature for tools where it adds value (`get_schema`, `get_routes`, etc.). Out of scope for this patch.
 
 ### Added — Framework Association Noise Filter
 

--- a/lib/rails_ai_context/tools/base_tool.rb
+++ b/lib/rails_ai_context/tools/base_tool.rb
@@ -8,27 +8,6 @@ module RailsAiContext
     # Inherits from the official MCP::Tool to get schema validation,
     # annotations, and protocol compliance for free.
     class BaseTool < MCP::Tool
-      # Default output schema for all tools. MCP::Tool.inherited resets
-      # @output_schema_value to nil on each subclass, so we re-set it
-      # via our own inherited hook.
-      DEFAULT_OUTPUT_SCHEMA = MCP::Tool::OutputSchema.new(
-        type: "object",
-        properties: {
-          content: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                type: { type: "string", enum: [ "text" ] },
-                text: { type: "string", description: "Tool response as Markdown-formatted text" }
-              },
-              required: [ "type", "text" ]
-            }
-          }
-        },
-        required: [ "content" ]
-      ).freeze
-
       # ── Auto-registration ────────────────────────────────────────────
       # Every subclass is tracked automatically via inherited.
       # BaseTool itself is abstract — only concrete tools are registered.
@@ -39,7 +18,6 @@ module RailsAiContext
 
       def self.inherited(subclass)
         super
-        subclass.instance_variable_set(:@output_schema_value, DEFAULT_OUTPUT_SCHEMA)
         subclass.instance_variable_set(:@abstract, false)
         # Thread-safe append. Mutex is NOT held during eager_load!'s const_get
         # (which triggers inherited), so no recursive locking risk here.

--- a/lib/rails_ai_context/version.rb
+++ b/lib/rails_ai_context/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiContext
-  VERSION = "5.7.1"
+  VERSION = "5.7.2"
 end

--- a/spec/lib/rails_ai_context/tools_spec.rb
+++ b/spec/lib/rails_ai_context/tools_spec.rb
@@ -21,15 +21,43 @@ RSpec.describe "MCP Tool Integration" do
           expect(annotations.destructive_hint).to eq(false)
         end
 
-        it "has an output_schema defined" do
+        it "does not declare a default output_schema (issue #69)" do
+          # Declaring an outputSchema without returning structured_content violates
+          # the MCP spec — strict clients (e.g. Copilot CLI) reject the response
+          # with "MCP error -32600: Tool ... has an output schema but did not
+          # return structured content". Tools that return only text MUST NOT
+          # advertise an outputSchema. See issue #69.
           schema = tool_class.instance_variable_get(:@output_schema_value)
-          expect(schema).not_to be_nil
-          expect(schema).to be_a(MCP::Tool::OutputSchema)
+          expect(schema).to be_nil
 
           h = tool_class.to_h
-          expect(h).to have_key(:outputSchema)
+          expect(h).not_to have_key(:outputSchema)
         end
       end
+    end
+
+    # Stronger contract regression: if a future tool legitimately declares an
+    # output_schema, its source MUST also return structured_content. Catches
+    # the v5.4.0 mistake (issue #69) from sneaking back in.
+    it "any tool declaring output_schema must also return structured_content" do
+      offenders = RailsAiContext::Server.builtin_tools.filter_map do |tool_class|
+        schema = tool_class.instance_variable_get(:@output_schema_value)
+        next if schema.nil?
+
+        source_file = tool_class.method(:call).source_location&.first
+        next unless source_file && File.exist?(source_file)
+
+        source = File.read(source_file)
+        next if source.include?("structured_content:")
+
+        tool_class.tool_name
+      end
+
+      expect(offenders).to be_empty,
+        "These tools declare output_schema but never pass structured_content: " \
+        "in their source. Per MCP spec, when outputSchema is set, the response " \
+        "MUST include matching structured_content. See issue #69. Offenders: " \
+        "#{offenders.join(', ')}"
     end
   end
 


### PR DESCRIPTION
## Summary

Closes #69. Removes the `DEFAULT_OUTPUT_SCHEMA` that has been auto-applied to every tool since v5.4.0. The schema described the response wire envelope rather than app-level structured data, and tools never returned matching `structured_content`. Strict MCP clients (Copilot CLI) reject the responses with `MCP error -32600: Tool ... has an output schema but did not return structured content`.

## Root cause

`base_tool.rb:14-30` defined `DEFAULT_OUTPUT_SCHEMA` and `:42` re-assigned it on every subclass via `inherited`. The schema was conceptually wrong — it described `{content: [{type, text}]}` (the wire envelope MCP itself defines) instead of app-level data that should go in `structuredContent`. Per [MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content), declaring `outputSchema` is a **contract**: the tool MUST return matching `structuredContent`. Our tools route through `text_response` → `MCP::Tool::Response.new([...])` with no `structured_content:` keyword, so the wire response has only `content`.

## Why it went unnoticed since v5.4.0

The MCP Ruby SDK does not enforce `output_schema` server-side — there is no `validate_result` call in `MCP::Server` (only `input_schema.validate_arguments` is invoked). So the test suite passed end-to-end. Validation happens **client-side**:

- **Lenient MCP clients** silently ignored the missing `structuredContent` → no error surfaced.
- **Strict clients** (Copilot CLI, reported by @pardeyke) validate against the advertised `outputSchema` and reject → `-32600`.

I grepped both `mcp 0.10.0` (current Gemfile.lock) and `mcp 0.12.0` (Ruby 4.0.2 user) for the error string `"did not return structured"` — zero hits in either. The error originates client-side.

## What changed

- **`lib/rails_ai_context/tools/base_tool.rb`** — Deleted `DEFAULT_OUTPUT_SCHEMA` constant (lines 11-30) and the `inherited` hook line that set it (line 42). `MCP::Tool.inherited` already resets `@output_schema_value = nil` for every subclass, so removing our re-set leaves it `nil`. `MCP::Tool#to_h` uses `.compact` and cleanly omits the field from the wire definition.
- **`spec/lib/rails_ai_context/tools_spec.rb`** — Flipped the per-tool spec to assert no default `outputSchema`. **Added a contract regression spec** that catches the v5.4.0 mistake from sneaking back: any tool declaring `output_schema` must also have `structured_content:` in its source file. Allows future per-tool structured output, blocks the broken pattern.
- **`lib/rails_ai_context/version.rb`** — Bumped to `5.7.2`.
- **`CHANGELOG.md`** — Honest entry under v5.7.2 explaining the original misuse, the latency, and the future work.

## Verification

- `bundle exec rspec` → **1894 examples, 0 failures** (was 1893; +1 from the new contract regression spec)
- `bundle exec rubocop` on the 4 changed files → **0 offenses**
- Targeted run with `--format documentation` confirmed all 38 per-tool `does not declare a default output_schema (issue #69)` examples executed (no ghost-passing) plus the new contract spec
- Manually verified `MCP::Tool::Response#to_h` with `structured_content: nil` produces `{content: [...], isError: false}` — no `structuredContent` key, matching what the wire format will now look like for every tool

## Blast radius — full grep

Only **3 files** in the entire repo reference `output_schema`/`outputSchema`/`structured_content`:
- `lib/rails_ai_context/tools/base_tool.rb` — fixed
- `spec/lib/rails_ai_context/tools_spec.rb` — fixed
- `CHANGELOG.md` — historical v5.4.0 entry left intact (history)

Zero references in `server.rb`, `resources.rb`, `vfs.rb`, the 38 tool files, serializers, or docs. The fix is fully self-contained.

## What's NOT changed (and why)

The CHANGELOG entry at v5.4.0 (line 120) advertised "output_schema on all 38 tools" as a feature. I left it in the changelog (history is history) but the v5.7.2 entry is honest about the misuse. Per-tool structured output (returning parseable JSON in `structured_content` for tools like `get_schema`, `get_routes`) is a real future enhancement — out of scope for this patch.

## Test plan

- [x] Full rspec suite (1894 examples, 0 failures)
- [x] Rubocop clean
- [x] New contract regression spec passes
- [x] No tool advertises `outputSchema` in its `to_h`
- [x] `text_response("hello").to_h` produces no `structuredContent` key
- [x] `Server.new(app).build` succeeds with all 38 tools
- [ ] Manual smoke test from a strict client (Copilot CLI) — recommended before tagging the release