### PR TITLE
fix: GetConcern includers search for plural concern names

### DIFF
--- a/lib/rails_ai_context/tools/get_concern.rb
+++ b/lib/rails_ai_context/tools/get_concern.rb
@@ -470,9 +470,11 @@ module RailsAiContext
 
         max_size = RailsAiContext.configuration.max_file_size
         # Build pattern: match `include ConcernName` or `include ModuleName::ConcernName`
-        # Handle both simple and namespaced concern names
-        # Classify to handle lowercase input: "plan_limitable" → "PlanLimitable"
-        simple_name = concern_name.demodulize.classify
+        # Handle both simple and namespaced concern names.
+        # Use `camelize` (not `classify`) — `classify` singularizes, which drops
+        # the final `s` from plural concern names like `WorksheetImports` and
+        # then fails to match `include WorksheetImports` in the model.
+        simple_name = concern_name.demodulize.camelize
         pattern = /^\s*include\s+(?:\w+::)*#{Regexp.escape(simple_name)}\b/
 
         search_dirs.each do |dir|

--- a/spec/lib/rails_ai_context/tools/get_concern_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_concern_spec.rb
@@ -166,6 +166,29 @@ RSpec.describe RailsAiContext::Tools::GetConcern do
         expect(text).to include("Included By")
         expect(text).to include("Post")
       end
+
+      it "finds includers when the concern name is plural" do
+        File.write(File.join(model_concerns_dir, "worksheet_imports.rb"), <<~RUBY)
+          module WorksheetImports
+            extend ActiveSupport::Concern
+
+            class_methods do
+              def import(file); end
+            end
+          end
+        RUBY
+
+        File.write(File.join(models_dir, "worksheet.rb"), <<~RUBY)
+          class Worksheet < ApplicationRecord
+            include WorksheetImports
+          end
+        RUBY
+
+        result = described_class.call(name: "WorksheetImports")
+        text = result.content.first[:text]
+        expect(text).to include("Included By")
+        expect(text).to include("Worksheet")
+      end
     end
 
     context "detail levels" do


### PR DESCRIPTION
## Summary

`GetConcern` fails to find models that include a concern whose name is plural (e.g. `WorksheetImports`, `PaperTrailEvents`). The lookup reports **no includers**, even when `include WorksheetImports` is right there in the model.

## Root cause

`lib/rails_ai_context/tools/get_concern.rb` uses `String#classify` to normalize the concern name before building the include-pattern:

```ruby
simple_name = concern_name.demodulize.classify
pattern = /^\s*include\s+(?:\w+::)*#{Regexp.escape(simple_name)}\b/
```

`classify` **singularizes** its input. So `"WorksheetImports".classify` returns `"WorksheetImport"`, and the resulting regex `/\binclude\s+WorksheetImport\b/` never matches `include WorksheetImports` in the model source.

## Fix

Use `camelize` instead of `classify`. `camelize` normalizes case (so lowercase input like `plan_limitable` → `PlanLimitable` still works — the original reason `classify` was used) **without** singularizing.

```ruby
simple_name = concern_name.demodulize.camelize
```

## Tests

Added a spec covering the plural-name case:

```ruby
it "finds includers when the concern name is plural" do
  # module WorksheetImports + class Worksheet; include WorksheetImports; end
  result = described_class.call(name: "WorksheetImports")
  expect(result.content.first[:text]).to include("Included By")
  expect(result.content.first[:text]).to include("Worksheet")
end
```

All 22 examples in `spec/lib/rails_ai_context/tools/get_concern_spec.rb` pass.

## Test plan

- [x] `bundle exec rspec spec/lib/rails_ai_context/tools/get_concern_spec.rb` — 22/22 passing, including the new plural-name case
- [x] Existing lowercase-input behaviour (`plan_limitable` → `PlanLimitable`) still works — covered by existing specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)