### PR TITLE
fix: v5.8.1 security hardening + hot-path perf + coverage gaps (multi-round review)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4"]
-        rails: ["7.1", "7.2", "8.0"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        rails: ["7.1", "7.2", "8.0", "8.1"]
         exclude:
+          # Rails 8.x requires Ruby 3.3+
           - ruby: "3.2"
             rails: "8.0"
+          - ruby: "3.2"
+            rails: "8.1"
+          # Rails 7.x is not Ruby 4.0 compatible (no upstream support)
+          - ruby: "4.0"
+            rails: "7.1"
+          - ruby: "4.0"
+            rails: "7.2"
 
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,23 @@ Four exploitable vulnerabilities across `rails_query`, the VFS URI dispatcher, a
 
 - `.github/workflows/release.yml` test matrix was still on the old Ruby `3.2/3.3/3.4` × Rails `7.1/7.2/8.0` grid even though `ci.yml` was expanded to cover Ruby 4.0 and Rails 8.1 in v5.8.0. Now synced — release-time testing matches PR-time testing across all 12 combos, including the #69 reporter's environment (Ruby 4.0.2 + Rails 8.1.3).
 
+### Fixed — Pre-release review pass (rounds 2–3)
+
+Five additional issues found during multi-round cold-eyes security and correctness review after the initial hardening pass.
+
+- **`search_code` sibling-directory path traversal.** `rails_search_code`'s `path` parameter used `real_search.start_with?(real_root)` without a `File::SEPARATOR` suffix — the same bypass class as the original VFS C1 bug. A Rails root of `/app/myapp` would accept a search path whose realpath is `/app/myapp_evil`. **Fix:** changed to `real_search == real_root || real_search.start_with?(real_root + File::SEPARATOR)`. Spec added.
+
+- **Instrumentation callback: `data[:method]` extraction outside `begin/rescue`.** Two lines before the `begin` block (`method = data[:method]` and `event_name = ...`) were not covered by the rescue. A non-Hash `data` argument from the MCP SDK would raise `NoMethodError` which would propagate into the SDK's `ensure` context and overwrite the tool's return value. **Fix:** moved `begin` to wrap the full lambda body after the early-exit guard.
+
+- **`get_partial_interface` TOCTOU gap (residual from initial hardening).** `resolve_partial_path` performed the `File.realpath` security check internally but returned the original glob `found` path to the caller. The caller then called `File.size(found)` and `safe_read(found)` — creating a sub-millisecond race window where a symlink swap could read from a path that bypassed the check. **Fix:** `resolve_partial_path` now returns `real_found`. All file operations in the caller use the pre-checked realpath.
+
+- **`validate` tool passed pre-realpath path to validators.** `validate_ruby`, `validate_erb`, `validate_javascript`, and `check_rails_semantics` all received `full_path` (pre-realpath) after the security check resolved `real`. **Fix:** all four now receive `Pathname.new(real)`.
+
+- **`rails_query` `LOAD DATA INFILE` not explicitly blocked.** Added `LOAD\s+DATA` to `BLOCKED_FUNCTIONS`. Belt-and-suspenders: `ALLOWED_PREFIX` already blocks it at statement level, but the explicit entry makes intent self-documenting. Two specs added (`LOAD DATA INFILE` and `LOAD DATA LOCAL INFILE`).
+
 ### Test coverage
 
-- **1989 examples, 0 failures** (was 1928 in v5.8.0, +61 new regression tests across the security + hardening + empty-schema + VFS + instrumentation fixes).
+- **2004 examples, 0 failures** (was 1928 in v5.8.0, +76 new regression tests across the security + hardening + empty-schema + VFS + instrumentation + review-pass fixes).
 
 ## [5.8.0] — 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.8.1] — 2026-04-15
+
+### Fixed — Security Hardening
+
+Two exploitable vulnerabilities in `rails_query` and four defense-in-depth hardening issues. All discovered by an adversarial security review conducted during v5.8.1 pre-release verification. None were known at the v5.8.0 release — users should upgrade immediately.
+
+- **SQL column-aliasing redaction bypass (exploitable).** Post-execution redaction in `rails_query` operated on `result.columns` (the DB-returned column names), which the caller controls via aliases and expressions. `SELECT password_digest AS x FROM users` returned raw bcrypt hashes. Same for `SELECT substring(password_digest, 1, 60) FROM users` (column named `substring`), `SELECT md5(session_data) FROM sessions`, `SELECT CASE WHEN id > 0 THEN password_digest END FROM users`, and subqueries that re-project the sensitive column. **Fix:** moved enforcement to pre-execution in `validate_sql`. Any query that textually references a column name in `config.query_redacted_columns` OR the hard-coded `SENSITIVE_COLUMN_SUFFIXES` list (password_digest, encrypted_password, password_hash, reset_password_token, api_key, refresh_token, otp_secret, session_data, secret_key, private_key, etc.) is now rejected. Users with a legitimately non-sensitive column matching one of these names can subtract from `config.query_redacted_columns` in an initializer. **8 bypass scenarios covered by new specs.**
+
+- **Arbitrary filesystem read via database functions (exploitable).** `rails_query` did not block PostgreSQL's `pg_read_file`, `pg_read_binary_file`, `pg_ls_dir`, `pg_stat_file`, `lo_import`/`lo_export`, `dblink`, MySQL's `LOAD_FILE`, `SELECT ... INTO OUTFILE/DUMPFILE`, or SQLite's `load_extension`. These are SELECT-callable (so they pass the `BLOCKED_KEYWORDS` scanner and `SET TRANSACTION READ ONLY`) but give the caller a filesystem and shared-library-load primitive — completely bypassing the gem's `sensitive_patterns` allowlist by pivoting through the database process. PoC: `SELECT pg_read_file('/etc/passwd')`, `SELECT pg_read_file('config/master.key')`. **Fix:** added a `BLOCKED_FUNCTIONS` regex and `BLOCKED_OUTPUT` pattern that reject any query referencing these built-ins. **10 function-specific specs added.**
+
+- **`sensitive_patterns` default list expanded.** The v5.8.0 default list covered `.env`, `.env.*`, `config/master.key`, `config/credentials*.yml.enc`, `*.pem`, `*.key` but missed common secret locations. v5.8.1 adds `config/database.yml`, `config/secrets.yml`, `config/cable.yml`, `config/storage.yml`, `config/mongoid.yml`, `config/redis.yml`, `*.p12`, `*.pfx`, `*.jks`, `*.keystore`, `**/id_rsa`, `**/id_ed25519`, `**/id_ecdsa`, `**/id_dsa`, `.ssh/*`, `.aws/credentials`, `.aws/config`, `.netrc`, `.pgpass`, `.my.cnf`.
+
+- **`get_edit_context` now re-checks `sensitive_file?` after realpath resolution.** The initial check ran on the caller-supplied string; a symlink inside `app/models/` pointing at `config/master.key` previously passed the basename check and fell through to `File.read`. The post-realpath check blocks this.
+
+- **`validate` now enforces `sensitive_file?`.** The validate tool had no sensitive-file check at all. Even though its output is limited to error messages (not raw content), it still leaked file existence/size and ran readers on secret files. Now denied with an `access denied (sensitive file)` error.
+
+- **`BaseTool.sensitive_file?` has direct spec coverage for the first time.** The security boundary behind every file-accepting tool had zero direct tests in v5.8.0 — 36 new specs added covering the Rails secret locations, the v5.8.1 expanded pattern list, private keys and certificates, case-insensitivity, basename-only matching, and custom pattern configurations.
+
+### Performance — Hot-Path Optimization
+
+- **`cached_context` TTL short-circuit.** The hot path of every tool call ran `Fingerprinter.changed?` on every hit, which walks every `*.{rb,rake,js,ts,erb,haml,slim,yml}` file in `WATCHED_DIRS` plus (for path:-installed users) every file in the gem's own lib/ tree — doing an `mtime` stat per file. Measured at ~12ms per call in dev-mode path installs, ~0.5ms in production. Since LiveReload fires `reset_all_caches!` on actual file-change events, stale-cache risk during a short TTL window is already covered. **Fix:** skip the fingerprint check entirely when within the TTL window. When TTL expires, re-fingerprint; if unchanged, bump the timestamp and reuse the cached context (avoiding a 31-introspector re-run).
+
+- **Fingerprinter gem-lib scan memoized.** For users who install the gem via `path:` (common for gem contributors, monorepos, the standalone dev workflow), the fingerprinter was walking 123 gem-lib files on every tool call. Memoized at class level with a `reset_gem_lib_fingerprint!` hook that `BaseTool.reset_cache!` and LiveReload invoke.
+
+- **Measured result:** `cached_context` hot-path benchmark dropped from **11.77ms to 0.199ms** per call — a **~59x speedup** on dev-mode path installs. In-Gemfile / production users see a smaller but still meaningful improvement (0.77ms → 0.199ms).
+
+### Fixed — schema.rb empty-file wrinkle
+
+- `SchemaIntrospector#static_schema_parse` returned `{ error: "No db/schema.rb, db/structure.sql, or migrations found" }` when `db/schema.rb` existed but contained zero `create_table` calls (common on freshly-created Rails apps between `db:create` and the first migration). Now returns `{ total_tables: 0, tables: {}, note: "Schema file exists but is empty — no migrations have been run yet..." }`.
+
+### Changed — CI release matrix synced to PR matrix
+
+- `.github/workflows/release.yml` test matrix was still on the old Ruby `3.2/3.3/3.4` × Rails `7.1/7.2/8.0` grid even though `ci.yml` was expanded to cover Ruby 4.0 and Rails 8.1 in v5.8.0. Now synced — release-time testing matches PR-time testing across all 12 combos, including the #69 reporter's environment (Ruby 4.0.2 + Rails 8.1.3).
+
+### Test coverage
+
+- **1982 examples, 0 failures** (was 1928 in v5.8.0, +54 new regression tests across the security + hardening + empty-schema fixes).
+
 ## [5.8.0] — 2026-04-14
 
 ### Added — Modern Rails Coverage Pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed — Security Hardening
 
-Two exploitable vulnerabilities in `rails_query` and four defense-in-depth hardening issues. All discovered by an adversarial security review conducted during v5.8.1 pre-release verification. None were known at the v5.8.0 release — users should upgrade immediately.
+Four exploitable vulnerabilities across `rails_query`, the VFS URI dispatcher, and the instrumentation bridge, plus six defense-in-depth hardening issues. All discovered by security and deep code-review passes conducted during v5.8.1 pre-release verification. None were known at the v5.8.0 release — **users should upgrade immediately**.
 
 - **SQL column-aliasing redaction bypass (exploitable).** Post-execution redaction in `rails_query` operated on `result.columns` (the DB-returned column names), which the caller controls via aliases and expressions. `SELECT password_digest AS x FROM users` returned raw bcrypt hashes. Same for `SELECT substring(password_digest, 1, 60) FROM users` (column named `substring`), `SELECT md5(session_data) FROM sessions`, `SELECT CASE WHEN id > 0 THEN password_digest END FROM users`, and subqueries that re-project the sensitive column. **Fix:** moved enforcement to pre-execution in `validate_sql`. Any query that textually references a column name in `config.query_redacted_columns` OR the hard-coded `SENSITIVE_COLUMN_SUFFIXES` list (password_digest, encrypted_password, password_hash, reset_password_token, api_key, refresh_token, otp_secret, session_data, secret_key, private_key, etc.) is now rejected. Users with a legitimately non-sensitive column matching one of these names can subtract from `config.query_redacted_columns` in an initializer. **8 bypass scenarios covered by new specs.**
 
@@ -22,6 +22,18 @@ Two exploitable vulnerabilities in `rails_query` and four defense-in-depth harde
 - **`validate` now enforces `sensitive_file?`.** The validate tool had no sensitive-file check at all. Even though its output is limited to error messages (not raw content), it still leaked file existence/size and ran readers on secret files. Now denied with an `access denied (sensitive file)` error.
 
 - **`BaseTool.sensitive_file?` has direct spec coverage for the first time.** The security boundary behind every file-accepting tool had zero direct tests in v5.8.0 — 36 new specs added covering the Rails secret locations, the v5.8.1 expanded pattern list, private keys and certificates, case-insensitivity, basename-only matching, and custom pattern configurations.
+
+- **VFS `resolve_view` sibling-directory path traversal (exploitable).** The `rails-ai-context://views/{path}` URI resolver used bare `String#start_with?` on the realpath without a `File::SEPARATOR` suffix check. `/app/views_spec/secret.erb` matched `/app/views` as a prefix, so a symlink inside `app/views/` pointing at a sibling directory escaped containment and returned arbitrary file content. **Fix:** changed the containment check to `real == base || real.start_with?(base + File::SEPARATOR)`. Also added a `sensitive_file?` realpath check mirroring the v5.8.1 `get_edit_context` fix, so `.env`/`.key` symlinks inside `app/views/` are rejected. **2 new regression specs covering both PoCs.**
+
+- **Instrumentation bridge leaks raw tool arguments to ActiveSupport::Notifications subscribers (exploitable).** `Instrumentation.callback` forwarded the MCP SDK's full data hash to `ActiveSupport::Notifications.instrument`. The SDK's `add_instrumentation_data(tool_name:, tool_arguments:)` includes raw tool inputs — so every Rails observability subscriber (Datadog, Scout, New Relic, custom loggers) received `rails_query`'s raw SQL, `rails_get_env`'s env var names, and `rails_read_logs`'s search patterns unredacted. The response-side redaction each of those tools carefully implements did nothing for the request side. **Fix:** introduced `Instrumentation::SAFE_KEYS` (`method`, `tool_name`, `duration`, `error`, `resource_uri`, `prompt_name`) — only those fields are forwarded. Users who need arguments in observability can set `config.instrumentation_include_arguments = true` in an initializer (taking on the redaction obligation). **3 new regression specs.**
+
+- **Instrumentation subscriber failures could crash tool calls (exploitable).** The MCP SDK's `instrument_call` invokes our callback from an `ensure` block. Any exception raised inside the callback (e.g. a custom subscriber bug, a Datadog client losing connection) would propagate out of `ensure` and overwrite the tool's actual return value — effectively failing every tool call whenever any subscriber was broken. **Fix:** wrapped the `Notifications.instrument` call in a `rescue => e` block. Subscriber failures now log to stderr under `DEBUG=1` instead of corrupting tool responses. **1 new regression spec.**
+
+- **`analyze_feature` caps per-directory file scans at 500 files.** `discover_services`, `discover_jobs`, and `discover_views` previously ran unbounded `Dir.glob` + `SafeFile.read` on every match, which on large monorepos could read thousands of files per call. Matches the existing cap used by `discover_tests`. Tool output notes when the cap was hit so the AI agent knows to narrow its feature keyword.
+
+### Added — Configuration
+
+- **`config.instrumentation_include_arguments`** (default `false`) — controls whether raw tool arguments are forwarded to `ActiveSupport::Notifications` subscribers. See the Security Hardening note above for the opt-in risk.
 
 ### Performance — Hot-Path Optimization
 
@@ -41,7 +53,7 @@ Two exploitable vulnerabilities in `rails_query` and four defense-in-depth harde
 
 ### Test coverage
 
-- **1982 examples, 0 failures** (was 1928 in v5.8.0, +54 new regression tests across the security + hardening + empty-schema fixes).
+- **1989 examples, 0 failures** (was 1928 in v5.8.0, +61 new regression tests across the security + hardening + empty-schema + VFS + instrumentation fixes).
 
 ## [5.8.0] — 2026-04-14
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <br>
 [![Ruby](https://img.shields.io/badge/Ruby-3.2%20%7C%203.3%20%7C%203.4-CC342D)](https://github.com/crisnahine/rails-ai-context)
 [![Rails](https://img.shields.io/badge/Rails-7.1%20%7C%207.2%20%7C%208.0-CC0000)](https://github.com/crisnahine/rails-ai-context)
-[![Tests](https://img.shields.io/badge/Tests-1925%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
+[![Tests](https://img.shields.io/badge/Tests-1982%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>
@@ -543,7 +543,7 @@ end
 ## About
 
 Built by a Rails developer with 10+ years of production experience.<br>
-1925 tests. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
+1982 tests. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
 MIT licensed. [Contributions welcome.](CONTRIBUTING.md)
 
 <br>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <br>
 [![Ruby](https://img.shields.io/badge/Ruby-3.2%20%7C%203.3%20%7C%203.4-CC342D)](https://github.com/crisnahine/rails-ai-context)
 [![Rails](https://img.shields.io/badge/Rails-7.1%20%7C%207.2%20%7C%208.0-CC0000)](https://github.com/crisnahine/rails-ai-context)
-[![Tests](https://img.shields.io/badge/Tests-1982%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
+[![Tests](https://img.shields.io/badge/Tests-1989%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>
@@ -543,7 +543,7 @@ end
 ## About
 
 Built by a Rails developer with 10+ years of production experience.<br>
-1982 tests. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
+1989 tests. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
 MIT licensed. [Contributions welcome.](CONTRIBUTING.md)
 
 <br>

--- a/docs/social-preview.html
+++ b/docs/social-preview.html
@@ -144,7 +144,7 @@
         <div class="stat-label">Introspectors</div>
       </div>
       <div class="stat">
-        <div class="stat-number">1925</div>
+        <div class="stat-number">1982</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat">

--- a/docs/social-preview.html
+++ b/docs/social-preview.html
@@ -144,7 +144,7 @@
         <div class="stat-label">Introspectors</div>
       </div>
       <div class="stat">
-        <div class="stat-number">1982</div>
+        <div class="stat-number">1989</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat">

--- a/lib/rails_ai_context/configuration.rb
+++ b/lib/rails_ai_context/configuration.rb
@@ -229,8 +229,15 @@ module RailsAiContext
       @introspectors       = PRESETS[:full].dup
       @excluded_paths      = %w[node_modules tmp log vendor .git doc docs]
       @sensitive_patterns  = %w[
-        .env .env.* config/master.key config/credentials.yml.enc
-        config/credentials/*.yml.enc *.pem *.key
+        .env .env.*
+        config/master.key
+        config/credentials.yml.enc config/credentials/*.yml.enc
+        config/database.yml config/secrets.yml
+        config/cable.yml config/storage.yml
+        config/mongoid.yml config/redis.yml
+        *.pem *.key *.p12 *.pfx *.jks *.keystore
+        **/id_rsa **/id_ed25519 **/id_ecdsa **/id_dsa
+        .ssh/* .aws/credentials .aws/config .netrc .pgpass .my.cnf
       ]
       @auto_mount          = false
       @http_path           = "/mcp"

--- a/lib/rails_ai_context/configuration.rb
+++ b/lib/rails_ai_context/configuration.rb
@@ -24,6 +24,7 @@ module RailsAiContext
       query_timeout query_row_limit query_redacted_columns allow_query_in_production
       log_lines introspectors
       hydration_enabled hydration_max_hints
+      instrumentation_include_arguments
     ].freeze
 
     # Load configuration from a YAML file, applying values to the current config instance.
@@ -130,6 +131,19 @@ module RailsAiContext
 
     # Debounce interval in seconds for live reload file watching
     attr_accessor :live_reload_debounce
+
+    # Whether to include raw tool arguments in ActiveSupport::Notifications
+    # instrumentation events. Default: false (v5.8.1+). When false, only
+    # metadata (method, tool_name, duration, error) is forwarded to
+    # subscribers. When true, `tool_arguments` and `arguments` are forwarded
+    # verbatim — including raw SQL from `rails_query`, env var names from
+    # `rails_get_env`, and log search patterns from `rails_read_logs`.
+    #
+    # Setting this to true means the operator takes on the redaction
+    # obligation for any downstream observability pipeline (Datadog, Scout,
+    # custom loggers) that receives these events. See CHANGELOG.md for v5.8.1
+    # for the security review that changed the default.
+    attr_accessor :instrumentation_include_arguments
 
     # Whether to generate root-level context files (CLAUDE.md, AGENTS.md, etc.)
     # When false, only generates split rule files (.claude/rules/, .cursor/rules/, etc.)
@@ -256,6 +270,7 @@ module RailsAiContext
       @max_tool_response_chars  = 200_000
       @live_reload              = :auto
       @live_reload_debounce     = 1.5
+      @instrumentation_include_arguments = false
       @generate_root_files      = true
       @anti_hallucination_rules = true
       @max_file_size            = 5_000_000

--- a/lib/rails_ai_context/fingerprinter.rb
+++ b/lib/rails_ai_context/fingerprinter.rb
@@ -39,13 +39,13 @@ module RailsAiContext
         # Include the gem's own version so cache invalidates during gem development
         digest.update(RailsAiContext::VERSION)
 
-        # Include gem lib directory mtime when using a local/path gem (development mode)
-        gem_lib = File.expand_path("../../..", __FILE__)
-        if gem_lib.start_with?(root) || (defined?(Bundler) && local_gem_path?)
-          Dir.glob(File.join(gem_lib, "**/*.rb")).sort.each do |path|
-            digest.update(File.mtime(path).to_f.to_s)
-          end
-        end
+        # Include gem lib directory fingerprint when using a local/path gem.
+        # MEMOIZED — the gem lib contents don't change within a single process
+        # lifetime unless a developer is actively editing the gem source (rare
+        # audience, they should restart the server to see changes). Previously
+        # this walked 123 gem files on every tool call, adding ~12ms to the
+        # cached_context hot path for path:-installed users.
+        digest.update(gem_lib_fingerprint(root))
 
         WATCHED_FILES.each do |file|
           path = File.join(root, file)
@@ -68,7 +68,34 @@ module RailsAiContext
         digest.hexdigest
       end
 
+      # Clear the memoized gem-lib fingerprint. Called by BaseTool.reset_cache!
+      # and LiveReload so active gem development gets a fresh scan on next call
+      # without requiring a process restart.
+      def reset_gem_lib_fingerprint!
+        @gem_lib_fingerprint = nil
+      end
+
       private
+
+      # Memoized gem-lib fingerprint. Computed ONCE per process lifetime
+      # (or per reset_gem_lib_fingerprint! call) instead of on every
+      # tool invocation.
+      def gem_lib_fingerprint(root)
+        @gem_lib_fingerprint ||= compute_gem_lib_fingerprint(root)
+      end
+
+      def compute_gem_lib_fingerprint(root)
+        gem_lib = File.expand_path("../../..", __FILE__)
+        return "" unless gem_lib.start_with?(root) || (defined?(Bundler) && local_gem_path?)
+
+        sub = Digest::SHA256.new
+        Dir.glob(File.join(gem_lib, "**/*.rb")).sort.each do |path|
+          sub.update(File.mtime(path).to_f.to_s)
+        rescue Errno::ENOENT
+          # File deleted between glob and mtime read — skip
+        end
+        sub.hexdigest
+      end
 
       # Detect if this gem is loaded via a local path (path: in Gemfile)
       def local_gem_path?

--- a/lib/rails_ai_context/instrumentation.rb
+++ b/lib/rails_ai_context/instrumentation.rb
@@ -25,12 +25,14 @@ module RailsAiContext
       ->(data) {
         return unless defined?(ActiveSupport::Notifications)
 
-        method = data[:method] || "unknown"
-        event_name = "#{EVENT_PREFIX}.#{method.to_s.tr("/", ".")}"
-
-        payload = build_payload(data)
-
         begin
+          method = data[:method] || "unknown"
+          event_name = "#{EVENT_PREFIX}.#{method.to_s.tr("/", ".")}"
+
+          # build_payload reads configuration — wrap it in the rescue so a
+          # broken/nil configuration doesn't propagate out of the lambda and
+          # crash the MCP SDK's ensure block. v5.8.1-r3 hardening.
+          payload = build_payload(data)
           ActiveSupport::Notifications.instrument(event_name, payload)
         rescue => e
           # The MCP SDK's instrument_call invokes this callback from an `ensure`

--- a/lib/rails_ai_context/instrumentation.rb
+++ b/lib/rails_ai_context/instrumentation.rb
@@ -6,6 +6,19 @@ module RailsAiContext
   module Instrumentation
     EVENT_PREFIX = "rails_ai_context"
 
+    # Metadata-only fields forwarded to ActiveSupport::Notifications. We
+    # deliberately exclude `tool_arguments`, `params`, `arguments`, and
+    # `request` because the MCP SDK includes raw tool inputs in those keys —
+    # e.g. `rails_query(sql: "SELECT password_digest...")`, `rails_get_env(name: "SECRET_KEY_BASE")`,
+    # `rails_read_logs(search: "api_key=xyz")`. Forwarding them unredacted
+    # would leak the request-side data that each tool's response-side
+    # redaction was specifically designed to protect. Fixed in v5.8.1.
+    #
+    # Users who legitimately need tool arguments in observability can set
+    # config.instrumentation_include_arguments = true in an initializer
+    # (see CONFIGURATION.md for the redaction obligation that comes with it).
+    SAFE_KEYS = %i[method tool_name duration error resource_uri prompt_name].freeze
+
     # Returns a lambda for MCP::Configuration#instrumentation_callback.
     # Instruments each MCP method call as an ActiveSupport::Notifications event.
     def self.callback
@@ -13,10 +26,38 @@ module RailsAiContext
         return unless defined?(ActiveSupport::Notifications)
 
         method = data[:method] || "unknown"
-        event_name = "#{EVENT_PREFIX}.#{method.tr("/", ".")}"
+        event_name = "#{EVENT_PREFIX}.#{method.to_s.tr("/", ".")}"
 
-        ActiveSupport::Notifications.instrument(event_name, data)
+        payload = build_payload(data)
+
+        begin
+          ActiveSupport::Notifications.instrument(event_name, payload)
+        rescue => e
+          # The MCP SDK's instrument_call invokes this callback from an `ensure`
+          # block, which means any exception raised here would overwrite the
+          # tool's actual return value with the subscriber's error — effectively
+          # crashing every tool call whenever a single subscriber is broken.
+          # Swallow the error and log to stderr instead. Fixed in v5.8.1.
+          $stderr.puts "[rails-ai-context] instrumentation subscriber failed: #{e.message}" if ENV["DEBUG"]
+        end
       }
+    end
+
+    # Build a safe payload from the raw MCP SDK data hash. Strips tool
+    # arguments unless the user has explicitly opted in.
+    def self.build_payload(data)
+      payload = SAFE_KEYS.each_with_object({}) do |key, acc|
+        acc[key] = data[key] if data.key?(key)
+      end
+
+      if RailsAiContext.configuration.instrumentation_include_arguments
+        # User opted in: include arguments verbatim. They take on the
+        # redaction obligation for anything downstream consumers log.
+        payload[:tool_arguments] = data[:tool_arguments] if data.key?(:tool_arguments)
+        payload[:arguments]      = data[:arguments]      if data.key?(:arguments)
+      end
+
+      payload
     end
   end
 end

--- a/lib/rails_ai_context/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_context/introspectors/schema_introspector.rb
@@ -174,7 +174,9 @@ module RailsAiContext
       # Tries db/schema.rb first, then db/structure.sql, then migrations.
       # This enables introspection in CI, Claude Code, etc.
       def static_schema_parse
-        if File.exist?(schema_file_path)
+        schema_rb_exists = File.exist?(schema_file_path)
+
+        if schema_rb_exists
           result = parse_schema_rb(schema_file_path)
           return result if result[:total_tables].to_i > 0
         end
@@ -186,6 +188,18 @@ module RailsAiContext
 
         if Dir.exist?(migrations_dir) && Dir.glob(File.join(migrations_dir, "*.rb")).any?
           return parse_migrations
+        end
+
+        # schema.rb exists but has no tables — happens on fresh Rails apps right
+        # after `db:create` where no migrations have been run yet. Return a
+        # legitimate empty-schema state instead of a misleading "not found" error.
+        if schema_rb_exists
+          return {
+            total_tables: 0,
+            tables: {},
+            note: "Schema file exists but is empty — no migrations have been run yet. " \
+                  "Run `bin/rails db:migrate` after generating migrations to populate schema.rb."
+          }
         end
 
         { error: "No db/schema.rb, db/structure.sql, or migrations found" }

--- a/lib/rails_ai_context/tools/analyze_feature.rb
+++ b/lib/rails_ai_context/tools/analyze_feature.rb
@@ -24,10 +24,12 @@ module RailsAiContext
       # Map well-known feature keywords to gem-based patterns
       AUTH_KEYWORDS = %w[auth authentication login signup signin session devise omniauth].freeze
 
-      # Cap per-directory file scans to avoid unbounded Dir.glob + SafeFile.read
-      # on large monorepos. Matches the pattern used by discover_tests. Tool
-      # output notes when the cap is hit so the AI agent knows to narrow its
-      # feature keyword. v5.8.1 hardening.
+      # Cap per-directory file scans to avoid unbounded work on large monorepos.
+      # Note: Dir.glob materialises the full path array before .first() truncates —
+      # the directory walk itself is unbounded; only per-file reading and processing
+      # is capped at MAX_SCAN_FILES. Applied to every discover_* method that walks
+      # the filesystem. Tool output notes when the cap is hit so the AI agent knows
+      # to narrow its feature keyword. v5.8.1 hardening; all glob sites in r2.
       MAX_SCAN_FILES = 500
       AUTH_GEM_NAMES = %w[devise omniauth rodauth sorcery clearance authlogic warden jwt].freeze
 
@@ -313,20 +315,26 @@ module RailsAiContext
         def discover_tests(root, pattern, lines)
           test_dirs = [ File.join(root, "spec"), File.join(root, "test") ]
           found = []
+          truncated = false
 
           test_dirs.each do |dir|
             next unless Dir.exist?(dir)
-            Dir.glob(File.join(dir, "**", "*_{test,spec}.rb")).each do |path|
+            suffix_glob = Dir.glob(File.join(dir, "**", "*_{test,spec}.rb")).first(MAX_SCAN_FILES)
+            truncated = true if suffix_glob.size == MAX_SCAN_FILES
+            suffix_glob.each do |path|
               found << path if File.basename(path, ".rb").include?(pattern)
             end
-            Dir.glob(File.join(dir, "**", "{test,spec}_*.rb")).each do |path|
+            prefix_glob = Dir.glob(File.join(dir, "**", "{test,spec}_*.rb")).first(MAX_SCAN_FILES)
+            truncated = true if prefix_glob.size == MAX_SCAN_FILES
+            prefix_glob.each do |path|
               found << path if File.basename(path, ".rb").include?(pattern)
             end
           end
           found.uniq!
           return found if found.empty?
 
-          lines << "## Tests (#{found.size})"
+          header = "## Tests (#{found.size}#{truncated ? " — first #{MAX_SCAN_FILES} per glob scanned" : ""})"
+          lines << header
           found.each do |path|
             relative = path.sub("#{root}/", "")
             source = RailsAiContext::SafeFile.read(path) or next
@@ -366,7 +374,7 @@ module RailsAiContext
           # Check jobs
           job_dir = File.join(root, "app", "jobs")
           if Dir.exist?(job_dir)
-            Dir.glob(File.join(job_dir, "**", "*.rb")).each do |path|
+            Dir.glob(File.join(job_dir, "**", "*.rb")).first(MAX_SCAN_FILES).each do |path|
               next unless File.basename(path, ".rb").include?(pattern)
               snake = File.basename(path, ".rb")
               unless test_basenames.any? { |t| t.include?(snake) }
@@ -378,7 +386,7 @@ module RailsAiContext
           # Check services
           service_dir = File.join(root, "app", "services")
           if Dir.exist?(service_dir)
-            Dir.glob(File.join(service_dir, "**", "*.rb")).each do |path|
+            Dir.glob(File.join(service_dir, "**", "*.rb")).first(MAX_SCAN_FILES).each do |path|
               next unless File.basename(path, ".rb").include?(pattern)
               snake = File.basename(path, ".rb")
               unless test_basenames.any? { |t| t.include?(snake) }
@@ -490,10 +498,11 @@ module RailsAiContext
           dir = File.join(root, "app", "channels")
           return unless Dir.exist?(dir)
 
-          found = Dir.glob(File.join(dir, "**", "*.rb")).select { |p| File.basename(p, ".rb").include?(pattern) }
+          candidates = Dir.glob(File.join(dir, "**", "*.rb")).first(MAX_SCAN_FILES)
+          found = candidates.select { |p| File.basename(p, ".rb").include?(pattern) }
           return if found.empty?
 
-          lines << "## Channels (#{found.size})"
+          lines << "## Channels (#{found.size}#{candidates.size == MAX_SCAN_FILES ? " — first #{MAX_SCAN_FILES} scanned" : ""})"
           found.each do |path|
             relative = path.sub("#{root}/", "")
             lines << "- `#{relative}`"
@@ -509,10 +518,11 @@ module RailsAiContext
           dir = File.join(root, "app", "mailers")
           return unless Dir.exist?(dir)
 
-          found = Dir.glob(File.join(dir, "**", "*.rb")).select { |p| File.basename(p, ".rb").include?(pattern) }
+          candidates = Dir.glob(File.join(dir, "**", "*.rb")).first(MAX_SCAN_FILES)
+          found = candidates.select { |p| File.basename(p, ".rb").include?(pattern) }
           return if found.empty?
 
-          lines << "## Mailers (#{found.size})"
+          lines << "## Mailers (#{found.size}#{candidates.size == MAX_SCAN_FILES ? " — first #{MAX_SCAN_FILES} scanned" : ""})"
           found.each do |path|
             relative = path.sub("#{root}/", "")
             source = RailsAiContext::SafeFile.read(path) or next
@@ -555,9 +565,12 @@ module RailsAiContext
           # Scan services, jobs, and model files for ENV references
           dirs = %w[app/services app/jobs].map { |d| File.join(root, d) }.select { |d| Dir.exist?(d) }
           env_vars = Set.new
+          truncated = false
 
           dirs.each do |dir|
-            Dir.glob(File.join(dir, "**", "*.rb")).each do |path|
+            candidates = Dir.glob(File.join(dir, "**", "*.rb")).first(MAX_SCAN_FILES)
+            truncated = true if candidates.size == MAX_SCAN_FILES
+            candidates.each do |path|
               next unless File.basename(path, ".rb").include?(pattern) || path.downcase.include?(pattern)
               source = RailsAiContext::SafeFile.read(path) or next
               source.scan(/ENV\[["']([^"']+)["']\]|ENV\.fetch\(["']([^"']+)["']\)/).each do |m|
@@ -567,7 +580,8 @@ module RailsAiContext
           end
           return if env_vars.empty?
 
-          lines << "## Environment Dependencies"
+          header = "## Environment Dependencies#{truncated ? " (first #{MAX_SCAN_FILES} per dir scanned)" : ""}"
+          lines << header
           env_vars.sort.each { |v| lines << "- `#{v}`" }
           lines << ""
         rescue => e

--- a/lib/rails_ai_context/tools/analyze_feature.rb
+++ b/lib/rails_ai_context/tools/analyze_feature.rb
@@ -23,6 +23,12 @@ module RailsAiContext
 
       # Map well-known feature keywords to gem-based patterns
       AUTH_KEYWORDS = %w[auth authentication login signup signin session devise omniauth].freeze
+
+      # Cap per-directory file scans to avoid unbounded Dir.glob + SafeFile.read
+      # on large monorepos. Matches the pattern used by discover_tests. Tool
+      # output notes when the cap is hit so the AI agent knows to narrow its
+      # feature keyword. v5.8.1 hardening.
+      MAX_SCAN_FILES = 500
       AUTH_GEM_NAMES = %w[devise omniauth rodauth sorcery clearance authlogic warden jwt].freeze
 
       def self.call(feature:, server_context: nil) # rubocop:disable Metrics
@@ -192,13 +198,17 @@ module RailsAiContext
           dir = File.join(root, "app", "services")
           return unless Dir.exist?(dir)
 
-          found = Dir.glob(File.join(dir, "**", "*.rb")).select do |path|
-            File.basename(path, ".rb").include?(pattern) ||
-              (File.size(path) < 50_000 && (RailsAiContext::SafeFile.read(path) || "").downcase.include?(pattern))
+          candidates = Dir.glob(File.join(dir, "**", "*.rb")).first(MAX_SCAN_FILES)
+          # Prefer basename match (fast, no file read) and only fall back to
+          # a content scan for files whose basename doesn't match. This
+          # avoids reading every service file's full contents on large apps.
+          found = candidates.select do |path|
+            next true if File.basename(path, ".rb").include?(pattern)
+            File.size(path) < 50_000 && (RailsAiContext::SafeFile.read(path) || "").downcase.include?(pattern)
           end
           return if found.empty?
 
-          lines << "## Services (#{found.size})"
+          lines << "## Services (#{found.size}#{candidates.size == MAX_SCAN_FILES ? " — first #{MAX_SCAN_FILES} scanned" : ""})"
           found.each do |path|
             relative = path.sub("#{root}/", "")
             source = RailsAiContext::SafeFile.read(path) or next
@@ -218,12 +228,13 @@ module RailsAiContext
           dir = File.join(root, "app", "jobs")
           return unless Dir.exist?(dir)
 
-          found = Dir.glob(File.join(dir, "**", "*.rb")).select do |path|
+          candidates = Dir.glob(File.join(dir, "**", "*.rb")).first(MAX_SCAN_FILES)
+          found = candidates.select do |path|
             File.basename(path, ".rb").include?(pattern)
           end
           return if found.empty?
 
-          lines << "## Jobs (#{found.size})"
+          lines << "## Jobs (#{found.size}#{candidates.size == MAX_SCAN_FILES ? " — first #{MAX_SCAN_FILES} scanned" : ""})"
           found.each do |path|
             relative = path.sub("#{root}/", "")
             source = RailsAiContext::SafeFile.read(path) or next
@@ -242,12 +253,13 @@ module RailsAiContext
           views_dir = File.join(root, "app", "views")
           return unless Dir.exist?(views_dir)
 
-          found = Dir.glob(File.join(views_dir, "**", "*.{erb,haml,slim}")).select do |path|
+          candidates = Dir.glob(File.join(views_dir, "**", "*.{erb,haml,slim}")).first(MAX_SCAN_FILES)
+          found = candidates.select do |path|
             path.sub("#{views_dir}/", "").downcase.include?(pattern)
           end
           return if found.empty?
 
-          lines << "## Views (#{found.size})"
+          lines << "## Views (#{found.size}#{candidates.size == MAX_SCAN_FILES ? " — first #{MAX_SCAN_FILES} scanned" : ""})"
           found.each do |path|
             relative = path.sub("#{views_dir}/", "")
             source = RailsAiContext::SafeFile.read(path) or next

--- a/lib/rails_ai_context/tools/base_tool.rb
+++ b/lib/rails_ai_context/tools/base_tool.rb
@@ -108,7 +108,22 @@ module RailsAiContext
             now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
             ttl = RailsAiContext.configuration.cache_ttl
 
-            if SHARED_CACHE[:context] && (now - SHARED_CACHE[:timestamp]) < ttl && !Fingerprinter.changed?(rails_app, SHARED_CACHE[:fingerprint])
+            # Fast path: within TTL window, trust the cache and skip the
+            # fingerprint walk entirely. Fingerprinter stats every *.rb file
+            # in WATCHED_DIRS (plus, in dev-mode path: installs, every file
+            # in the gem's own lib/ tree) — measured at ~12ms per call in
+            # dev mode, ~0.5ms in production. Since LiveReload fires
+            # reset_all_caches! on actual file-change events, stale-cache
+            # risk during a short TTL window is already covered.
+            if SHARED_CACHE[:context] && (now - SHARED_CACHE[:timestamp]) < ttl
+              return SHARED_CACHE[:context].deep_dup
+            end
+
+            # TTL expired: re-validate via fingerprint before re-introspecting.
+            # If fingerprint is unchanged, bump the timestamp and reuse the
+            # cached context — saves re-running all 31 introspectors.
+            if SHARED_CACHE[:context] && !Fingerprinter.changed?(rails_app, SHARED_CACHE[:fingerprint])
+              SHARED_CACHE[:timestamp] = now
               return SHARED_CACHE[:context].deep_dup
             end
 
@@ -125,6 +140,10 @@ module RailsAiContext
             SHARED_CACHE.delete(:timestamp)
             SHARED_CACHE.delete(:fingerprint)
           end
+          # Also invalidate the memoized gem-lib fingerprint so active gem
+          # development sees a fresh scan on next call without a process
+          # restart. No-op for production installs.
+          Fingerprinter.reset_gem_lib_fingerprint!
         end
 
         # Reset the shared cache. Used by LiveReload to invalidate on file change.

--- a/lib/rails_ai_context/tools/get_edit_context.rb
+++ b/lib/rails_ai_context/tools/get_edit_context.rb
@@ -59,9 +59,13 @@ module RailsAiContext
           return text_response("File not found: #{file}.#{hint}")
         end
         begin
-          real = File.realpath(full_path)
-          rails_root_real = File.realpath(Rails.root)
-          unless real.start_with?(rails_root_real)
+          real = File.realpath(full_path).to_s
+          rails_root_real = File.realpath(Rails.root).to_s
+          # Separator-aware containment — matches the v5.8.1-r2 hardening in
+          # get_view.rb / vfs.rb. Without `+ File::SEPARATOR`, a sibling-dir
+          # like `/app/rails_evil/...` would prefix-match a Rails root at
+          # `/app/rails`. Same bug class as the original C1.
+          unless real == rails_root_real || real.start_with?(rails_root_real + File::SEPARATOR)
             return text_response("Path not allowed: #{file}")
           end
           # Re-run the sensitive_file? check on the realpath. Defense against
@@ -76,11 +80,11 @@ module RailsAiContext
         rescue Errno::ENOENT
           return text_response("File not found: #{file}")
         end
-        if File.size(full_path) > max_file_size
+        if File.size(real) > max_file_size
           return text_response("File too large: #{file}")
         end
 
-        source_lines = (RailsAiContext::SafeFile.read(full_path) || "").lines
+        source_lines = (RailsAiContext::SafeFile.read(real) || "").lines
         context_lines = [ context_lines.to_i, 0 ].max
 
         # Find all matching lines

--- a/lib/rails_ai_context/tools/get_edit_context.rb
+++ b/lib/rails_ai_context/tools/get_edit_context.rb
@@ -59,8 +59,19 @@ module RailsAiContext
           return text_response("File not found: #{file}.#{hint}")
         end
         begin
-          unless File.realpath(full_path).start_with?(File.realpath(Rails.root))
+          real = File.realpath(full_path)
+          rails_root_real = File.realpath(Rails.root)
+          unless real.start_with?(rails_root_real)
             return text_response("Path not allowed: #{file}")
+          end
+          # Re-run the sensitive_file? check on the realpath. Defense against
+          # symlinks that point at sensitive files from a non-sensitive path
+          # (e.g. app/models/notes.rb -> ../../config/master.key). The initial
+          # check above runs on the caller-supplied string, not the resolved
+          # target. See v5.8.1 security review.
+          relative_real = real.sub("#{rails_root_real}/", "")
+          if sensitive_file?(relative_real)
+            return text_response("Access denied: #{file} resolves to a sensitive file (secrets/keys/credentials).")
           end
         rescue Errno::ENOENT
           return text_response("File not found: #{file}")

--- a/lib/rails_ai_context/tools/get_partial_interface.rb
+++ b/lib/rails_ai_context/tools/get_partial_interface.rb
@@ -52,6 +52,11 @@ module RailsAiContext
             recovery_tool: "Call rails_get_view(detail:\"summary\") to see all views and partials")
         end
 
+        # Derive display-string bases from the realpath that resolve_partial_path
+        # already computed internally — keeps all path operations on realpaths.
+        real_root = File.realpath(root)
+        real_views_dir = File.realpath(views_dir)
+
         if File.size(file_path) > max_file_size
           return text_response("Partial file too large: #{file_path} (#{File.size(file_path)} bytes, max: #{max_file_size})")
         end
@@ -59,8 +64,8 @@ module RailsAiContext
         source = safe_read(file_path)
         return text_response("Could not read partial file.") unless source
 
-        relative_path = file_path.sub("#{root}/", "")
-        partial_name = file_path.sub("#{views_dir}/", "")
+        relative_path = file_path.sub("#{real_root}/", "")
+        partial_name = file_path.sub("#{real_views_dir}/", "")
 
         # Parse the partial's interface
         magic_locals = extract_magic_comment_locals(source)
@@ -245,16 +250,22 @@ module RailsAiContext
 
         return nil unless found
 
-        # Path traversal protection
+        # Path traversal protection: separator-aware containment + post-realpath
+        # sensitive recheck. Returns real_found (the resolved realpath) so the
+        # caller reads from the same path that was security-checked — TOCTOU closed.
         begin
-          unless File.realpath(found).start_with?(File.realpath(views_dir))
+          real_found = File.realpath(found).to_s
+          real_base = File.realpath(views_dir).to_s
+          unless real_found == real_base || real_found.start_with?(real_base + File::SEPARATOR)
             return nil
           end
+          relative_real = real_found.sub("#{real_base}/", "")
+          return nil if sensitive_file?(relative_real) || sensitive_file?(partial)
         rescue Errno::ENOENT
           return nil
         end
 
-        found
+        real_found
       end
 
       # Extract locals declared via Rails 7.1+ magic comment: <%# locals: (name:, title: "default") %>

--- a/lib/rails_ai_context/tools/get_view.rb
+++ b/lib/rails_ai_context/tools/get_view.rb
@@ -229,28 +229,47 @@ module RailsAiContext
           return text_response("Path not allowed: #{path}")
         end
 
+        # Block sensitive files on the caller-supplied string before any
+        # filesystem stat — closes the existence-oracle side channel.
+        if sensitive_file?(path)
+          return text_response("Access denied: #{path} is a sensitive file (secrets/keys/credentials).")
+        end
+
         views_dir = Rails.root.join("app", "views")
         full_path = views_dir.join(path)
 
-        # Path traversal protection (resolves symlinks)
         unless File.exist?(full_path)
           dir = File.dirname(path)
           siblings = Dir.glob(File.join(views_dir, dir, "*")).map { |f| "#{dir}/#{File.basename(f)}" }.sort.first(10)
           hint = siblings.any? ? " Files in #{dir}/: #{siblings.join(', ')}" : ""
           return text_response("View not found: #{path}.#{hint}")
         end
+        # Containment check with separator + post-realpath sensitive recheck.
+        # Mirrors the v5.8.1 fix in vfs.rb / get_edit_context.rb. Without
+        # `File::SEPARATOR`, `start_with?` matches sibling directories like
+        # `app/views_backup/secret` against `app/views`. Without the
+        # post-realpath sensitive recheck, a symlink at
+        # `app/views/leak.key → ../../config/master.key` would slip through
+        # and read the secret.
+        real = nil
         begin
-          unless File.realpath(full_path).start_with?(File.realpath(views_dir))
+          real = File.realpath(full_path).to_s
+          real_base = File.realpath(views_dir).to_s
+          unless real == real_base || real.start_with?(real_base + File::SEPARATOR)
             return text_response("Path not allowed: #{path}")
+          end
+          relative_real = real.sub("#{real_base}/", "")
+          if sensitive_file?(relative_real)
+            return text_response("Access denied: #{path} resolves to a sensitive file (secrets/keys/credentials).")
           end
         rescue Errno::ENOENT
           return text_response("View not found: #{path}")
         end
-        if File.size(full_path) > max_file_size
-          return text_response("File too large: #{path} (#{File.size(full_path)} bytes, max: #{max_file_size})")
+        if File.size(real) > max_file_size
+          return text_response("File too large: #{path} (#{File.size(real)} bytes, max: #{max_file_size})")
         end
 
-        content = RailsAiContext::SafeFile.read(full_path)
+        content = RailsAiContext::SafeFile.read(real)
         return text_response("Could not read file: #{path}") unless content
         content = compress_tailwind(strip_svg(content))
         text_response("# #{path}\n\n```erb\n#{content}\n```")

--- a/lib/rails_ai_context/tools/query.rb
+++ b/lib/rails_ai_context/tools/query.rb
@@ -67,6 +67,7 @@ module RailsAiContext
         pg_stat_file | pg_file_settings | pg_current_logfile |
         lo_import | lo_export |
         dblink[a-z_]* |
+        LOAD\s+DATA |
         load_file | load_extension
       )\b/ix
 

--- a/lib/rails_ai_context/tools/query.rb
+++ b/lib/rails_ai_context/tools/query.rb
@@ -48,6 +48,53 @@ module RailsAiContext
       MULTI_STATEMENT  = /;\s*\S/
       ALLOWED_PREFIX   = /\A\s*(SELECT|WITH|SHOW|EXPLAIN|DESCRIBE|DESC)\b/i
 
+      # SELECT-callable functions that give the caller a filesystem / network
+      # exfiltration primitive even though the query is technically a SELECT.
+      # These pass `SET TRANSACTION READ ONLY` because they're reads from the
+      # DB engine's perspective, but they bypass the gem's `sensitive_patterns`
+      # file allowlist entirely by pivoting through the database process.
+      #
+      # Postgres: pg_read_file / pg_read_binary_file / pg_ls_dir / pg_stat_file
+      #           (file read), lo_import / lo_export (large-object I/O),
+      #           dblink* (cross-db exfiltration), COPY ... FROM/TO PROGRAM
+      #           (arbitrary command execution when COPY permissions permit).
+      # MySQL:    LOAD_FILE (scalar file read outside SELECT INTO contexts).
+      # SQLite:   load_extension (shared-library load — disabled by default
+      #           but harden in defense).
+      BLOCKED_FUNCTIONS = /\b(
+        pg_read_binary_file | pg_read_file |
+        pg_ls_dir | pg_ls_logdir | pg_ls_tmpdir | pg_ls_waldir | pg_ls_archive_statusdir |
+        pg_stat_file | pg_file_settings | pg_current_logfile |
+        lo_import | lo_export |
+        dblink[a-z_]* |
+        load_file | load_extension
+      )\b/ix
+
+      # MySQL `SELECT ... INTO OUTFILE 'path'` / `INTO DUMPFILE 'path'`
+      # are caught by SELECT_INTO already, but make an explicit pattern so
+      # the error message is accurate.
+      BLOCKED_OUTPUT = /\bINTO\s+(OUTFILE|DUMPFILE)\b/i
+
+      # Defense against the column-aliasing redaction bypass:
+      #
+      #   SELECT password_digest AS x FROM users       -- bypasses result.columns redaction
+      #   SELECT substring(password_digest, 1, 60) ... -- column name becomes "substring"
+      #   SELECT md5(session_data) FROM sessions       -- column name becomes "md5"
+      #
+      # Post-execution redaction operates on the column names the DB returns,
+      # which the caller controls via aliases and expressions. The only
+      # defense that works is to reject queries that TEXTUALLY reference
+      # any sensitive column, before execution. Users who need to query
+      # non-sensitive columns with a similar name can subtract from
+      # `config.query_redacted_columns` in an initializer.
+      SENSITIVE_COLUMN_SUFFIXES = %w[
+        password_digest password_hash encrypted_password
+        password_reset_token confirmation_token unlock_token
+        remember_token reset_password_token api_key api_secret
+        access_token refresh_token jti otp_secret session_data
+        secret_key secret private_key
+      ].freeze
+
       # SQL injection tautology patterns: OR 1=1, OR true, OR ''='', UNION SELECT, etc.
       TAUTOLOGY_PATTERNS = [
         /\bOR\s+1\s*=\s*1\b/i,
@@ -148,6 +195,14 @@ module RailsAiContext
         return [ false, "Blocked: FOR UPDATE/SHARE clause" ] if cleaned.match?(BLOCKED_CLAUSES)
         return [ false, "Blocked: sensitive SHOW command" ] if cleaned.match?(BLOCKED_SHOWS)
         return [ false, "Blocked: SELECT INTO creates a table" ] if cleaned.match?(SELECT_INTO)
+        return [ false, "Blocked: SELECT INTO OUTFILE / DUMPFILE writes to disk" ] if cleaned.match?(BLOCKED_OUTPUT)
+
+        # Block database functions that give a filesystem/network primitive —
+        # pg_read_file, lo_import, dblink, LOAD_FILE, load_extension, etc.
+        # These pass SET TRANSACTION READ ONLY but bypass sensitive_patterns.
+        if (m = cleaned.match(BLOCKED_FUNCTIONS))
+          return [ false, "Blocked: dangerous function #{m[0]} (filesystem/network primitive)" ]
+        end
 
         # Check for SQL injection tautology patterns (OR 1=1, UNION SELECT, etc.)
         tautology = TAUTOLOGY_PATTERNS.find { |p| cleaned.match?(p) }
@@ -162,7 +217,37 @@ module RailsAiContext
 
         return [ false, "Only SELECT, WITH, SHOW, EXPLAIN, DESCRIBE allowed" ] unless cleaned.match?(ALLOWED_PREFIX)
 
+        # Column-aliasing redaction bypass defense: reject any query that
+        # textually references a sensitive column name. See the comment on
+        # SENSITIVE_COLUMN_SUFFIXES above — post-execution redaction cannot
+        # survive `SELECT password_digest AS x`.
+        if (offending = references_sensitive_column?(cleaned))
+          return [ false,
+            "Blocked: query references sensitive column `#{offending}`. " \
+            "Post-execution redaction cannot survive aliases / expressions, so " \
+            "the entire query is rejected. Remove the reference or subtract " \
+            "from config.query_redacted_columns in an initializer if this " \
+            "column is not actually sensitive in your app." ]
+        end
+
         [ true, nil ]
+      end
+
+      # Returns the first sensitive column name referenced by the SQL, or nil.
+      # Checks both the user's configured redacted columns (config.query_redacted_columns)
+      # AND the hard-coded suffix list (SENSITIVE_COLUMN_SUFFIXES). The match is
+      # case-insensitive and word-bounded so unrelated identifiers containing
+      # a sensitive substring are not false-positives.
+      def self.references_sensitive_column?(cleaned_sql)
+        down = cleaned_sql.downcase
+        # Build the combined list ONCE per call and dedupe.
+        configured = Array(config.query_redacted_columns).map { |c| c.to_s.downcase }
+        suffixed   = SENSITIVE_COLUMN_SUFFIXES.map(&:downcase)
+        (configured + suffixed).uniq.each do |col|
+          next if col.empty?
+          return col if down.match?(/\b#{Regexp.escape(col)}\b/)
+        end
+        nil
       end
 
       # ── Database-level execution (Layer 2) ──────────────────────────

--- a/lib/rails_ai_context/tools/search_code.rb
+++ b/lib/rails_ai_context/tools/search_code.rb
@@ -126,7 +126,7 @@ module RailsAiContext
         begin
           real_search = File.realpath(search_path)
           real_root = File.realpath(root)
-          unless real_search.start_with?(real_root)
+          unless real_search == real_root || real_search.start_with?(real_root + File::SEPARATOR)
             return text_response("Path not allowed: #{path}")
           end
         rescue Errno::ENOENT

--- a/lib/rails_ai_context/tools/validate.rb
+++ b/lib/rails_ai_context/tools/validate.rb
@@ -66,8 +66,18 @@ module RailsAiContext
 
           begin
             real = File.realpath(full_path)
-            unless real.start_with?(File.realpath(Rails.root))
+            rails_root_real = File.realpath(Rails.root)
+            unless real.start_with?(rails_root_real)
               results << "\u2717 #{file} \u2014 path not allowed (outside Rails root)"
+              total += 1
+              next
+            end
+            # Reject validation on sensitive files — no need to let the
+            # caller probe existence/size of secrets via validation errors.
+            # Added in v5.8.1 (matches the defense already in get_edit_context).
+            relative_real = real.sub("#{rails_root_real}/", "")
+            if sensitive_file?(file) || sensitive_file?(relative_real)
+              results << "\u2717 #{file} \u2014 access denied (sensitive file)"
               total += 1
               next
             end

--- a/lib/rails_ai_context/tools/validate.rb
+++ b/lib/rails_ai_context/tools/validate.rb
@@ -54,6 +54,17 @@ module RailsAiContext
             next
           end
 
+          # Block sensitive files on the caller-supplied string BEFORE any
+          # filesystem stat. Closes the existence-oracle side channel where
+          # an attacker could distinguish "file not found" from "access denied"
+          # for a path like config/master.key. Mirrors get_edit_context.rb
+          # ordering. v5.8.1 round 2 hardening.
+          if sensitive_file?(file)
+            results << "\u2717 #{file} \u2014 access denied (sensitive file)"
+            total += 1
+            next
+          end
+
           full_path = Rails.root.join(file)
 
           unless File.exist?(full_path)
@@ -65,19 +76,24 @@ module RailsAiContext
           end
 
           begin
-            real = File.realpath(full_path)
-            rails_root_real = File.realpath(Rails.root)
-            unless real.start_with?(rails_root_real)
+            real = File.realpath(full_path).to_s
+            rails_root_real = File.realpath(Rails.root).to_s
+            # Separator-aware containment — matches the v5.8.1-r2 hardening in
+            # get_view.rb / vfs.rb. Without `+ File::SEPARATOR`, a sibling-dir
+            # like `/app/rails_evil/...` would prefix-match a Rails root at
+            # `/app/rails`. Same bug class as the original C1.
+            unless real == rails_root_real || real.start_with?(rails_root_real + File::SEPARATOR)
               results << "\u2717 #{file} \u2014 path not allowed (outside Rails root)"
               total += 1
               next
             end
-            # Reject validation on sensitive files — no need to let the
-            # caller probe existence/size of secrets via validation errors.
-            # Added in v5.8.1 (matches the defense already in get_edit_context).
+            # Defense-in-depth: re-run sensitive_file? on the resolved path.
+            # Catches symlinks pointing into sensitive territory from a
+            # non-sensitive caller string (e.g. app/views/leak.html.erb →
+            # ../../config/master.key).
             relative_real = real.sub("#{rails_root_real}/", "")
-            if sensitive_file?(file) || sensitive_file?(relative_real)
-              results << "\u2717 #{file} \u2014 access denied (sensitive file)"
+            if sensitive_file?(relative_real)
+              results << "\u2717 #{file} \u2014 access denied (resolves to sensitive file)"
               total += 1
               next
             end
@@ -89,12 +105,13 @@ module RailsAiContext
 
           total += 1
 
+          real_path = Pathname.new(real)
           ok, msg, warnings = if file.end_with?(".rb")
-            validate_ruby(full_path)
+            validate_ruby(real_path)
           elsif file.end_with?(".html.erb") || file.end_with?(".erb")
-            validate_erb(full_path)
+            validate_erb(real_path)
           elsif file.end_with?(".js")
-            validate_javascript(full_path)
+            validate_javascript(real_path)
           else
             results << "- #{file} \u2014 skipped (unsupported file type)"
             total -= 1
@@ -111,7 +128,7 @@ module RailsAiContext
           (warnings || []).each { |w| results << "  \u26A0 #{w}" }
 
           if level == "rails" && ok
-            rails_warnings = check_rails_semantics(file, full_path)
+            rails_warnings = check_rails_semantics(file, real_path)
             rails_warnings.each { |w| results << "  \u26A0 #{w}" }
           end
         end

--- a/lib/rails_ai_context/version.rb
+++ b/lib/rails_ai_context/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiContext
-  VERSION = "5.8.0"
+  VERSION = "5.8.1"
 end

--- a/lib/rails_ai_context/vfs.rb
+++ b/lib/rails_ai_context/vfs.rb
@@ -151,13 +151,16 @@ module RailsAiContext
           raise RailsAiContext::Error, "Path not allowed: #{path} (sensitive file)"
         end
 
+        # Use the canonicalized realpath for size + read to eliminate the TOCTOU
+        # window between the containment/sensitive check and the actual file
+        # access. Mirrors the pattern in get_view.rb and get_edit_context.rb.
         max_size = RailsAiContext.configuration.max_file_size
-        if File.size(full_path) > max_size
-          content = JSON.pretty_generate(error: "File too large: #{path} (#{File.size(full_path)} bytes)")
+        if File.size(real_view) > max_size
+          content = JSON.pretty_generate(error: "File too large: #{path} (#{File.size(real_view)} bytes)")
           return [ { uri: uri, mime_type: "application/json", text: content } ]
         end
 
-        view_content = RailsAiContext::SafeFile.read(full_path) || ""
+        view_content = RailsAiContext::SafeFile.read(real_view) || ""
         mime = path.end_with?(".rb") ? "text/x-ruby" : "text/html"
         [ { uri: uri, mime_type: mime, text: view_content } ]
       end

--- a/lib/rails_ai_context/vfs.rb
+++ b/lib/rails_ai_context/vfs.rb
@@ -130,9 +130,25 @@ module RailsAiContext
           return [ { uri: uri, mime_type: "application/json", text: content } ]
         end
 
-        # Verify resolved path is still under views_dir
-        unless File.realpath(full_path).start_with?(File.realpath(views_dir))
+        # Verify resolved path is still under views_dir. `start_with?` alone
+        # matches `/app/views_spec/x` against `/app/views` — so we append
+        # File::SEPARATOR (or accept exact equality for the dir itself).
+        # A symlink at `app/views/leak → ../views_spec/secret.html.erb`
+        # would otherwise escape the views tree. Fixed in v5.8.1.
+        real_view = File.realpath(full_path)
+        real_base = File.realpath(views_dir)
+        unless real_view == real_base || real_view.start_with?(real_base + File::SEPARATOR)
           raise RailsAiContext::Error, "Path not allowed: #{path}"
+        end
+
+        # Defense-in-depth: re-run sensitive_file? on the realpath. If someone
+        # places a `.env` or `config/master.key` symlink inside `app/views/`,
+        # reject it even though the containment check passed. Mirrors the
+        # v5.8.1 fix in `get_edit_context.rb`.
+        relative_real = real_view.sub("#{real_base}/", "")
+        if RailsAiContext::Tools::BaseTool.send(:sensitive_file?, relative_real) ||
+           RailsAiContext::Tools::BaseTool.send(:sensitive_file?, path)
+          raise RailsAiContext::Error, "Path not allowed: #{path} (sensitive file)"
         end
 
         max_size = RailsAiContext.configuration.max_file_size

--- a/spec/lib/rails_ai_context/fingerprinter_spec.rb
+++ b/spec/lib/rails_ai_context/fingerprinter_spec.rb
@@ -95,4 +95,21 @@ RSpec.describe RailsAiContext::Fingerprinter do
       expect(described_class.changed?(Rails.application, "stale")).to be true
     end
   end
+
+  describe ".reset_gem_lib_fingerprint!" do
+    after { described_class.reset_gem_lib_fingerprint! }
+
+    it "clears the memoized ivar so the next compute recomputes it" do
+      described_class.compute(Rails.application)
+      described_class.reset_gem_lib_fingerprint!
+      expect(described_class.instance_variable_get(:@gem_lib_fingerprint)).to be_nil
+    end
+
+    it "allows a successful compute after reset" do
+      described_class.compute(Rails.application)
+      described_class.reset_gem_lib_fingerprint!
+      result = described_class.compute(Rails.application)
+      expect(result).to match(/\A[a-f0-9]{64}\z/)
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/instrumentation_spec.rb
+++ b/spec/lib/rails_ai_context/instrumentation_spec.rb
@@ -15,11 +15,12 @@ RSpec.describe RailsAiContext::Instrumentation do
       end
 
       callback = described_class.callback
-      callback.call({ method: "tools/call", tool: "rails_get_schema" })
+      callback.call({ method: "tools/call", tool_name: "rails_get_schema", duration: 42 })
 
       expect(events.size).to eq(1)
       expect(events.first[:name]).to eq("rails_ai_context.tools.call")
-      expect(events.first[:payload][:tool]).to eq("rails_get_schema")
+      expect(events.first[:payload][:tool_name]).to eq("rails_get_schema")
+      expect(events.first[:payload][:duration]).to eq(42)
     ensure
       ActiveSupport::Notifications.unsubscribe(/rails_ai_context/)
     end
@@ -46,6 +47,109 @@ RSpec.describe RailsAiContext::Instrumentation do
       expect(events.first).to eq("rails_ai_context.unknown")
     ensure
       ActiveSupport::Notifications.unsubscribe(/rails_ai_context/)
+    end
+
+    # v5.8.1 C2 — the MCP SDK forwards raw tool_arguments to the callback.
+    # rails_query receives raw SQL, rails_get_env receives env var names,
+    # rails_read_logs receives search patterns. Previously these were
+    # forwarded unredacted to every AS::Notifications subscriber.
+    describe "tool_arguments redaction (v5.8.1 C2)" do
+      it "does NOT forward tool_arguments to subscribers by default" do
+        events = []
+        ActiveSupport::Notifications.subscribe(/rails_ai_context/) do |_n, _s, _f, _id, payload|
+          events << payload
+        end
+
+        described_class.callback.call({
+          method: "tools/call",
+          tool_name: "rails_query",
+          tool_arguments: { sql: "SELECT password_digest FROM users" },
+          duration: 10
+        })
+
+        payload = events.first
+        expect(payload).not_to have_key(:tool_arguments)
+        expect(payload).not_to have_key(:arguments)
+        expect(payload.to_s).not_to include("password_digest")
+        expect(payload.to_s).not_to include("SELECT")
+        # metadata still present
+        expect(payload[:tool_name]).to eq("rails_query")
+        expect(payload[:duration]).to eq(10)
+      ensure
+        ActiveSupport::Notifications.unsubscribe(/rails_ai_context/)
+      end
+
+      it "forwards tool_arguments when the user opts in via config" do
+        original = RailsAiContext.configuration.instrumentation_include_arguments
+        RailsAiContext.configuration.instrumentation_include_arguments = true
+
+        events = []
+        ActiveSupport::Notifications.subscribe(/rails_ai_context/) do |_n, _s, _f, _id, payload|
+          events << payload
+        end
+
+        described_class.callback.call({
+          method: "tools/call",
+          tool_name: "rails_query",
+          tool_arguments: { sql: "SELECT id FROM users" }
+        })
+
+        expect(events.first[:tool_arguments]).to eq({ sql: "SELECT id FROM users" })
+      ensure
+        ActiveSupport::Notifications.unsubscribe(/rails_ai_context/)
+        RailsAiContext.configuration.instrumentation_include_arguments = original
+      end
+    end
+
+    # v5.8.1 C2 — a failing subscriber must not crash the tool call. The MCP
+    # SDK invokes this callback from an ensure block, so any exception would
+    # overwrite the tool's actual return value.
+    describe "subscriber failure isolation (v5.8.1 C2)" do
+      it "swallows subscriber exceptions instead of crashing the tool call" do
+        ActiveSupport::Notifications.subscribe(/rails_ai_context/) do |_n, _s, _f, _id, _payload|
+          raise "simulated subscriber crash (Datadog dropped connection, etc.)"
+        end
+
+        # Should not raise — callback must rescue internally.
+        expect {
+          described_class.callback.call({ method: "tools/call", tool_name: "rails_get_schema" })
+        }.not_to raise_error
+      ensure
+        ActiveSupport::Notifications.unsubscribe(/rails_ai_context/)
+      end
+    end
+  end
+
+  describe ".build_payload" do
+    it "keeps only metadata fields" do
+      payload = described_class.build_payload({
+        method: "tools/call",
+        tool_name: "rails_query",
+        tool_arguments: { sql: "SECRET" },
+        duration: 5,
+        error: nil,
+        resource_uri: "rails-ai-context://models/User",
+        extra_field_from_future_sdk: "ignored"
+      })
+
+      expect(payload.keys).to contain_exactly(:method, :tool_name, :duration, :error, :resource_uri)
+      expect(payload).not_to have_key(:tool_arguments)
+      expect(payload).not_to have_key(:extra_field_from_future_sdk)
+    end
+
+    it "passes arguments through when opt-in is true" do
+      original = RailsAiContext.configuration.instrumentation_include_arguments
+      RailsAiContext.configuration.instrumentation_include_arguments = true
+
+      payload = described_class.build_payload({
+        method: "tools/call",
+        tool_name: "rails_query",
+        tool_arguments: { sql: "SELECT 1" }
+      })
+
+      expect(payload[:tool_arguments]).to eq({ sql: "SELECT 1" })
+    ensure
+      RailsAiContext.configuration.instrumentation_include_arguments = original
     end
   end
 end

--- a/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
         expect(result[:note]).to include("no migrations have been run yet")
         expect(result[:note]).to include("bin/rails db:migrate")
       end
+
+      it "returns the empty-schema state for a genuinely 0-byte schema.rb" do
+        File.write(File.join(fixture_path, "db", "schema.rb"), "")
+        result = introspector.call
+        expect(result[:error]).to be_nil
+        expect(result[:total_tables]).to eq(0)
+        expect(result[:note]).to include("no migrations have been run yet")
+      end
     end
 
     context "with a valid schema.rb fixture" do

--- a/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
@@ -19,6 +19,34 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
       end
     end
 
+    context "with an empty schema.rb and no migrations (fresh Rails app)" do
+      before do
+        allow(introspector).to receive(:active_record_connected?).and_return(false)
+
+        db_dir = File.join(fixture_path, "db")
+        FileUtils.mkdir_p(db_dir)
+        File.write(File.join(db_dir, "schema.rb"), <<~RUBY)
+          ActiveRecord::Schema[8.0].define(version: 0) do
+          end
+        RUBY
+      end
+
+      after { FileUtils.rm_rf(File.join(fixture_path, "db")) }
+
+      it "does not report 'file not found' when schema.rb exists but is empty" do
+        result = introspector.call
+        expect(result[:error]).to be_nil
+      end
+
+      it "returns an empty-schema state with total_tables=0 and a helpful note" do
+        result = introspector.call
+        expect(result[:total_tables]).to eq(0)
+        expect(result[:tables]).to eq({})
+        expect(result[:note]).to include("no migrations have been run yet")
+        expect(result[:note]).to include("bin/rails db:migrate")
+      end
+    end
+
     context "with a valid schema.rb fixture" do
       before do
         allow(introspector).to receive(:active_record_connected?).and_return(false)

--- a/spec/lib/rails_ai_context/tools/analyze_feature_spec.rb
+++ b/spec/lib/rails_ai_context/tools/analyze_feature_spec.rb
@@ -178,5 +178,97 @@ RSpec.describe RailsAiContext::Tools::AnalyzeFeature do
       expect(text).to include("### PostsController")
       expect(text).to include("`GET` `/posts`")
     end
+
+    context "DoS cap (v5.8.1 round 2)" do
+      it "caps discover_services at MAX_SCAN_FILES and emits truncation note" do
+        Dir.mktmpdir("rac_dos_services") do |tmp|
+          services_dir = File.join(tmp, "app", "services")
+          FileUtils.mkdir_p(services_dir)
+          (described_class::MAX_SCAN_FILES + 50).times do |i|
+            File.write(File.join(services_dir, "dos_service_#{i}.rb"),
+                       "class DosService#{i}\n  def call; end\nend\n")
+          end
+
+          allow(described_class).to receive(:cached_context).and_return({})
+          allow(described_class).to receive(:rails_app).and_return(double(root: Pathname.new(tmp)))
+
+          result = described_class.call(feature: "dos_service")
+          text = result.content.first[:text]
+
+          expect(text).to include("first #{described_class::MAX_SCAN_FILES} scanned")
+          expect(text).to include("## Services")
+          # Listed body is bounded by the cap (each candidate is also a match here).
+          listed = text.scan(/`app\/services\/dos_service_\d+\.rb`/).size
+          expect(listed).to be <= described_class::MAX_SCAN_FILES
+        end
+      end
+
+      it "caps discover_jobs at MAX_SCAN_FILES" do
+        Dir.mktmpdir("rac_dos_jobs") do |tmp|
+          jobs_dir = File.join(tmp, "app", "jobs")
+          FileUtils.mkdir_p(jobs_dir)
+          (described_class::MAX_SCAN_FILES + 25).times do |i|
+            File.write(File.join(jobs_dir, "dos_job_#{i}.rb"),
+                       "class DosJob#{i}\n  queue_as :default\nend\n")
+          end
+
+          allow(described_class).to receive(:cached_context).and_return({})
+          allow(described_class).to receive(:rails_app).and_return(double(root: Pathname.new(tmp)))
+
+          result = described_class.call(feature: "dos_job")
+          text = result.content.first[:text]
+
+          expect(text).to include("first #{described_class::MAX_SCAN_FILES} scanned")
+          expect(text).to include("## Jobs")
+        end
+      end
+
+      it "caps discover_mailers, discover_channels, discover_env_dependencies independently" do
+        Dir.mktmpdir("rac_dos_mixed") do |tmp|
+          %w[app/mailers app/channels app/services].each do |sub|
+            dir = File.join(tmp, sub)
+            FileUtils.mkdir_p(dir)
+            (described_class::MAX_SCAN_FILES + 10).times do |i|
+              File.write(File.join(dir, "dos_thing_#{i}.rb"),
+                         "class DosThing#{i}\n  def deliver; ENV['DOS_THING_KEY']; end\nend\n")
+            end
+          end
+
+          allow(described_class).to receive(:cached_context).and_return({})
+          allow(described_class).to receive(:rails_app).and_return(double(root: Pathname.new(tmp)))
+
+          result = described_class.call(feature: "dos_thing")
+          text = result.content.first[:text]
+
+          # Each section asserted independently — a regression in any single
+          # discover_* method would now fail the spec on its own line.
+          expect(text).to include("## Mailers (#{described_class::MAX_SCAN_FILES} — first #{described_class::MAX_SCAN_FILES} scanned)")
+          expect(text).to include("## Channels (#{described_class::MAX_SCAN_FILES} — first #{described_class::MAX_SCAN_FILES} scanned)")
+          expect(text).to include("## Environment Dependencies (first #{described_class::MAX_SCAN_FILES} per dir scanned)")
+        end
+      end
+
+      it "does NOT emit a truncation note when file count is below the cap" do
+        Dir.mktmpdir("rac_below_cap") do |tmp|
+          services_dir = File.join(tmp, "app", "services")
+          FileUtils.mkdir_p(services_dir)
+          # Strictly below MAX_SCAN_FILES — guard against a `>= cap` off-by-one
+          # that would falsely emit the truncation note.
+          (described_class::MAX_SCAN_FILES - 50).times do |i|
+            File.write(File.join(services_dir, "small_service_#{i}.rb"),
+                       "class SmallService#{i}\n  def call; end\nend\n")
+          end
+
+          allow(described_class).to receive(:cached_context).and_return({})
+          allow(described_class).to receive(:rails_app).and_return(double(root: Pathname.new(tmp)))
+
+          result = described_class.call(feature: "small_service")
+          text = result.content.first[:text]
+
+          expect(text).to include("## Services")
+          expect(text).not_to include("first #{described_class::MAX_SCAN_FILES} scanned")
+        end
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_context/tools/base_tool_sensitive_file_spec.rb
+++ b/spec/lib/rails_ai_context/tools/base_tool_sensitive_file_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiContext::Tools::BaseTool, ".sensitive_file?" do
+  # sensitive_file? is the security boundary behind every tool that accepts a
+  # file path. v5.8.0 had zero direct spec coverage on it. v5.8.1 adds this
+  # spec so a regression in the matching logic or the default pattern list
+  # would fail loudly.
+
+  subject { described_class.send(:sensitive_file?, path) }
+
+  shared_examples "blocks" do |path|
+    let(:path) { path }
+    it "blocks #{path}" do
+      expect(subject).to be true
+    end
+  end
+
+  shared_examples "allows" do |path|
+    let(:path) { path }
+    it "allows #{path}" do
+      expect(subject).to be false
+    end
+  end
+
+  describe "Rails secret files (should be blocked)" do
+    include_examples "blocks", ".env"
+    include_examples "blocks", ".env.production"
+    include_examples "blocks", ".env.local"
+    include_examples "blocks", "config/master.key"
+    include_examples "blocks", "config/credentials.yml.enc"
+    include_examples "blocks", "config/credentials/production.yml.enc"
+  end
+
+  describe "v5.8.1 expanded default patterns (should be blocked)" do
+    include_examples "blocks", "config/database.yml"
+    include_examples "blocks", "config/secrets.yml"
+    include_examples "blocks", "config/cable.yml"
+    include_examples "blocks", "config/storage.yml"
+    include_examples "blocks", "config/redis.yml"
+    include_examples "blocks", ".pgpass"
+    include_examples "blocks", ".netrc"
+    include_examples "blocks", ".my.cnf"
+    include_examples "blocks", ".aws/credentials"
+    include_examples "blocks", ".aws/config"
+  end
+
+  describe "private keys and certificates (should be blocked)" do
+    include_examples "blocks", "certs/tls.pem"
+    include_examples "blocks", "certs/private.key"
+    include_examples "blocks", "certs/bundle.p12"
+    include_examples "blocks", "certs/keystore.jks"
+  end
+
+  describe "common plaintext files (should NOT be blocked)" do
+    include_examples "allows", "Gemfile"
+    include_examples "allows", "Gemfile.lock"
+    include_examples "allows", "README.md"
+    include_examples "allows", "config/routes.rb"
+    include_examples "allows", "config/application.rb"
+    include_examples "allows", "app/models/user.rb"
+    include_examples "allows", "app/controllers/users_controller.rb"
+    include_examples "allows", "spec/models/user_spec.rb"
+    include_examples "allows", ".rspec"
+    include_examples "allows", ".rubocop.yml"
+  end
+
+  describe "case-insensitivity (File::FNM_CASEFOLD)" do
+    include_examples "blocks", ".ENV"
+    include_examples "blocks", "Config/Master.Key"
+  end
+
+  describe "basename-only matching (dotmatch)" do
+    # sensitive_file? matches both the relative path AND the basename alone,
+    # so a nested copy of .env or a key file still gets blocked.
+    include_examples "blocks", "deep/nested/dir/.env"
+    include_examples "blocks", "some/weird/place/id_rsa"
+  end
+
+  describe "with a custom sensitive_patterns list" do
+    around do |example|
+      original = RailsAiContext.configuration.sensitive_patterns.dup
+      RailsAiContext.configuration.sensitive_patterns = %w[forbidden/*.txt]
+      example.run
+      RailsAiContext.configuration.sensitive_patterns = original
+    end
+
+    it "blocks files matching the custom pattern" do
+      expect(described_class.send(:sensitive_file?, "forbidden/secret.txt")).to be true
+    end
+
+    it "allows .env when only custom patterns are configured" do
+      expect(described_class.send(:sensitive_file?, ".env")).to be false
+    end
+  end
+end

--- a/spec/lib/rails_ai_context/tools/get_edit_context_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_edit_context_spec.rb
@@ -47,6 +47,27 @@ RSpec.describe RailsAiContext::Tools::GetEditContext do
       expect(text).to include("Access denied")
     end
 
+    it "blocks access via symlink target (v5.8.1 realpath sensitive check)" do
+      # Simulates the case where app/models/evil.rb is a symlink pointing
+      # at config/master.key. The basename/path initial check passes (evil.rb
+      # isn't in the sensitive list), but the realpath resolves to a sensitive
+      # file and the second check should catch it.
+      secret = File.join(Rails.root, "config", "master.key")
+      symlink = File.join(Rails.root, "app", "models", "evil.rb")
+      begin
+        File.write(secret, "test-master-key-value")
+        File.symlink(secret, symlink)
+        result = described_class.call(file: "app/models/evil.rb", near: "anything")
+        text = result.content.first[:text]
+        expect(text).to include("Access denied")
+        expect(text).to include("sensitive")
+        expect(text).not_to include("test-master-key-value")
+      ensure
+        FileUtils.rm_f(symlink)
+        FileUtils.rm_f(secret)
+      end
+    end
+
     it "prevents path traversal" do
       result = described_class.call(file: "../../etc/passwd", near: "root")
       text = result.content.first[:text]

--- a/spec/lib/rails_ai_context/tools/get_partial_interface_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_partial_interface_spec.rb
@@ -95,5 +95,44 @@ RSpec.describe RailsAiContext::Tools::GetPartialInterface do
         expect(text).to match(/title|body/)
       end
     end
+
+    context "C1 symlink hardening (v5.8.1 round 2)" do
+      let(:views_dir) { Rails.root.join("app", "views") }
+
+      it "refuses partials whose realpath escapes app/views via sibling-dir symlink" do
+        sibling_dir = Rails.root.join("app", "views_spec_gpi_#{Process.pid}")
+        FileUtils.mkdir_p(sibling_dir.join("posts"))
+        secret_partial = sibling_dir.join("posts", "_secret.html.erb")
+        File.write(secret_partial, "<h1>SIBLING PARTIAL SECRET</h1>")
+
+        FileUtils.mkdir_p(views_dir.join("posts"))
+        symlink = views_dir.join("posts", "_gpi_leak_#{Process.pid}.html.erb")
+        File.symlink(secret_partial, symlink)
+
+        result = described_class.call(partial: "posts/gpi_leak_#{Process.pid}")
+        text = result.content.first[:text]
+        # When containment fails, resolve_partial_path returns nil → "not found".
+        expect(text).to match(/not found|not allowed/i)
+        expect(text).not_to include("SIBLING PARTIAL SECRET")
+      ensure
+        FileUtils.rm_f(symlink) if defined?(symlink)
+        FileUtils.rm_rf(sibling_dir) if defined?(sibling_dir)
+      end
+
+      it "refuses partials whose realpath lands on a sensitive file" do
+        secret = Rails.root.join("config", "_gpi_test_master_#{Process.pid}.key")
+        File.write(secret, "should-never-leak")
+        FileUtils.mkdir_p(views_dir.join("posts"))
+        symlink = views_dir.join("posts", "_gpi_secret_#{Process.pid}.html.erb")
+        File.symlink(secret, symlink)
+
+        result = described_class.call(partial: "posts/gpi_secret_#{Process.pid}")
+        text = result.content.first[:text]
+        expect(text).not_to include("should-never-leak")
+      ensure
+        FileUtils.rm_f(symlink) if defined?(symlink)
+        FileUtils.rm_f(secret) if defined?(secret)
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_context/tools/get_view_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_view_spec.rb
@@ -115,5 +115,54 @@ RSpec.describe RailsAiContext::Tools::GetView do
         expect(text).to include("view_template")
       end
     end
+
+    context "C1 symlink hardening (v5.8.1 round 2)" do
+      let(:views_dir) { Rails.root.join("app", "views") }
+
+      it "blocks sibling-directory traversal via symlink" do
+        sibling_dir = Rails.root.join("app", "views_spec_gv_#{Process.pid}")
+        FileUtils.mkdir_p(sibling_dir)
+        secret_file = sibling_dir.join("secret.html.erb")
+        File.write(secret_file, "<h1>SIBLING SECRET</h1>")
+
+        symlink = views_dir.join("gv_leak_#{Process.pid}.html.erb")
+        File.symlink(secret_file, symlink)
+
+        result = described_class.call(path: "gv_leak_#{Process.pid}.html.erb")
+        text = result.content.first[:text]
+        expect(text).to match(/not allowed/)
+        expect(text).not_to include("SIBLING SECRET")
+      ensure
+        FileUtils.rm_f(symlink) if defined?(symlink)
+        FileUtils.rm_rf(sibling_dir) if defined?(sibling_dir)
+      end
+
+      it "blocks sensitive files resolved via symlink (post-realpath recheck)" do
+        # The caller-supplied path uses an .html.erb extension so the EARLY
+        # `sensitive_file?(path)` guard does NOT fire. The block has to come
+        # from the post-realpath recheck (line ~262 of get_view.rb), which
+        # canonicalizes the symlink target and then re-runs sensitive_file?
+        # against the relative real path. This isolates that defense from
+        # the early-guard layer.
+        secret = Rails.root.join("config", "_gv_test_master_#{Process.pid}.key")
+        File.write(secret, "should-never-leak")
+        symlink = views_dir.join("gv_leak_secret_#{Process.pid}.html.erb")
+        File.symlink(secret, symlink)
+
+        result = described_class.call(path: "gv_leak_secret_#{Process.pid}.html.erb")
+        text = result.content.first[:text]
+        expect(text).to match(/sensitive|not allowed|denied/)
+        expect(text).not_to include("should-never-leak")
+      ensure
+        FileUtils.rm_f(symlink) if defined?(symlink)
+        FileUtils.rm_f(secret) if defined?(secret)
+      end
+
+      it "rejects sensitive caller-supplied paths before any filesystem stat" do
+        result = described_class.call(path: "../../config/master.key")
+        text = result.content.first[:text]
+        expect(text).to match(/not allowed|denied|sensitive/)
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_context/tools/query_spec.rb
+++ b/spec/lib/rails_ai_context/tools/query_spec.rb
@@ -342,22 +342,125 @@ RSpec.describe RailsAiContext::Tools::Query do
       end
     end
 
-    context "column redaction" do
-      it "redacts sensitive columns in results" do
-        # Create a mock result with a password_digest column
-        columns = %w[id email password_digest]
-        rows = [ [ 1, "user@example.com", "$2a$12$secrethash" ] ]
-        mock_result = ActiveRecord::Result.new(columns, rows)
+    context "sensitive column reference rejection (pre-execution)" do
+      # v5.8.1 replaced post-execution redaction with pre-execution rejection.
+      # Post-execution redaction runs on `result.columns`, which the caller
+      # controls via aliases and expressions — trivially bypassable by
+      # `SELECT password_digest AS x FROM users`. Reject at validate_sql instead.
 
-        allow(ActiveRecord::Base.connection).to receive(:select_all).and_return(mock_result)
-        # Skip the PRAGMA calls for this mock test
-        allow(ActiveRecord::Base.connection).to receive(:execute)
+      it "rejects a direct reference to a sensitive column" do
+        valid, error = described_class.validate_sql("SELECT id, email, password_digest FROM users")
+        expect(valid).to be false
+        expect(error).to include("sensitive column")
+        expect(error).to include("password_digest")
+      end
 
-        result = described_class.call(sql: "SELECT id, email, password_digest FROM users")
-        text = result.content.first[:text]
-        expect(text).to include("[REDACTED]")
-        expect(text).to include("user@example.com")
-        expect(text).not_to include("$2a$12$secrethash")
+      it "rejects an aliased reference (SELECT password_digest AS x)" do
+        valid, error = described_class.validate_sql("SELECT password_digest AS x FROM users LIMIT 50")
+        expect(valid).to be false
+        expect(error).to include("password_digest")
+      end
+
+      it "rejects a function-wrapped reference (substring)" do
+        valid, error = described_class.validate_sql("SELECT substring(password_digest, 1, 60) FROM users")
+        expect(valid).to be false
+        expect(error).to include("password_digest")
+      end
+
+      it "rejects an md5() reference on encrypted/session data" do
+        valid, error = described_class.validate_sql("SELECT md5(session_data) FROM sessions")
+        expect(valid).to be false
+        expect(error).to include("session_data")
+      end
+
+      it "rejects a subquery that projects the sensitive column" do
+        valid, error = described_class.validate_sql("SELECT v FROM (SELECT password_digest AS v FROM users) sub")
+        expect(valid).to be false
+        expect(error).to include("password_digest")
+      end
+
+      it "rejects CASE expressions that project the sensitive column" do
+        valid, error = described_class.validate_sql("SELECT CASE WHEN id > 0 THEN password_digest END FROM users")
+        expect(valid).to be false
+        expect(error).to include("password_digest")
+      end
+
+      it "rejects references to configured query_redacted_columns" do
+        RailsAiContext.configuration.query_redacted_columns = %w[custom_secret_field]
+        valid, error = described_class.validate_sql("SELECT custom_secret_field AS y FROM tenants")
+        expect(valid).to be false
+        expect(error).to include("custom_secret_field")
+      ensure
+        RailsAiContext.configuration.query_redacted_columns = %w[
+          password_digest encrypted_password password_hash
+          reset_password_token confirmation_token unlock_token
+          otp_secret session_data secret_key
+          api_key api_secret access_token refresh_token jti
+        ]
+      end
+
+      it "does not false-positive on unrelated columns containing a substring" do
+        # `keyword` contains "key" as a substring but the match is word-bounded
+        # so this should pass. `description` contains "script" — fine.
+        valid, error = described_class.validate_sql("SELECT id, keyword, description FROM tags")
+        expect(valid).to be true
+        expect(error).to be_nil
+      end
+    end
+
+    context "blocked dangerous functions (filesystem/network primitives)" do
+      it "blocks pg_read_file" do
+        valid, error = described_class.validate_sql("SELECT pg_read_file('/etc/passwd')")
+        expect(valid).to be false
+        expect(error).to include("pg_read_file")
+      end
+
+      it "blocks pg_read_binary_file" do
+        valid, error = described_class.validate_sql("SELECT pg_read_binary_file('/etc/shadow')")
+        expect(valid).to be false
+        expect(error).to include("pg_read_binary_file")
+      end
+
+      it "blocks pg_ls_dir" do
+        valid, error = described_class.validate_sql("SELECT pg_ls_dir('/home/dev/.ssh')")
+        expect(valid).to be false
+        expect(error).to include("pg_ls_dir")
+      end
+
+      it "blocks pg_stat_file" do
+        valid, error = described_class.validate_sql("SELECT pg_stat_file('/etc/passwd')")
+        expect(valid).to be false
+        expect(error).to include("pg_stat_file")
+      end
+
+      it "blocks lo_import" do
+        valid, error = described_class.validate_sql("SELECT lo_import('/etc/passwd')")
+        expect(valid).to be false
+        expect(error).to include("lo_import")
+      end
+
+      it "blocks dblink" do
+        valid, error = described_class.validate_sql("SELECT * FROM dblink('host=evil.com', 'SELECT 1') AS t(a int)")
+        expect(valid).to be false
+        expect(error).to include("dblink")
+      end
+
+      it "blocks MySQL LOAD_FILE" do
+        valid, error = described_class.validate_sql("SELECT LOAD_FILE('/etc/passwd')")
+        expect(valid).to be false
+        expect(error).to match(/load_file/i)
+      end
+
+      it "blocks SQLite load_extension" do
+        valid, error = described_class.validate_sql("SELECT load_extension('/tmp/lib.so')")
+        expect(valid).to be false
+        expect(error).to include("load_extension")
+      end
+
+      it "blocks SELECT INTO OUTFILE (MySQL)" do
+        valid, error = described_class.validate_sql("SELECT 1 INTO OUTFILE '/tmp/leak.txt'")
+        expect(valid).to be false
+        expect(error).to match(/OUTFILE|SELECT INTO/)
       end
     end
 

--- a/spec/lib/rails_ai_context/tools/query_spec.rb
+++ b/spec/lib/rails_ai_context/tools/query_spec.rb
@@ -451,6 +451,18 @@ RSpec.describe RailsAiContext::Tools::Query do
         expect(error).to match(/load_file/i)
       end
 
+      it "blocks MySQL LOAD DATA INFILE" do
+        valid, error = described_class.validate_sql("LOAD DATA INFILE '/etc/passwd' INTO TABLE users")
+        expect(valid).to be false
+        expect(error).to match(/LOAD.*DATA/i)
+      end
+
+      it "blocks MySQL LOAD DATA LOCAL INFILE" do
+        valid, error = described_class.validate_sql("LOAD DATA LOCAL INFILE '/etc/passwd' INTO TABLE users")
+        expect(valid).to be false
+        expect(error).to match(/LOAD.*DATA/i)
+      end
+
       it "blocks SQLite load_extension" do
         valid, error = described_class.validate_sql("SELECT load_extension('/tmp/lib.so')")
         expect(valid).to be false

--- a/spec/lib/rails_ai_context/tools/search_code_spec.rb
+++ b/spec/lib/rails_ai_context/tools/search_code_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe RailsAiContext::Tools::SearchCode do
       expect(text).to match(/Path not (found|allowed)/)
     end
 
+    it "blocks sibling-directory escape via File::SEPARATOR-aware containment" do
+      # A realpath like /app/myapp_evil would pass start_with?("/app/myapp") without
+      # the separator suffix — the fix adds File::SEPARATOR to close this gap.
+      Dir.mktmpdir("rac_sibling_") do |sibling_dir|
+        result = described_class.call(pattern: "test", path: sibling_dir)
+        text = result.content.first[:text]
+        expect(text).to match(/Path not (found|allowed)/)
+      end
+    end
+
     it "returns results for a valid search" do
       result = described_class.call(pattern: "ActiveRecord::Schema")
       text = result.content.first[:text]

--- a/spec/lib/rails_ai_context/tools/validate_spec.rb
+++ b/spec/lib/rails_ai_context/tools/validate_spec.rb
@@ -47,9 +47,24 @@ RSpec.describe RailsAiContext::Tools::Validate do
     end
 
     it "skips unsupported file types" do
-      result = described_class.call(files: [ "config/database.yml" ])
+      # package.json is neither sensitive nor a validatable language — it
+      # should be skipped, not denied. (Previously this test used
+      # config/database.yml which is now blocked by the v5.8.1 expanded
+      # sensitive_patterns list.)
+      result = described_class.call(files: [ "package.json" ])
       text = result.content.first[:text]
       expect(text).to include("skipped")
+    end
+
+    it "denies access to sensitive files (v5.8.1)" do
+      # config/database.yml, .env, config/master.key — all blocked by the
+      # v5.8.1 sensitive_patterns expansion. validate.rb previously had no
+      # sensitive_file? check at all, so these would be read + probed via
+      # error messages.
+      result = described_class.call(files: [ "config/database.yml" ])
+      text = result.content.first[:text]
+      expect(text).to include("access denied")
+      expect(text).to include("sensitive file")
     end
 
     it "returns empty message for no files" do

--- a/spec/lib/rails_ai_context/vfs_spec.rb
+++ b/spec/lib/rails_ai_context/vfs_spec.rb
@@ -166,6 +166,44 @@ RSpec.describe RailsAiContext::VFS do
         data = JSON.parse(result.first[:text])
         expect(data["error"]).to include("not found")
       end
+
+      it "blocks sibling-directory traversal via symlink (v5.8.1 C1)" do
+        # Reproduces the v5.8.1 security review finding: String#start_with?
+        # without a File::SEPARATOR check matches `/a/views_spec` against
+        # `/a/views` prefix, letting a symlink in app/views/ escape to a
+        # sibling directory.
+        sibling_dir = Rails.root.join("app", "views_spec_#{Process.pid}")
+        FileUtils.mkdir_p(sibling_dir)
+        secret_file = sibling_dir.join("secret.html.erb")
+        File.write(secret_file, "<h1>SIBLING SECRET</h1>")
+
+        symlink = views_dir.join("leak_#{Process.pid}.html.erb")
+        File.symlink(secret_file, symlink)
+
+        expect {
+          described_class.resolve("rails-ai-context://views/leak_#{Process.pid}.html.erb")
+        }.to raise_error(RailsAiContext::Error, /not allowed/)
+      ensure
+        FileUtils.rm_f(symlink) if defined?(symlink)
+        FileUtils.rm_rf(sibling_dir) if defined?(sibling_dir)
+      end
+
+      it "blocks sensitive files resolved via symlink (v5.8.1 C1 defense-in-depth)" do
+        # If a .key or .env file is symlinked into app/views/, the realpath
+        # would be under views_dir but the file is sensitive. sensitive_file?
+        # on the realpath catches this.
+        secret = Rails.root.join("config", "_vfs_test_master_#{Process.pid}.key")
+        File.write(secret, "should-never-leak")
+        symlink = views_dir.join("leak_secret_#{Process.pid}.key")
+        File.symlink(secret, symlink)
+
+        expect {
+          described_class.resolve("rails-ai-context://views/leak_secret_#{Process.pid}.key")
+        }.to raise_error(RailsAiContext::Error, /sensitive|not allowed/)
+      ensure
+        FileUtils.rm_f(symlink) if defined?(symlink)
+        FileUtils.rm_f(secret) if defined?(secret)
+      end
     end
 
     context "unknown URI" do


### PR DESCRIPTION
## Summary

Security hardening patch for v5.8.1, validated through 3 rounds of independent code review and E2E testing of all 38 MCP tools.

### Security fixes (exploitable vulnerabilities)
- **VFS path traversal (C1)**: `resolve_view` sibling-directory bypass via bare `start_with?` without `File::SEPARATOR` — now closed in `vfs.rb`, `get_view.rb`, `get_partial_interface.rb`, `search_code.rb`
- **Instrumentation data leak (C2)**: raw `tool_arguments` (SQL, env var names, log search patterns) forwarded to `ActiveSupport::Notifications` subscribers — stripped via `SAFE_KEYS` allowlist; full lambda now wrapped in blast-shield rescue
- **SQL filesystem pivot**: `pg_read_file`, `lo_import`, `dblink`, `LOAD_FILE`, `LOAD DATA INFILE`, `load_extension` blocked via `BLOCKED_FUNCTIONS` regex before execution
- **SQL column-aliasing redaction bypass**: pre-execution `SENSITIVE_COLUMN_SUFFIXES` check replaces bypassable post-execution redaction

### Additional hardening
- `analyze_feature`: `Dir.glob` results capped at `MAX_SCAN_FILES=500` across all discover_* methods
- `get_partial_interface`: TOCTOU closed — `resolve_partial_path` returns `real_found`; all file ops use the checked realpath
- `validate`: `Pathname(real)` passed to all validator methods; `sensitive_file?` checked before any filesystem access
- `get_edit_context`: post-realpath `sensitive_file?` recheck added
- `schema_introspector`: fresh Rails apps with 0-byte `schema.rb` return helpful empty-schema state
- `fingerprinter`: gem-lib fingerprint memoized (~59x hot-path speedup in dev mode)

### Test coverage
- 2004 examples, 0 failures (was 1928 in v5.8.0, +76 new regression specs)

## Test plan
- [x] Full RSpec suite: 2004 examples, 0 failures
- [x] Rubocop: 0 offenses on all changed files
- [x] All 38 MCP tools exercised against combustion test app
- [x] All path traversal vectors confirmed blocked
- [x] 3 rounds of independent cold-eyes code review (security + correctness + coverage)