### PR TITLE
chore: release v5.9.1 — internal invariant compliance + GetConcern plural-name fix (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.9.1] — 2026-04-20
+
+### Fixed — internal invariant compliance
+
+- **`validate.rb` now routes all Prism parses through `AstCache`.** The Ruby syntax validator was calling `Prism.parse_file` directly and the ERB + semantic-visitor paths `Prism.parse` on string input, bypassing the cache entirely for the first and violating the "all Prism parses must flow through `RailsAiContext::AstCache`" invariant (`.results/3-identify-architecture.json:33`) for all three. Now uses `AstCache.parse(path)` for on-disk sources (picking up the existing size-cap + content-hash caching) and `AstCache.parse_string(source)` for synthetic strings. Note: `AstCache.parse` enforces a 5 MB `MAX_PARSE_SIZE` cap; Ruby files above that size fall through the existing `rescue` to the `ruby -c` subprocess validator, which returns errors but not Prism warnings — a graceful degradation that affects only pathologically large source files.
+- **`Listeners::BaseListener` uses `Confidence::INFERRED` constant.** Replaced three hardcoded `"[INFERRED]"` literals in `extract_first_symbol`, `extract_key`, and `extract_value` with `RailsAiContext::Confidence::INFERRED`. Value is identical; constant reference prevents drift if the marker string is ever versioned.
+- **Diagnostic `$stderr.puts` in `rescue` blocks now `ENV["DEBUG"]`-gated.** 12 previously-unconditional stderr writes across `tools/diagnose.rb` (5), `tools/review_changes.rb` (4), and `serializers/stack_overview_helper.rb` (3) were logging under normal operation whenever an optional context-enrichment step failed. These were never visible to most users but polluted stderr in MCP/CLI logs. Now silent unless `DEBUG=1`, matching the convention used everywhere else in the gem.
+
+### Added
+
+- **Prism-discipline regression spec** (`spec/lib/rails_ai_context/ast_cache_discipline_spec.rb`). Scans every `lib/**/*.rb` file (excluding `ast_cache.rb`) for direct `Prism.parse` / `Prism.parse_file` / `Prism.parse_string` calls and fails if any are found. Prevents re-introduction of the bypass that `validate.rb` had.
+
 ## [5.9.0] — 2026-04-16
 
 ### Fixed — Cursor chat agent didn't detect rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.9.1] — 2026-04-20
 
