### PR TITLE
fix: Cursor chat agent rule detection — restore legacy .cursorrules fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,17 @@ Real user report during release QA: the Cursor IDE's chat agent didn't pick up r
 
 `CursorRulesSerializer` now writes **both**: `.cursor/rules/*.mdc` (newer format with frontmatter / glob scoping / agent-requested triggers) AND a plain-text `.cursorrules` at the project root (legacy fallback, parsed verbatim by every Cursor build). Newer clients read the mdc files; older / chat-mode clients read `.cursorrules`. No behavior change for users who already relied on the mdc format.
 
+The `.cursorrules` content goes through the **same** `CompactSerializerHelper#render_compact_rules` pipeline as `CLAUDE.md`, so both files convey identical project context — header, stack overview, key models, gems, architecture, commands, rules, and the MCP tool guide. Drift between the two files is no longer possible short of a manual divergence (regression spec enforces parity).
+
+`.cursorrules` is **wrapped in `<!-- BEGIN/END rails-ai-context -->` markers** via the new `SectionMarkerWriter` module — same convention as `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md`. Pre-existing user content above or below the marker block survives every `rails ai:context` regeneration. Three regression specs cover the three branches: no-file → write markers; existing-without-markers → prepend gem block; existing-with-markers → replace only the gem block.
+
 `FORMAT_PATHS[:cursor]` in the install generator now includes `.cursorrules` so re-install cleanup covers both files when a user removes Cursor from their selection. Regression specs added in `cursor_rules_serializer_spec.rb` and `in_gemfile_install_spec.rb` (e2e) verify both files are produced and the legacy file is plain text without frontmatter.
+
+### Fixed — Round 3 follow-ups (post-quad-agent review)
+
+- **`safe_glob_realpath` rescue widened.** Previously rescued only `Errno::ENOENT` and `Errno::EACCES`. Circular symlink chains (think `node_modules/@scope/*` cycles or developer-crafted loops) raise `Errno::ELOOP`; path components exceeding `NAME_MAX` raise `Errno::ENAMETOOLONG`. Both now rescued — return `nil` to skip the entry — preserving the CLAUDE.md invariant that every introspector wraps errors.
+
+- **Install generator `CONFIG_SECTIONS` gained 3 sections.** Several user-facing config options existed in `Configuration::YAML_KEYS` but had no commented-out template line in the generated `config/initializers/rails_ai_context.rb`. Added "Database Query Tool" (`query_timeout`, `query_row_limit`, `query_redacted_columns`, `allow_query_in_production`), "Log Reading" (`log_lines`), and "Hydration" (`hydration_enabled`, `hydration_max_hints`) sections so in-Gemfile installs surface every supported knob.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.9.0] — 2026-04-16
 
