### PR TITLE
fix: rails_query crashes with NameError on api-only Rails apps

### DIFF
--- a/lib/rails_ai_context/tools/query.rb
+++ b/lib/rails_ai_context/tools/query.rb
@@ -70,6 +70,20 @@ module RailsAiContext
           )
         end
 
+        # ── ActiveRecord guard (api-only apps) ──────────────────────
+        # Must come BEFORE any code that rescues ActiveRecord::* — Ruby
+        # resolves rescue class constants at raise time, and `rescue
+        # ActiveRecord::ConnectionNotEstablished` crashes with NameError
+        # on apps where ActiveRecord is not loaded (e.g.
+        # `rails new --api --skip-active-record`).
+        unless defined?(ActiveRecord::Base)
+          return text_response(
+            "Database queries are unavailable: ActiveRecord is not loaded in this app. " \
+            "This happens on API-only apps created with `rails new --api --skip-active-record`. " \
+            "rails_query requires a database connection to function."
+          )
+        end
+
         # ── Layer 1: SQL validation ─────────────────────────────────
         valid, error = validate_sql(sql)
         return text_response(error) unless valid

--- a/spec/lib/rails_ai_context/tools/query_spec.rb
+++ b/spec/lib/rails_ai_context/tools/query_spec.rb
@@ -542,4 +542,28 @@ RSpec.describe RailsAiContext::Tools::Query do
       expect(text).to include('"line1')
     end
   end
+
+  describe "graceful degradation when ActiveRecord is not loaded" do
+    # Simulates `rails new --api --skip-active-record` where Ruby cannot
+    # resolve `ActiveRecord::*` rescue constants at raise time, causing a
+    # NameError unless the tool guards the entry point. See the edge-case
+    # verification report from v5.8.0 pre-release E2E.
+    it "returns a friendly message instead of crashing with NameError" do
+      result = with_activerecord_hidden { described_class.call(sql: "SELECT 1") }
+      text = result.content.first[:text]
+      expect(text).to include("Database queries are unavailable")
+      expect(text).to include("ActiveRecord is not loaded")
+      expect(text).to include("--skip-active-record")
+    end
+
+    # Temporarily hides the top-level `ActiveRecord` constant so
+    # `defined?(ActiveRecord::Base)` returns nil inside the block. Restores
+    # it in an ensure regardless of exceptions raised by the block.
+    def with_activerecord_hidden
+      saved = Object.send(:remove_const, :ActiveRecord) if Object.const_defined?(:ActiveRecord)
+      yield
+    ensure
+      Object.const_set(:ActiveRecord, saved) if saved
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`rails_query` crashed with `NameError: uninitialized constant RailsAiContext::Tools::Query::ActiveRecord` at `query.rb:102` when called on a Rails app created with `rails new --api --skip-active-record`. Violates the gem's "graceful degradation — works without DB" promise.

Discovered by the v5.8.0 pre-release edge-case verification agent on a fresh api-only Rails 8 app. Every other introspector and tool degraded cleanly on that same app — only `query` crashed. **This lands in v5.8.0 (not yet tagged or published to RubyGems)** so the release ships without the known crash.

## Root cause

Ruby resolves `rescue` class constants at raise time, not at parse time. The rescue clause

```ruby
rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError => e
```

at `query.rb:102` crashes with `NameError` whenever the body raises any exception on a Rails app where `ActiveRecord` is not loaded. Observed crash (captured in the edge-case verification report):

```
NameError: uninitialized constant RailsAiContext::Tools::Query::ActiveRecord
/.../lib/rails_ai_context/tools/query.rb:102:in 'RailsAiContext::Tools::Query.call'
```

## Fix

Added an early guard at the top of `Query.call` that returns a friendly "Database queries are unavailable" message when `defined?(ActiveRecord::Base)` is false. The guard runs BEFORE any code that rescues `ActiveRecord::*`, so Ruby never has to resolve the rescue constants on api-only apps.

## Test

Added a spec under `"graceful degradation when ActiveRecord is not loaded"` that hides the top-level `ActiveRecord` constant via `Object.send(:remove_const, :ActiveRecord)` (with restoration in an `ensure` block) and asserts the tool returns the friendly message instead of crashing.

**Empirically verified via TDD:**
- Temporarily reverted `query.rb` → spec fails with the exact `NameError` at line 102
- Restored the fix → spec passes

## Verification

- `bundle exec rspec` → **1926 examples, 0 failures** (was 1925 on main, +1 new regression test)
- `bundle exec rubocop` on changed files → **0 offenses**

## Test plan

- [x] New spec fails against the buggy code (proves the bug is real)
- [x] New spec passes with the fix applied
- [x] Full rspec suite: 1926/1926
- [x] Rubocop clean
- [x] Behavior on normal apps (with AR) is unchanged — the guard only fires when AR is genuinely absent

## Release gate for v5.8.0

v5.8.0 is merged to `main` (PR #73) but has NOT been tagged or pushed to RubyGems. This PR merges into `main` and becomes part of the v5.8.0 release. After merging, the tag + publish should happen from the merged state.