+### Fixed — `GetConcern` missed plural concern names (#78)
+
+Thanks to [@johan--](https://github.com/johan--) for the report and fix.
+
+`rails_get_concern`'s includer search built its include-pattern regex via `String#classify`, which singularizes its input. Concerns with intentionally plural module names — `WorksheetImports`, `PaperTrailEvents`, `SoftDeletables`, etc. — got demodulized to `WorksheetImport` and the `include WorksheetImports` line in the model never matched. The tool reported no includers even when the concern was in use.
+
+Switched to `String#camelize`, which normalizes case (so lowercase input like `plan_limitable` → `PlanLimitable` still works) **without** singularizing. This also restores consistency with the three other `.camelize` calls already used in `get_concern.rb` for the same "file basename / module name → class name" conversion. Covered by a new spec in `get_concern_spec.rb` that exercises the plural-name case end-to-end.
+
 ### Fixed — internal invariant compliance
 
 - **`validate.rb` now routes all Prism parses through `AstCache`.** The Ruby syntax validator was calling `Prism.parse_file` directly and the ERB + semantic-visitor paths `Prism.parse` on string input, bypassing the cache entirely for the first and violating the "all Prism parses must flow through `RailsAiContext::AstCache`" invariant (`.results/3-identify-architecture.json:33`) for all three. Now uses `AstCache.parse(path)` for on-disk sources (picking up the existing size-cap + content-hash caching) and `AstCache.parse_string(source)` for synthetic strings. Note: `AstCache.parse` enforces a 5 MB `MAX_PARSE_SIZE` cap; Ruby files above that size fall through the existing `rescue` to the `ruby -c` subprocess validator, which returns errors but not Prism warnings — a graceful degradation that affects only pathologically large source files.

--- a/lib/rails_ai_context/introspectors/listeners/base_listener.rb
+++ b/lib/rails_ai_context/introspectors/listeners/base_listener.rb
@@ -23,7 +23,7 @@ module RailsAiContext
           case arg
           when Prism::SymbolNode then arg.value.to_sym
           when Prism::StringNode then arg.unescaped.to_sym
-          else "[INFERRED]"
+          else RailsAiContext::Confidence::INFERRED
           end
         end
 
@@ -56,7 +56,7 @@ module RailsAiContext
           case node
           when Prism::SymbolNode then node.value.to_sym
           when Prism::StringNode then node.unescaped.to_sym
-          else "[INFERRED]"
+          else RailsAiContext::Confidence::INFERRED
           end
         end
 
@@ -74,7 +74,7 @@ module RailsAiContext
           when Prism::ArrayNode          then node.elements.map { |e| extract_value(e) }
           when Prism::HashNode           then hash_node_to_hash(node)
           when Prism::KeywordHashNode    then hash_node_to_hash(node)
-          else "[INFERRED]"
+          else RailsAiContext::Confidence::INFERRED
           end
         end
 

--- a/lib/rails_ai_context/serializers/stack_overview_helper.rb
+++ b/lib/rails_ai_context/serializers/stack_overview_helper.rb
@@ -186,7 +186,7 @@ module RailsAiContext
           .map { |f| File.basename(f, ".rb").camelize }
           .reject { |s| s == "ApplicationService" }
       rescue => e
-        $stderr.puts "[rails-ai-context] Service file scan skipped: #{e.message}"
+        $stderr.puts "[rails-ai-context] Service file scan skipped: #{e.message}" if ENV["DEBUG"]
         []
       end
 
@@ -198,7 +198,7 @@ module RailsAiContext
           .map { |f| File.basename(f, ".rb").camelize }
           .reject { |j| j == "ApplicationJob" }
       rescue => e
-        $stderr.puts "[rails-ai-context] Job file scan skipped: #{e.message}"
+        $stderr.puts "[rails-ai-context] Job file scan skipped: #{e.message}" if ENV["DEBUG"]
         []
       end
 
@@ -208,7 +208,7 @@ module RailsAiContext
         return [] unless File.exist?(app_ctrl_file)
         File.read(app_ctrl_file).scan(/before_action\s+:([\w!?]+)/).flatten
       rescue => e
-        $stderr.puts "[rails-ai-context] Before actions scan skipped: #{e.message}"
+        $stderr.puts "[rails-ai-context] Before actions scan skipped: #{e.message}" if ENV["DEBUG"]
         []
       end
     end

--- a/lib/rails_ai_context/tools/diagnose.rb
+++ b/lib/rails_ai_context/tools/diagnose.rb
@@ -265,7 +265,7 @@ module RailsAiContext
                   lines << text
                   lines << ""
                 end
-              rescue => e; $stderr.puts "[rails-ai-context] Diagnosis step skipped: #{e.message}"; end
+              rescue => e; $stderr.puts "[rails-ai-context] Diagnosis step skipped: #{e.message}" if ENV["DEBUG"]; end
             end
           end
 
@@ -284,7 +284,7 @@ module RailsAiContext
                   lines << text
                   lines << ""
                 end
-              rescue => e; $stderr.puts "[rails-ai-context] Diagnosis step skipped: #{e.message}"; end
+              rescue => e; $stderr.puts "[rails-ai-context] Diagnosis step skipped: #{e.message}" if ENV["DEBUG"]; end
             end
           end
 
@@ -298,7 +298,7 @@ module RailsAiContext
                 lines << text
                 lines << ""
               end
-            rescue => e; $stderr.puts "[rails-ai-context] Diagnosis step skipped: #{e.message}"; end
+            rescue => e; $stderr.puts "[rails-ai-context] Diagnosis step skipped: #{e.message}" if ENV["DEBUG"]; end
           end
 
           lines
@@ -329,7 +329,7 @@ module RailsAiContext
                          "This variable may not be set in all code paths — check if it's assigned before use, " \
                          "or use `#{receiver}&.#{method}` for safe navigation."
                 end
-              rescue => e; $stderr.puts "[rails-ai-context] Diagnosis step skipped: #{e.message}"; end
+              rescue => e; $stderr.puts "[rails-ai-context] Diagnosis step skipped: #{e.message}" if ENV["DEBUG"]; end
             end
           end
 
@@ -346,7 +346,7 @@ module RailsAiContext
                          "The record with the given ID doesn't exist or doesn't belong to the current user. " \
                          "Check if the record was deleted or if the user is authorized to access it."
                 end
-              rescue => e; $stderr.puts "[rails-ai-context] Diagnosis step skipped: #{e.message}"; end
+              rescue => e; $stderr.puts "[rails-ai-context] Diagnosis step skipped: #{e.message}" if ENV["DEBUG"]; end
             end
           end
 

--- a/lib/rails_ai_context/tools/review_changes.rb
+++ b/lib/rails_ai_context/tools/review_changes.rb
@@ -186,7 +186,7 @@ module RailsAiContext
               result = GetModelDetails.call(model: model_name, detail: "standard")
               text = result.content.first[:text]
               lines << "" << "**Model context:** #{model_name}" unless text.include?("not found")
-            rescue => e; $stderr.puts "[rails-ai-context] Context lookup skipped: #{e.message}"; end
+            rescue => e; $stderr.puts "[rails-ai-context] Context lookup skipped: #{e.message}" if ENV["DEBUG"]; end
 
           when :controller
             ctrl_name = File.basename(file, ".rb").camelize
@@ -195,7 +195,7 @@ module RailsAiContext
               result = GetRoutes.call(controller: snake, detail: "summary")
               text = result.content.first[:text]
               lines << "" << "**Routes:**" << text unless text.include?("not found") || text.include?("No routes")
-            rescue => e; $stderr.puts "[rails-ai-context] Context lookup skipped: #{e.message}"; end
+            rescue => e; $stderr.puts "[rails-ai-context] Context lookup skipped: #{e.message}" if ENV["DEBUG"]; end
 
           when :migration
             # Parse migration for table/column info
@@ -211,7 +211,7 @@ module RailsAiContext
                       result = GetSchema.call(table: t, detail: "summary")
                       text = result.content.first[:text]
                       lines << "  #{t}: #{text.lines.first&.strip}" unless text.include?("not found")
-                    rescue => e; $stderr.puts "[rails-ai-context] Context lookup skipped: #{e.message}"; end
+                    rescue => e; $stderr.puts "[rails-ai-context] Context lookup skipped: #{e.message}" if ENV["DEBUG"]; end
                   end
                 end
               end
@@ -221,7 +221,7 @@ module RailsAiContext
             begin
               result = GetRoutes.call(detail: "summary")
               lines << "" << "**Current routes:** #{result.content.first[:text].lines.first&.strip}"
-            rescue => e; $stderr.puts "[rails-ai-context] Context lookup skipped: #{e.message}"; end
+            rescue => e; $stderr.puts "[rails-ai-context] Context lookup skipped: #{e.message}" if ENV["DEBUG"]; end
           end
 
           lines << ""

--- a/lib/rails_ai_context/tools/validate.rb
+++ b/lib/rails_ai_context/tools/validate.rb
@@ -170,7 +170,7 @@ module RailsAiContext
       end
 
       private_class_method def self.validate_ruby_prism(full_path)
-        result = Prism.parse_file(full_path.to_s)
+        result = AstCache.parse(full_path.to_s)
         basename = File.basename(full_path.to_s)
         warnings = result.warnings.map do |w|
           "#{basename}:#{w.location.start_line}:#{w.location.start_column}: warning: #{w.message}"
@@ -213,7 +213,7 @@ module RailsAiContext
         erb_src.force_encoding("UTF-8")
         compiled = "# encoding: utf-8\ndef __erb_syntax_check\n#{erb_src}\nend"
 
-        result = Prism.parse(compiled)
+        result = AstCache.parse_string(compiled)
         if result.success?
           [ true, nil, [] ]
         else
@@ -457,7 +457,7 @@ module RailsAiContext
           content
         end
 
-        result = Prism.parse(source)
+        result = AstCache.parse_string(source)
         visitor = RailsSemanticVisitor.new
         result.value.accept(visitor)
         visitor

--- a/lib/rails_ai_context/version.rb
+++ b/lib/rails_ai_context/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiContext
-  VERSION = "5.9.0"
+  VERSION = "5.9.1"
 end

--- a/spec/lib/rails_ai_context/ast_cache_discipline_spec.rb
+++ b/spec/lib/rails_ai_context/ast_cache_discipline_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Prism parsing discipline" do
+  it "routes every Prism.parse call in lib/ through AstCache" do
+    lib_root = File.expand_path("../../../../lib", __FILE__)
+    ast_cache_path = File.join(lib_root, "rails_ai_context", "ast_cache.rb")
+
+    pattern = /\bPrism\.(parse|parse_file|parse_string)\b/
+
+    offenders = Dir.glob(File.join(lib_root, "**", "*.rb"))
+      .reject { |f| f == ast_cache_path }
+      .select { |f|
+        File.readlines(f)
+          .reject { |l| l.strip.start_with?("#") }
+          .any? { |l| l.match?(pattern) }
+      }
+      .map { |f| f.sub("#{lib_root}/", "") }
+
+    expect(offenders).to be_empty,
+      "Files calling Prism.parse* directly (must go through AstCache): #{offenders.join(', ')}"
+  end
+end


### PR DESCRIPTION
## Summary

Release branch for **v5.9.1**. Bundles two independent fixes:

1. **PR #78 (already merged to main) — `GetConcern.find_includers` plural concern names.** External contributor fix by @johan--. `classify` singularized module names like `WorksheetImports` → `WorksheetImport`, breaking includer detection for plural concerns. Now uses `camelize`.
2. **Internal invariant compliance sweep.** Three categories of violations against `CLAUDE.md` §4 / `.results/3-identify-architecture.json`:
   - `validate.rb`: route 3 direct `Prism.parse*` calls through `AstCache`.
   - `base_listener.rb`: replace 3 `"[INFERRED]"` string literals with `Confidence::INFERRED` constant.
   - `diagnose.rb`, `review_changes.rb`, `stack_overview_helper.rb`: gate 12 diagnostic `$stderr.puts` calls in `rescue` blocks with `ENV["DEBUG"]`.

Also adds `spec/lib/rails_ai_context/ast_cache_discipline_spec.rb` — a guard regression spec that scans `lib/**/*.rb` for direct `Prism.parse*` calls.

Version bumped `5.9.0 → 5.9.1`. CHANGELOG entry covers both fixes.

## Test plan

- [x] Unit suite: **2079 / 2079 pass** locally
- [x] Parallel e2e (`rake e2e:parallel`): **104 / 104 pass** across 4 install paths
- [x] RuboCop clean on all edited files
- [x] Guard spec passes on current `lib/` and would fail if any file outside `ast_cache.rb` calls `Prism.parse*` directly
- [x] Code-reviewer agent: zero high-confidence issues; two low-confidence defensive notes addressed (comment-line filter in guard spec; 5 MB cap caveat in CHANGELOG)
- [x] CI matrix green on this PR (Ruby 3.2–4.0 × Rails 7.1–8.1 + lint + e2e)

After merge: tag `v5.9.1` on `main` to trigger RubyGems + GitHub Release + MCP Registry publish via `.github/workflows/release.yml`.