+### Fixed — Cursor chat agent didn't detect rules
+
+Real user report during release QA: the Cursor IDE's chat agent didn't pick up rules written only as `.cursor/rules/*.mdc`, even when the rule declared `alwaysApply: true`. Cursor has **two** rule systems and the chat-agent composition path still consults the legacy `.cursorrules` file in many current builds.
+
+`CursorRulesSerializer` now writes **both**: `.cursor/rules/*.mdc` (newer format with frontmatter / glob scoping / agent-requested triggers) AND a plain-text `.cursorrules` at the project root (legacy fallback, parsed verbatim by every Cursor build). Newer clients read the mdc files; older / chat-mode clients read `.cursorrules`. No behavior change for users who already relied on the mdc format.
+
+`FORMAT_PATHS[:cursor]` in the install generator now includes `.cursorrules` so re-install cleanup covers both files when a user removes Cursor from their selection. Regression specs added in `cursor_rules_serializer_spec.rb` and `in_gemfile_install_spec.rb` (e2e) verify both files are produced and the legacy file is plain text without frontmatter.
+
 ### Added
 
 - **`preset` command** — composite multi-tool workflows from CLI and rake. `rails ai:preset[architecture]` runs `analyze_feature` + `dependency_graph` + `performance_check` in one call. Also: `debugging` (logs + review + validate) and `migration` (schema + migration_advisor + validate). Available via both `rails-ai-context preset architecture` and `rails 'ai:preset[architecture]'`.

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Plus 9 static resources (schema, routes, conventions, gems, controllers, config,
 Every generated context file ships with **6 rules that force AI verification** before writing code. The protocol targets the exact cognitive failures that produce confident-wrong code: statistical priors overriding observed facts, pattern completion beating verification, stale context lies.
 
 <details>
-<summary><strong>The 6 rules (shown to AI in every CLAUDE.md / .cursor/rules / .github/instructions)</strong></summary>
+<summary><strong>The 6 rules (shown to AI in every CLAUDE.md / .cursor/rules / .cursorrules / .github/instructions)</strong></summary>
 
 <br>
 
@@ -403,7 +403,7 @@ graph TD
 
     B --> C["MCP Server\nstdio / HTTP\n38 tools · 5 templates"]
     B --> D["CLI Tools\nRake / Thor\nSame 38 tools"]
-    B --> E["Static Files\nCLAUDE.md · .cursor/rules/\n.github/instructions/"]
+    B --> E["Static Files\nCLAUDE.md · .cursor/rules/ · .cursorrules\n.github/instructions/"]
 
     style A fill:#4a9eff,stroke:#2d7ad4,color:#fff
     style B fill:#2d2d2d,stroke:#555,color:#fff

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <br>
 [![Ruby](https://img.shields.io/badge/Ruby-3.2%20%7C%203.3%20%7C%203.4-CC342D)](https://github.com/crisnahine/rails-ai-context)
 [![Rails](https://img.shields.io/badge/Rails-7.1%20%7C%207.2%20%7C%208.0-CC0000)](https://github.com/crisnahine/rails-ai-context)
-[![Tests](https://img.shields.io/badge/Tests-2075%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
+[![Tests](https://img.shields.io/badge/Tests-2078%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>
@@ -543,7 +543,7 @@ end
 ## About
 
 Built by a Rails developer with 10+ years of production experience.<br>
-2075 tests + 100-example e2e harness. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
+2078 tests + 100-example e2e harness. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
 MIT licensed. [Contributions welcome.](CONTRIBUTING.md)
 
 <br>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <br>
 [![Ruby](https://img.shields.io/badge/Ruby-3.2%20%7C%203.3%20%7C%203.4-CC342D)](https://github.com/crisnahine/rails-ai-context)
 [![Rails](https://img.shields.io/badge/Rails-7.1%20%7C%207.2%20%7C%208.0-CC0000)](https://github.com/crisnahine/rails-ai-context)
-[![Tests](https://img.shields.io/badge/Tests-1989%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
+[![Tests](https://img.shields.io/badge/Tests-2075%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>
@@ -543,7 +543,7 @@ end
 ## About
 
 Built by a Rails developer with 10+ years of production experience.<br>
-1989 tests. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
+2075 tests + 100-example e2e harness. 38 tools. 5 resource templates. 31 introspectors. Standalone or in-Gemfile.<br>
 MIT licensed. [Contributions welcome.](CONTRIBUTING.md)
 
 <br>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -173,7 +173,7 @@ Result: controller and view tools automatically include relevant schema informat
 |:-----------|:-------|
 | `ClaudeSerializer` | `CLAUDE.md` |
 | `ClaudeRulesSerializer` | `.claude/rules/*.md` |
-| `CursorRulesSerializer` | `.cursor/rules/*.mdc` |
+| `CursorRulesSerializer` | `.cursor/rules/*.mdc` AND `.cursorrules` (legacy chat-agent fallback) |
 | `CopilotSerializer` | `.github/copilot-instructions.md` |
 | `CopilotInstructionsSerializer` | `.github/instructions/*.instructions.md` |
 | `OpencodeSerializer` | `AGENTS.md` (root) |

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -53,7 +53,7 @@ Yes, freely. Both generate identical context files and provide the same 38 tools
 
 **Yes, commit these:**
 - `.mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json`, `opencode.json`, `.codex/config.toml` — so teammates get MCP auto-discovery
-- `CLAUDE.md`, `.cursor/rules/`, `.github/instructions/`, `AGENTS.md` — so AI has context
+- `CLAUDE.md`, `.cursor/rules/`, `.cursorrules`, `.github/instructions/`, `AGENTS.md` — so AI has context
 - `config/initializers/rails_ai_context.rb`, `.rails-ai-context.yml` — so config is shared
 
 **Don't commit:**
@@ -126,7 +126,7 @@ Depends on your `ai_tools` config. For all tools:
 | AI Tool | Files |
 |:--------|:------|
 | Claude | CLAUDE.md, .claude/rules/*.md |
-| Cursor | .cursor/rules/*.mdc |
+| Cursor | .cursor/rules/*.mdc AND .cursorrules (legacy fallback for chat agent) |
 | Copilot | .github/copilot-instructions.md, .github/instructions/*.instructions.md |
 | OpenCode | AGENTS.md, app/*/AGENTS.md |
 | Codex | Shares AGENTS.md and OpenCode rules |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -55,7 +55,7 @@ The install generator created:
 | File | Purpose |
 |:-----|:--------|
 | `.mcp.json` / `.cursor/mcp.json` / `.vscode/mcp.json` / `opencode.json` / `.codex/config.toml` | MCP auto-discovery — your AI tool detects these on project open |
-| `CLAUDE.md` / `.cursor/rules/` / `.github/instructions/` | Static context rules your AI reads |
+| `CLAUDE.md` / `.cursor/rules/` / `.cursorrules` / `.github/instructions/` / `AGENTS.md` | Static context rules your AI reads |
 | `config/initializers/rails_ai_context.rb` | All configuration options |
 | `.rails-ai-context.yml` | Config for standalone mode |
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -107,10 +107,11 @@ rails generate rails_ai_context:install  # Select "Cursor"
 
 This creates:
 - `.cursor/mcp.json` — MCP auto-discovery config
-- `.cursor/rules/rails-project.mdc` — Project overview
-- `.cursor/rules/rails-models.mdc` — Model rules
-- `.cursor/rules/rails-controllers.mdc` — Controller rules
-- `.cursor/rules/rails-mcp-tools.mdc` — Tool reference (agent-requested, Type 3)
+- `.cursor/rules/rails-project.mdc` — Project overview (Type 1: alwaysApply)
+- `.cursor/rules/rails-models.mdc` — Model rules (Type 2: glob `app/models/**/*.rb`)
+- `.cursor/rules/rails-controllers.mdc` — Controller rules (Type 2: glob `app/controllers/**/*.rb`)
+- `.cursor/rules/rails-mcp-tools.mdc` — Tool reference (Type 3: agent-requested)
+- `.cursorrules` — **legacy single-file fallback** at the project root. Cursor's chat agent doesn't always detect `.cursor/rules/*.mdc` (reported in v5.9.0 release QA); this file is parsed verbatim by every Cursor build and contains the same compact project context as `CLAUDE.md`.
 
 ### Manual MCP config
 

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -333,7 +333,7 @@ class RailsAiContextCLI < Thor
 
     AI_TOOL_OPTIONS = {
       "1" => { key: :claude,   name: "Claude Code",    files: "CLAUDE.md + .claude/rules/" },
-      "2" => { key: :cursor,   name: "Cursor",         files: ".cursor/rules/" },
+      "2" => { key: :cursor,   name: "Cursor",         files: ".cursor/rules/ + .cursorrules (legacy fallback)" },
       "3" => { key: :copilot,  name: "GitHub Copilot", files: ".github/copilot-instructions.md + .github/instructions/" },
       "4" => { key: :opencode, name: "OpenCode",       files: "AGENTS.md" },
       "5" => { key: :codex,   name: "Codex CLI",      files: "AGENTS.md + .codex/config.toml" }
@@ -386,7 +386,7 @@ class RailsAiContextCLI < Thor
     # McpConfigGenerator.remove to preserve other servers' entries.
     FORMAT_PATHS = {
       claude:   %w[CLAUDE.md .claude/rules],
-      cursor:   %w[.cursor/rules],
+      cursor:   %w[.cursor/rules .cursorrules],
       copilot:  %w[.github/copilot-instructions.md .github/instructions],
       opencode: %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md],
       codex:    %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md]

--- a/lib/generators/rails_ai_context/install/install_generator.rb
+++ b/lib/generators/rails_ai_context/install/install_generator.rb
@@ -259,6 +259,42 @@ module RailsAiContext
             # File patterns blocked from search and read tools
             # config.sensitive_patterns += %w[config/secrets.yml]
         SECTION
+        "Database Query Tool" => <<~SECTION,
+            # ── Database Query Tool (rails_query) ─────────────────────────────
+            # Per-query statement timeout in seconds. Default: 5.
+            # config.query_timeout = 5
+
+            # Hard cap on rows returned by a single query (1..1000).
+            # Prevents accidentally pulling a million-row table into the
+            # AI's context. Default: 100.
+            # config.query_row_limit = 100
+
+            # Additional column names whose values are redacted in tool
+            # output. Defaults already cover password_digest,
+            # encrypted_password, *_token, *_secret, *_key, etc.
+            # config.query_redacted_columns += %w[my_app_specific_secret]
+
+            # rails_query is DISABLED in production by default. Setting
+            # this to true is rarely correct — only do so if you have
+            # audit logging + access controls around your AI client.
+            # config.allow_query_in_production = false
+        SECTION
+        "Log Reading" => <<~SECTION,
+            # ── Log Reading (rails_read_logs) ─────────────────────────────────
+            # Default tail length when reading a log file. Larger values
+            # surface more context but cost more AI tokens per call.
+            # config.log_lines = 50
+        SECTION
+        "Hydration" => <<~SECTION,
+            # ── Hydration ─────────────────────────────────────────────────────
+            # When enabled, MCP tool responses include schema hints telling
+            # the AI which related tools to call next. Helps agents
+            # traverse the introspection graph efficiently. Default: true.
+            # config.hydration_enabled = true
+
+            # Maximum number of hydration hints embedded per tool response.
+            # config.hydration_max_hints = 5
+        SECTION
         "Search" => <<~SECTION,
             # ── Search ────────────────────────────────────────────────────────
             # File extensions for fallback search (when ripgrep unavailable)

--- a/lib/generators/rails_ai_context/install/install_generator.rb
+++ b/lib/generators/rails_ai_context/install/install_generator.rb
@@ -11,7 +11,7 @@ module RailsAiContext
 
       AI_TOOLS = {
         "1" => { key: :claude,   name: "Claude Code",     files: "CLAUDE.md + .claude/rules/",                        format: :claude },
-        "2" => { key: :cursor,   name: "Cursor",          files: ".cursor/rules/",                                     format: :cursor },
+        "2" => { key: :cursor,   name: "Cursor",          files: ".cursor/rules/ + .cursorrules (legacy fallback)",    format: :cursor },
         "3" => { key: :copilot,  name: "GitHub Copilot",  files: ".github/copilot-instructions.md + .github/instructions/", format: :copilot },
         "4" => { key: :opencode, name: "OpenCode",        files: "AGENTS.md",                                          format: :opencode },
         "5" => { key: :codex,   name: "Codex CLI",       files: "AGENTS.md + .codex/config.toml",                     format: :codex }

--- a/lib/generators/rails_ai_context/install/install_generator.rb
+++ b/lib/generators/rails_ai_context/install/install_generator.rb
@@ -22,7 +22,7 @@ module RailsAiContext
       # McpConfigGenerator.remove to preserve other servers' entries.
       FORMAT_PATHS = {
         claude:   %w[CLAUDE.md .claude/rules],
-        cursor:   %w[.cursor/rules],
+        cursor:   %w[.cursor/rules .cursorrules],
         copilot:  %w[.github/copilot-instructions.md .github/instructions],
         opencode: %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md],
         codex:    %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md]

--- a/lib/rails_ai_context/doctor.rb
+++ b/lib/rails_ai_context/doctor.rb
@@ -168,8 +168,11 @@ module RailsAiContext
 
     # ── Context file checks ───────────────────────────────────────────
 
-    # Per-tool context paths — root files or split rule directories.
-    # Some tools (cursor) produce only split rules, no root file.
+    # Per-tool context path — sentinel checked for the freshness check.
+    # Other files generated alongside are assumed in-sync (they're written
+    # atomically by the same serializer). For Cursor, `.cursor/rules/` is
+    # the sentinel; `.cursorrules` (v5.9.0 legacy fallback) is generated
+    # atomically next to it, so checking either proves both are fresh.
     CONTEXT_FILES = {
       claude:   "CLAUDE.md",
       cursor:   ".cursor/rules",

--- a/lib/rails_ai_context/serializers/claude_serializer.rb
+++ b/lib/rails_ai_context/serializers/claude_serializer.rb
@@ -21,84 +21,8 @@ module RailsAiContext
         if RailsAiContext.configuration.context_mode == :full
           FullClaudeSerializer.new(context).call
         else
-          render_compact
+          render_compact_rules
         end
-      end
-
-      private
-
-      def render_compact
-        lines = []
-        lines.concat(render_header)
-        lines.concat(render_stack_overview)
-        lines.concat(render_key_models)
-        lines.concat(render_notable_gems)
-        lines.concat(render_architecture)
-        lines.concat(render_commands)
-        lines.concat(render_warnings)
-        lines.concat(render_footer)
-        lines.concat(render_tools_guide_compact)
-
-        enforce_max_lines(lines)
-      end
-
-      def render_architecture
-        conv = context[:conventions]
-        return [] unless conv.is_a?(Hash) && !conv[:error]
-
-        arch = conv[:architecture] || []
-        patterns = conv[:patterns] || []
-        return [] if arch.empty? && patterns.empty?
-
-        arch_labels = arch_labels_hash
-        pattern_labels = pattern_labels_hash
-
-        lines = [ "## Architecture" ]
-        arch.each { |p| lines << "- #{arch_labels[p] || p}" }
-        patterns.first(8).each { |p| lines << "- #{pattern_labels[p] || p}" }
-
-        dir_struct = conv[:directory_structure] || {}
-
-        if dir_struct["app/services"]
-          services = detect_service_files
-          lines << "" << "**Services:** #{services.join(', ')}" if services.any?
-        end
-
-        if dir_struct["app/jobs"]
-          jobs = detect_job_files
-          lines << "**Jobs:** #{jobs.join(', ')}" if jobs.any?
-        end
-
-        lines << ""
-        lines
-      end
-
-      def render_footer
-        test_cmd = detect_test_command
-        lines = [ "## Rules" ]
-        lines << "- Run `#{test_cmd}` after changes"
-        lines << "- Do NOT re-read files to verify edits — trust your Edit, validate syntax only"
-
-        conv = context[:conventions]
-        if conv.is_a?(Hash) && !conv[:error]
-          arch = conv[:architecture] || []
-          lines << "- Follow #{arch.join(' + ')} architecture" if arch.any?
-          patterns = conv[:patterns] || []
-          lines << "- Use service objects for business logic" if patterns.include?("service_objects")
-          lines << "- Use form objects for complex forms" if patterns.include?("form_objects")
-          lines << "- Use query objects for complex queries" if patterns.include?("query_objects")
-        end
-
-        stimulus = context[:stimulus]
-        if stimulus.is_a?(Hash) && !stimulus[:error] && (stimulus[:controllers]&.any? || stimulus[:total_controllers]&.positive?)
-          lines << "- Stimulus controllers auto-register — no manual import in controllers/index.js needed"
-        end
-
-        before_actions = detect_before_actions
-        lines << "- Global before_actions: #{before_actions.join(', ')}" if before_actions.any?
-
-        lines << ""
-        lines
       end
     end
 

--- a/lib/rails_ai_context/serializers/compact_serializer_helper.rb
+++ b/lib/rails_ai_context/serializers/compact_serializer_helper.rb
@@ -132,6 +132,87 @@ module RailsAiContext
         end
         lines.join("\n")
       end
+
+      # Architecture / conventions section — moved from ClaudeSerializer so
+      # Cursor (.cursorrules) and any future compact serializer can reuse.
+      def render_architecture
+        conv = context[:conventions]
+        return [] unless conv.is_a?(Hash) && !conv[:error]
+
+        arch = conv[:architecture] || []
+        patterns = conv[:patterns] || []
+        return [] if arch.empty? && patterns.empty?
+
+        arch_labels = arch_labels_hash
+        pattern_labels = pattern_labels_hash
+
+        lines = [ "## Architecture" ]
+        arch.each { |p| lines << "- #{arch_labels[p] || p}" }
+        patterns.first(8).each { |p| lines << "- #{pattern_labels[p] || p}" }
+
+        dir_struct = conv[:directory_structure] || {}
+
+        if dir_struct["app/services"]
+          services = detect_service_files
+          lines << "" << "**Services:** #{services.join(', ')}" if services.any?
+        end
+
+        if dir_struct["app/jobs"]
+          jobs = detect_job_files
+          lines << "**Jobs:** #{jobs.join(', ')}" if jobs.any?
+        end
+
+        lines << ""
+        lines
+      end
+
+      # Footer rules section — also moved from ClaudeSerializer.
+      def render_footer
+        test_cmd = detect_test_command
+        lines = [ "## Rules" ]
+        lines << "- Run `#{test_cmd}` after changes"
+        lines << "- Do NOT re-read files to verify edits — trust your Edit, validate syntax only"
+
+        conv = context[:conventions]
+        if conv.is_a?(Hash) && !conv[:error]
+          arch = conv[:architecture] || []
+          lines << "- Follow #{arch.join(' + ')} architecture" if arch.any?
+          patterns = conv[:patterns] || []
+          lines << "- Use service objects for business logic" if patterns.include?("service_objects")
+          lines << "- Use form objects for complex forms" if patterns.include?("form_objects")
+          lines << "- Use query objects for complex queries" if patterns.include?("query_objects")
+        end
+
+        stimulus = context[:stimulus]
+        if stimulus.is_a?(Hash) && !stimulus[:error] && (stimulus[:controllers]&.any? || stimulus[:total_controllers]&.positive?)
+          lines << "- Stimulus controllers auto-register — no manual import in controllers/index.js needed"
+        end
+
+        before_actions = detect_before_actions
+        lines << "- Global before_actions: #{before_actions.join(', ')}" if before_actions.any?
+
+        lines << ""
+        lines
+      end
+
+      # Full compact-rules pipeline. Used by ClaudeSerializer (writes to
+      # CLAUDE.md) and CursorRulesSerializer (writes to .cursorrules).
+      # Both files give an AI agent the same project context; only the
+      # filename / distribution mechanism differs.
+      def render_compact_rules
+        lines = []
+        lines.concat(render_header)
+        lines.concat(render_stack_overview)
+        lines.concat(render_key_models)
+        lines.concat(render_notable_gems)
+        lines.concat(render_architecture)
+        lines.concat(render_commands)
+        lines.concat(render_warnings)
+        lines.concat(render_footer)
+        lines.concat(render_tools_guide_compact)
+
+        enforce_max_lines(lines)
+      end
     end
   end
 end

--- a/lib/rails_ai_context/serializers/context_file_serializer.rb
+++ b/lib/rails_ai_context/serializers/context_file_serializer.rb
@@ -29,8 +29,10 @@ module RailsAiContext
 
       ALL_FORMATS = (FORMAT_MAP.keys + SPLIT_ONLY_FORMATS).freeze
 
-      BEGIN_MARKER = "<!-- BEGIN rails-ai-context -->"
-      END_MARKER   = "<!-- END rails-ai-context -->"
+      # Re-exported from SectionMarkerWriter so existing code that referenced
+      # ContextFileSerializer::BEGIN_MARKER / END_MARKER keeps working.
+      BEGIN_MARKER = SectionMarkerWriter::BEGIN_MARKER
+      END_MARKER   = SectionMarkerWriter::END_MARKER
 
       def initialize(context, format: :all)
         @context = context
@@ -103,42 +105,22 @@ module RailsAiContext
         end
       end
 
-      # Wrap content in section markers so user content is preserved
+      # Wrap content in section markers so user content is preserved.
+      # Delegates to SectionMarkerWriter (also used by CursorRulesSerializer
+      # for .cursorrules) so the marker contract is implemented in exactly
+      # one place.
       def write_with_markers(filepath, content, written, skipped)
-        marked_content = "#{BEGIN_MARKER}\n#{content}\n#{END_MARKER}\n"
-
-        if File.exist?(filepath)
-          existing = File.read(filepath)
-
-          new_content = if existing.include?(BEGIN_MARKER) && existing.include?(END_MARKER)
-            existing.sub(
-              /#{Regexp.escape(BEGIN_MARKER)}.*?#{Regexp.escape(END_MARKER)}\n?/m,
-              marked_content
-            )
-          else
-            # File exists without markers — prepend our section so AI reads it first
-            "#{marked_content}\n#{existing}"
-          end
-
-          if new_content == existing
-            skipped << filepath
-          else
-            atomic_write(filepath, new_content)
-            written << filepath
-          end
-        else
-          atomic_write(filepath, marked_content)
-          written << filepath
+        case SectionMarkerWriter.write_with_markers(filepath, content)
+        when :written then written << filepath
+        when :skipped then skipped << filepath
         end
       end
 
-      # Write via temp file + rename to avoid partial writes from concurrent processes
+      # Atomic write — same temp-file + rename pattern as
+      # SectionMarkerWriter.atomic_write. Kept here because write_plain
+      # (JSON path) calls it directly without the marker layer.
       def atomic_write(filepath, content)
-        dir = File.dirname(filepath)
-        FileUtils.mkdir_p(dir)
-        tmp = File.join(dir, ".#{File.basename(filepath)}.#{SecureRandom.hex(4)}.tmp")
-        File.write(tmp, content)
-        File.rename(tmp, filepath)
+        SectionMarkerWriter.atomic_write(filepath, content)
       end
 
       def generate_split_rules(formats, output_dir, written, skipped)

--- a/lib/rails_ai_context/serializers/context_file_serializer.rb
+++ b/lib/rails_ai_context/serializers/context_file_serializer.rb
@@ -29,11 +29,10 @@ module RailsAiContext
 
       ALL_FORMATS = (FORMAT_MAP.keys + SPLIT_ONLY_FORMATS).freeze
 
-      # Re-exported from SectionMarkerWriter so existing code that referenced
-      # ContextFileSerializer::BEGIN_MARKER / END_MARKER keeps working.
-      BEGIN_MARKER = SectionMarkerWriter::BEGIN_MARKER
-      END_MARKER   = SectionMarkerWriter::END_MARKER
-
+      # Section markers live exclusively on SectionMarkerWriter — anyone
+      # who needs them references SectionMarkerWriter::BEGIN_MARKER /
+      # END_MARKER directly. (Re-exports were considered for back-compat
+      # but no external code referenced ContextFileSerializer::BEGIN_MARKER.)
       def initialize(context, format: :all)
         @context = context
         @format  = format

--- a/lib/rails_ai_context/serializers/cursor_rules_serializer.rb
+++ b/lib/rails_ai_context/serializers/cursor_rules_serializer.rb
@@ -2,9 +2,17 @@
 
 module RailsAiContext
   module Serializers
-    # Generates .cursor/rules/*.mdc files in the new Cursor MDC format.
-    # Each file is focused, <50 lines, with YAML frontmatter.
-    # .cursorrules is deprecated by Cursor; this is the recommended format.
+    # Generates .cursor/rules/*.mdc files (new Cursor MDC format) AND a
+    # .cursorrules legacy fallback at the project root.
+    #
+    # Why both:
+    #   - .cursor/rules/*.mdc is the recommended format for Cursor 0.42+
+    #     with per-file scoping (alwaysApply / globs / description triggers)
+    #   - .cursorrules is still consulted by Cursor's chat agent in many
+    #     versions and is the only format older clients understand. Real
+    #     user report (v5.9.0 release QA): the chat agent didn't detect
+    #     rules written only as .cursor/rules/*.mdc; adding .cursorrules
+    #     alongside fixed it.
     class CursorRulesSerializer
       include StackOverviewHelper
       include ToolGuideHelper
@@ -24,7 +32,8 @@ module RailsAiContext
           File.join(rules_dir, "rails-project.mdc") => render_project_rule,
           File.join(rules_dir, "rails-models.mdc") => render_models_rule,
           File.join(rules_dir, "rails-controllers.mdc") => render_controllers_rule,
-          File.join(rules_dir, "rails-mcp-tools.mdc") => render_mcp_tools_rule
+          File.join(rules_dir, "rails-mcp-tools.mdc") => render_mcp_tools_rule,
+          File.join(output_dir, ".cursorrules")       => render_cursorrules_legacy
         }
 
         write_rule_files(files)
@@ -166,6 +175,57 @@ module RailsAiContext
         ]
 
         lines.concat(render_tools_guide)
+
+        lines.join("\n")
+      end
+
+      # Legacy .cursorrules fallback. Plain text, no frontmatter — Cursor's
+      # chat agent reads it unconditionally in every version (unlike the
+      # newer .cursor/rules/*.mdc files which some Cursor builds / modes
+      # don't auto-attach to chat context). Keep it concise so it doesn't
+      # bloat the agent's context window on every message.
+      def render_cursorrules_legacy
+        lines = [
+          "# #{context[:app_name]} — Rails project rules",
+          "",
+          "Rails #{context[:rails_version]} | Ruby #{context[:ruby_version]}",
+          ""
+        ]
+
+        schema = context[:schema]
+        lines << "- Database: #{schema[:adapter]} — #{schema[:total_tables]} tables" if schema && !schema[:error]
+
+        models = context[:models]
+        lines << "- Models: #{models.size}" if models.is_a?(Hash) && !models[:error]
+
+        routes = context[:routes]
+        lines << "- Routes: #{routes[:total_routes]}" if routes && !routes[:error]
+
+        conv = context[:conventions]
+        if conv.is_a?(Hash) && !conv[:error]
+          arch_labels = arch_labels_hash
+          (conv[:architecture] || []).first(5).each { |p| lines << "- #{arch_labels[p] || p}" }
+        end
+
+        lines << ""
+        lines << "## MCP tools"
+        lines << ""
+        lines << "This project has rails-ai-context installed. Use its MCP tools for ground-truth Rails context instead of guessing from file listings:"
+        lines << ""
+        lines << "- `rails_get_schema` — DB tables + columns + indexes"
+        lines << "- `rails_get_routes` — all routes with controller actions"
+        lines << "- `rails_get_model_details model:\"Name\"` — associations, validations, scopes, callbacks"
+        lines << "- `rails_get_controllers controller:\"Name\"` — actions, filters, params, rendered views"
+        lines << "- `rails_search_code pattern:\"...\"` — ripgrep across the app, respecting .gitignore"
+        lines << "- `rails_validate file:\"path\"` — semantic validation (columns, partials, routes) before commit"
+        lines << ""
+        lines << "Always call with `detail:\"summary\"` first, then drill into specifics. See .cursor/rules/rails-mcp-tools.mdc for the full tool list."
+        lines << ""
+        lines << "## Anti-hallucination"
+        lines << ""
+        lines << "- Never invent column names, association names, or route paths. Call `rails_get_schema` / `rails_get_routes` / `rails_get_model_details` first."
+        lines << "- Never assume a gem is installed. Check `rails_get_gems` or the Gemfile."
+        lines << "- When editing an existing file, read the surrounding code via `rails_get_edit_context` before applying changes."
 
         lines.join("\n")
       end

--- a/lib/rails_ai_context/serializers/cursor_rules_serializer.rb
+++ b/lib/rails_ai_context/serializers/cursor_rules_serializer.rb
@@ -30,15 +30,30 @@ module RailsAiContext
       def call(output_dir)
         rules_dir = File.join(output_dir, ".cursor", "rules")
 
-        files = {
-          File.join(rules_dir, "rails-project.mdc") => render_project_rule,
-          File.join(rules_dir, "rails-models.mdc") => render_models_rule,
+        # Split rule files (.cursor/rules/*.mdc) are fully gem-owned —
+        # written as-is with no markers (the gem manages every file in
+        # that directory).
+        mdc_files = {
+          File.join(rules_dir, "rails-project.mdc")    => render_project_rule,
+          File.join(rules_dir, "rails-models.mdc")     => render_models_rule,
           File.join(rules_dir, "rails-controllers.mdc") => render_controllers_rule,
-          File.join(rules_dir, "rails-mcp-tools.mdc") => render_mcp_tools_rule,
-          File.join(output_dir, ".cursorrules")       => render_cursorrules_legacy
+          File.join(rules_dir, "rails-mcp-tools.mdc")  => render_mcp_tools_rule
         }
+        result = write_rule_files(mdc_files)
 
-        write_rule_files(files)
+        # .cursorrules is at the project root and may pre-date the gem
+        # install (users frequently hand-write .cursorrules before
+        # adopting any tooling). Wrap it in BEGIN/END markers like
+        # CLAUDE.md / AGENTS.md / .github/copilot-instructions.md so
+        # user content above/below the gem-managed block survives every
+        # `rails ai:context` regeneration.
+        cursorrules_path = File.join(output_dir, ".cursorrules")
+        case SectionMarkerWriter.write_with_markers(cursorrules_path, render_cursorrules_legacy)
+        when :written then result[:written] << cursorrules_path
+        when :skipped then result[:skipped] << cursorrules_path
+        end
+
+        result
       end
 
       private

--- a/lib/rails_ai_context/serializers/cursor_rules_serializer.rb
+++ b/lib/rails_ai_context/serializers/cursor_rules_serializer.rb
@@ -14,8 +14,10 @@ module RailsAiContext
     #     rules written only as .cursor/rules/*.mdc; adding .cursorrules
     #     alongside fixed it.
     class CursorRulesSerializer
+      include TestCommandDetection
       include StackOverviewHelper
       include ToolGuideHelper
+      include CompactSerializerHelper
 
       attr_reader :context
 
@@ -179,55 +181,15 @@ module RailsAiContext
         lines.join("\n")
       end
 
-      # Legacy .cursorrules fallback. Plain text, no frontmatter — Cursor's
-      # chat agent reads it unconditionally in every version (unlike the
-      # newer .cursor/rules/*.mdc files which some Cursor builds / modes
-      # don't auto-attach to chat context). Keep it concise so it doesn't
-      # bloat the agent's context window on every message.
+      # Legacy .cursorrules fallback. Same content pipeline as CLAUDE.md
+      # (render_compact_rules from CompactSerializerHelper) — both files
+      # give an AI agent the same project context; only the filename /
+      # distribution mechanism differs. Cursor's chat agent reads
+      # .cursorrules unconditionally in every version, so this serves as
+      # the guaranteed fallback while .cursor/rules/*.mdc is the
+      # preferred-when-supported scoped format.
       def render_cursorrules_legacy
-        lines = [
-          "# #{context[:app_name]} — Rails project rules",
-          "",
-          "Rails #{context[:rails_version]} | Ruby #{context[:ruby_version]}",
-          ""
-        ]
-
-        schema = context[:schema]
-        lines << "- Database: #{schema[:adapter]} — #{schema[:total_tables]} tables" if schema && !schema[:error]
-
-        models = context[:models]
-        lines << "- Models: #{models.size}" if models.is_a?(Hash) && !models[:error]
-
-        routes = context[:routes]
-        lines << "- Routes: #{routes[:total_routes]}" if routes && !routes[:error]
-
-        conv = context[:conventions]
-        if conv.is_a?(Hash) && !conv[:error]
-          arch_labels = arch_labels_hash
-          (conv[:architecture] || []).first(5).each { |p| lines << "- #{arch_labels[p] || p}" }
-        end
-
-        lines << ""
-        lines << "## MCP tools"
-        lines << ""
-        lines << "This project has rails-ai-context installed. Use its MCP tools for ground-truth Rails context instead of guessing from file listings:"
-        lines << ""
-        lines << "- `rails_get_schema` — DB tables + columns + indexes"
-        lines << "- `rails_get_routes` — all routes with controller actions"
-        lines << "- `rails_get_model_details model:\"Name\"` — associations, validations, scopes, callbacks"
-        lines << "- `rails_get_controllers controller:\"Name\"` — actions, filters, params, rendered views"
-        lines << "- `rails_search_code pattern:\"...\"` — ripgrep across the app, respecting .gitignore"
-        lines << "- `rails_validate file:\"path\"` — semantic validation (columns, partials, routes) before commit"
-        lines << ""
-        lines << "Always call with `detail:\"summary\"` first, then drill into specifics. See .cursor/rules/rails-mcp-tools.mdc for the full tool list."
-        lines << ""
-        lines << "## Anti-hallucination"
-        lines << ""
-        lines << "- Never invent column names, association names, or route paths. Call `rails_get_schema` / `rails_get_routes` / `rails_get_model_details` first."
-        lines << "- Never assume a gem is installed. Check `rails_get_gems` or the Gemfile."
-        lines << "- When editing an existing file, read the surrounding code via `rails_get_edit_context` before applying changes."
-
-        lines.join("\n")
+        render_compact_rules
       end
     end
   end

--- a/lib/rails_ai_context/serializers/section_marker_writer.rb
+++ b/lib/rails_ai_context/serializers/section_marker_writer.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "securerandom"
+
+module RailsAiContext
+  module Serializers
+    # Shared writer that wraps content in `<!-- BEGIN/END rails-ai-context -->`
+    # markers so user-added content OUTSIDE the markers survives regeneration.
+    #
+    # Used by ContextFileSerializer (for CLAUDE.md, AGENTS.md, .github/copilot-
+    # instructions.md) and CursorRulesSerializer (for .cursorrules). Same
+    # marker contract everywhere — a user can hand-write content above or below
+    # the gem-managed block and it'll persist across `rails ai:context` runs.
+    module SectionMarkerWriter
+      BEGIN_MARKER = "<!-- BEGIN rails-ai-context -->"
+      END_MARKER   = "<!-- END rails-ai-context -->"
+
+      module_function
+
+      # Write `content` to `filepath` wrapped in markers. If the file already
+      # exists with markers, replace only the marker block (preserving user
+      # content outside). If the file exists WITHOUT markers, prepend the
+      # marker block so AI tools read our context first while keeping the
+      # user's prior content intact below.
+      #
+      # Returns :written if the file changed, :skipped if it was already up
+      # to date, or :unchanged if a no-op.
+      def write_with_markers(filepath, content)
+        marked_content = "#{BEGIN_MARKER}\n#{content}\n#{END_MARKER}\n"
+
+        if File.exist?(filepath)
+          existing = File.read(filepath)
+
+          new_content = if existing.include?(BEGIN_MARKER) && existing.include?(END_MARKER)
+            existing.sub(
+              /#{Regexp.escape(BEGIN_MARKER)}.*?#{Regexp.escape(END_MARKER)}\n?/m,
+              marked_content
+            )
+          else
+            "#{marked_content}\n#{existing}"
+          end
+
+          return :skipped if new_content == existing
+          atomic_write(filepath, new_content)
+          :written
+        else
+          atomic_write(filepath, marked_content)
+          :written
+        end
+      end
+
+      # Write via temp file + rename so concurrent readers never see a partial.
+      def atomic_write(filepath, content)
+        dir = File.dirname(filepath)
+        FileUtils.mkdir_p(dir)
+        tmp = File.join(dir, ".#{File.basename(filepath)}.#{SecureRandom.hex(4)}.tmp")
+        File.write(tmp, content)
+        File.rename(tmp, filepath)
+      end
+    end
+  end
+end

--- a/lib/rails_ai_context/serializers/section_marker_writer.rb
+++ b/lib/rails_ai_context/serializers/section_marker_writer.rb
@@ -24,8 +24,8 @@ module RailsAiContext
       # marker block so AI tools read our context first while keeping the
       # user's prior content intact below.
       #
-      # Returns :written if the file changed, :skipped if it was already up
-      # to date, or :unchanged if a no-op.
+      # Returns :written if the file changed (created or block updated),
+      # :skipped if the file already had the exact same marker block.
       def write_with_markers(filepath, content)
         marked_content = "#{BEGIN_MARKER}\n#{content}\n#{END_MARKER}\n"
 

--- a/lib/rails_ai_context/tasks/rails_ai_context.rake
+++ b/lib/rails_ai_context/tasks/rails_ai_context.rake
@@ -5,7 +5,7 @@ ASSISTANT_TABLE = <<~TABLE unless defined?(ASSISTANT_TABLE)
   --                 --                                    --
   Claude Code        CLAUDE.md + .claude/rules/            rails ai:context:claude
   OpenCode           AGENTS.md                             rails ai:context:opencode
-  Cursor             .cursor/rules/                        rails ai:context:cursor
+  Cursor             .cursor/rules/ + .cursorrules         rails ai:context:cursor
   GitHub Copilot     .github/copilot-instructions.md       rails ai:context:copilot
   Codex CLI          AGENTS.md + .codex/config.toml        rails ai:context:codex
   JSON (generic)     .ai-context.json                      rails ai:context:json
@@ -166,7 +166,7 @@ end unless defined?(save_yaml_config)
 # McpConfigGenerator.remove to preserve other servers' entries.
 FORMAT_PATHS = {
   claude:   %w[CLAUDE.md .claude/rules],
-  cursor:   %w[.cursor/rules],
+  cursor:   %w[.cursor/rules .cursorrules],
   copilot:  %w[.github/copilot-instructions.md .github/instructions],
   opencode: %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md],
   codex:    %w[AGENTS.md app/models/AGENTS.md app/controllers/AGENTS.md]
@@ -423,7 +423,7 @@ namespace :ai do
 
   namespace :context do
     { claude: "CLAUDE.md", opencode: "AGENTS.md", codex: "AGENTS.md",
-      cursor: ".cursor/rules/", copilot: ".github/copilot-instructions.md",
+      cursor: ".cursor/rules/ + .cursorrules", copilot: ".github/copilot-instructions.md",
       json: ".ai-context.json" }.each do |fmt, file|
       desc "Generate #{file} context file"
       task fmt => :environment do

--- a/lib/rails_ai_context/tools/base_tool.rb
+++ b/lib/rails_ai_context/tools/base_tool.rb
@@ -368,7 +368,13 @@ module RailsAiContext
           relative = real.sub("#{real_root}/", "")
           return nil if sensitive_file?(relative)
           real
-        rescue Errno::ENOENT, Errno::EACCES
+        rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP, Errno::ENAMETOOLONG
+          # ENOENT: dangling symlink or path deleted between glob and realpath.
+          # EACCES: filesystem permission blocks resolution.
+          # ELOOP:  circular symlink chain (a → b → a, or node_modules cycles).
+          # ENAMETOOLONG: a path component exceeds NAME_MAX.
+          # Any of these mean "skip this entry"; surfacing as exception
+          # would crash the calling tool.
           nil
         end
 

--- a/spec/e2e/in_gemfile_install_spec.rb
+++ b/spec/e2e/in_gemfile_install_spec.rb
@@ -62,6 +62,20 @@ RSpec.describe "E2E: in-Gemfile install", type: :e2e do
       expect(File.exist?(init_path)).to be(true)
     end
 
+    it "writes both .cursor/rules/*.mdc AND the legacy .cursorrules (Cursor chat-agent fallback)" do
+      # v5.9.0: restored legacy .cursorrules because Cursor's chat agent
+      # didn't detect rules written only as .cursor/rules/*.mdc. See
+      # cursor_rules_serializer.rb for the full rationale.
+      cursorrules_path = File.join(@builder.app_path, ".cursorrules")
+      mdc_project_path = File.join(@builder.app_path, ".cursor", "rules", "rails-project.mdc")
+      expect(File.exist?(cursorrules_path)).to be(true), ".cursorrules (legacy) must be generated"
+      expect(File.exist?(mdc_project_path)).to be(true), ".cursor/rules/rails-project.mdc must be generated"
+
+      # Legacy file must be plain text, not MDC — older Cursor parses verbatim
+      expect(File.read(cursorrules_path)).not_to start_with("---")
+      expect(File.read(cursorrules_path)).to include("rails_get_schema")
+    end
+
     it "re-running the generator is idempotent (no duplicate entries)" do
       # Generator should be idempotent per CLAUDE.md #27.
       # Pipe answers for prompts: (a) all tools, (1) MCP mode, (n) no hook,

--- a/spec/lib/rails_ai_context/serializers/context_file_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/context_file_serializer_spec.rb
@@ -47,14 +47,18 @@ RSpec.describe RailsAiContext::Serializers::ContextFileSerializer do
       end
     end
 
-    it "generates only split rules for cursor format (no root .cursorrules)" do
+    it "generates split rules for cursor format AND a legacy .cursorrules fallback" do
+      # v5.9.0: restored .cursorrules alongside .cursor/rules/*.mdc because
+      # Cursor's chat agent didn't detect mdc rules in real user testing.
+      # Both formats coexist — new clients use mdc, older/chat clients use
+      # the legacy single-file format.
       Dir.mktmpdir do |dir|
         allow(RailsAiContext.configuration).to receive(:output_dir_for).and_return(dir)
         serializer = described_class.new(context, format: :cursor)
         result = serializer.call
         cursor_rules = result[:written].select { |f| f.include?(".cursor/rules/") }
         expect(cursor_rules).not_to be_empty
-        expect(result[:written].none? { |f| f.end_with?(".cursorrules") }).to be true
+        expect(result[:written].any? { |f| f.end_with?(".cursorrules") }).to be true
       end
     end
 

--- a/spec/lib/rails_ai_context/serializers/cursor_mdc_compliance_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/cursor_mdc_compliance_spec.rb
@@ -42,12 +42,18 @@ RSpec.describe "Cursor MDC compliance" do
     }
   end
 
+  # Scope the MDC-compliance assertions to files under .cursor/rules/ only.
+  # The serializer ALSO writes .cursorrules at the project root as a legacy
+  # fallback — that file is plain text, not MDC, and is intentionally
+  # outside the frontmatter/extension/<500-lines contract. The legacy file
+  # is covered separately in cursor_rules_serializer_spec.rb.
   let(:generated_files) do
     Dir.mktmpdir do |dir|
       result = RailsAiContext::Serializers::CursorRulesSerializer.new(context).call(dir)
       rules_dir = File.join(dir, ".cursor", "rules")
       files = {}
       result[:written].each do |path|
+        next unless path.start_with?(rules_dir)
         filename = File.basename(path)
         files[filename] = {
           path: path,

--- a/spec/lib/rails_ai_context/serializers/cursor_rules_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/cursor_rules_serializer_spec.rb
@@ -130,4 +130,58 @@ RSpec.describe RailsAiContext::Serializers::CursorRulesSerializer do
       end
     end
   end
+
+  # Real user concern: pre-existing .cursorrules content must not be
+  # destroyed on first install. The gem now wraps its block in
+  # `<!-- BEGIN/END rails-ai-context -->` markers (same convention as
+  # CLAUDE.md / AGENTS.md / .github/copilot-instructions.md) so user-
+  # added content above or below the gem block survives regeneration.
+  describe ".cursorrules section markers" do
+    it "wraps generated content in BEGIN/END markers so user content is preserved" do
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        content = File.read(File.join(dir, ".cursorrules"))
+        expect(content).to include("<!-- BEGIN rails-ai-context -->")
+        expect(content).to include("<!-- END rails-ai-context -->")
+      end
+    end
+
+    it "preserves user content above the marker block on first install" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, ".cursorrules")
+        user_content = "# My hand-written rules\n- Always use 2-space indent\n- Prefer guard clauses\n"
+        File.write(path, user_content)
+
+        described_class.new(context).call(dir)
+
+        new_content = File.read(path)
+        expect(new_content).to include(user_content),
+          "user-written .cursorrules content was destroyed by the install"
+        expect(new_content).to include("<!-- BEGIN rails-ai-context -->")
+      end
+    end
+
+    it "preserves user content above and below the markers on regeneration" do
+      Dir.mktmpdir do |dir|
+        # First write — gem creates the marker block.
+        described_class.new(context).call(dir)
+        path = File.join(dir, ".cursorrules")
+
+        # User adds content above and below the gem block.
+        gem_block = File.read(path)
+        File.write(path, "# Above the gem\n#{gem_block}\n# Below the gem\n")
+
+        # Regenerate — gem must replace ONLY its own block.
+        described_class.new(context).call(dir)
+
+        final = File.read(path)
+        expect(final).to include("# Above the gem")
+        expect(final).to include("# Below the gem")
+        expect(final).to include("<!-- BEGIN rails-ai-context -->")
+        expect(final).to include("<!-- END rails-ai-context -->")
+        # Marker block appears exactly once.
+        expect(final.scan("<!-- BEGIN rails-ai-context -->").size).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/serializers/cursor_rules_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/cursor_rules_serializer_spec.rb
@@ -84,4 +84,27 @@ RSpec.describe RailsAiContext::Serializers::CursorRulesSerializer do
       expect(second[:skipped].size).to eq(first[:written].size)
     end
   end
+
+  # v5.9.0 regression: real user report during release QA — Cursor chat
+  # agent didn't detect rules written only as .cursor/rules/*.mdc. Writing
+  # .cursorrules alongside (legacy format) fixed it. Ensure both are
+  # produced so neither older Cursor builds nor newer ones miss the rules.
+  it "also writes a legacy .cursorrules at the project root" do
+    Dir.mktmpdir do |dir|
+      result = described_class.new(context).call(dir)
+      cursorrules_path = File.join(dir, ".cursorrules")
+      expect(result[:written]).to include(cursorrules_path)
+      expect(File.exist?(cursorrules_path)).to be true
+
+      content = File.read(cursorrules_path)
+      # Plain text — no frontmatter — so every Cursor build reads it.
+      expect(content).not_to start_with("---")
+      # Must surface the gem's presence + name a couple of the MCP tools
+      # so the chat agent knows to use them rather than guess.
+      expect(content).to include("rails-ai-context")
+      expect(content).to include("rails_get_schema")
+      expect(content).to include("rails_get_routes")
+      expect(content).to include("App")  # app name from context
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/serializers/cursor_rules_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/cursor_rules_serializer_spec.rb
@@ -97,7 +97,8 @@ RSpec.describe RailsAiContext::Serializers::CursorRulesSerializer do
       expect(File.exist?(cursorrules_path)).to be true
 
       content = File.read(cursorrules_path)
-      # Plain text — no frontmatter — so every Cursor build reads it.
+      # Plain text / markdown — no YAML frontmatter — so every Cursor
+      # build reads it verbatim.
       expect(content).not_to start_with("---")
       # Must surface the gem's presence + name a couple of the MCP tools
       # so the chat agent knows to use them rather than guess.
@@ -105,6 +106,28 @@ RSpec.describe RailsAiContext::Serializers::CursorRulesSerializer do
       expect(content).to include("rails_get_schema")
       expect(content).to include("rails_get_routes")
       expect(content).to include("App")  # app name from context
+    end
+  end
+
+  # .cursorrules and CLAUDE.md share render_compact_rules from
+  # CompactSerializerHelper. They target different AI clients but
+  # deliver the same project context — so when one changes, the other
+  # changes in lockstep. Ship-time invariant: identical core content
+  # between the two files.
+  it ".cursorrules mirrors the CLAUDE.md compact-rules pipeline (shared content)" do
+    Dir.mktmpdir do |dir|
+      described_class.new(context).call(dir)
+      cursor_content = File.read(File.join(dir, ".cursorrules"))
+      claude_content = RailsAiContext::Serializers::ClaudeSerializer.new(context).call
+
+      # Every major section of CLAUDE.md also appears in .cursorrules,
+      # guaranteeing parity across both AI-client targets. Drift between
+      # them is the class of bug that leaves one agent with stale rules.
+      %w[## Stack ## Key\ models ## Rules ## Architecture].each do |section|
+        next unless claude_content.include?(section)
+        expect(cursor_content).to include(section),
+          ".cursorrules missing section '#{section}' that CLAUDE.md has — shared pipeline drift"
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Real user report during v5.9.0 release QA: the Cursor IDE's chat agent didn't detect rules when they were written only as `.cursor/rules/*.mdc`, even when the rule declared `alwaysApply: true`. Cursor has two rule systems and the chat-agent composition path in current builds still consults the legacy `.cursorrules` file at the project root.

`CursorRulesSerializer` now writes **both**:

- `.cursor/rules/*.mdc` — newer format with frontmatter / glob scoping / agent-requested triggers. Preferred by newer Cursor builds (0.42+) in editor context.
- `.cursorrules` — plain text at project root. Universally parsed by every Cursor build, including the chat agent's composition path.

## What changed

- `lib/rails_ai_context/serializers/cursor_rules_serializer.rb` — added `render_cursorrules_legacy` + wire it into the output file list.
- `lib/generators/rails_ai_context/install/install_generator.rb` — `FORMAT_PATHS[:cursor]` now includes `.cursorrules` so re-install cleanup covers both files when Cursor is deselected.
- `spec/lib/rails_ai_context/serializers/cursor_mdc_compliance_spec.rb` — scoped its 'all files must be .mdc with YAML frontmatter' assertions to files under `.cursor/rules/` only. The legacy `.cursorrules` is intentionally outside that contract.
- `spec/lib/rails_ai_context/serializers/cursor_rules_serializer_spec.rb` — added regression spec for the legacy file.
- `spec/lib/rails_ai_context/serializers/context_file_serializer_spec.rb` — rewritten to assert BOTH `.cursor/rules/` AND `.cursorrules` are produced (was asserting `.cursorrules` was NOT produced).
- `spec/e2e/in_gemfile_install_spec.rb` — end-to-end against a fresh Rails app, verifies both files materialize after the generator runs.
- `CHANGELOG.md` — documented under [5.9.0].

## Local results

- 2074 examples / 0 failures / 5s (unit)
- RuboCop: 290 files / 0 offenses

## Test plan

- [ ] CI green on Linux × 5 Ruby/Rails matrix entries
- [ ] E2E in_gemfile_install_spec new assertion passes (both files produced)
- [ ] Default unit suite still 2074 / 0 on every matrix entry