### PR TITLE
Fix validation false positives for local route-like methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Avoid false-positive route helper warnings when `rails_validate` sees locally defined Ruby methods ending in `_path` or `_url`.
+- Preserve newline-separated staged file names in the generated pre-commit validation hook before passing them to the CLI tool.
+
 ## [5.10.0] — 2026-04-20
 
 ### Added — 8 new introspectors closing RAILS_NERVOUS_SYSTEM.md gaps

--- a/lib/generators/rails_ai_context/install/install_generator.rb
+++ b/lib/generators/rails_ai_context/install/install_generator.rb
@@ -550,7 +550,8 @@ module RailsAiContext
           fi
 
           if command -v rails &> /dev/null; then
-            rails 'ai:tool[validate]' files="$(echo $changed_files | tr '\\n' ',')" 2>/dev/null
+            files=$(printf '%s\\n' "$changed_files" | tr '\\n' ',')
+            rails 'ai:tool[validate]' files="$files" 2>/dev/null
             exit_code=$?
             if [ $exit_code -ne 0 ]; then
               echo ""

--- a/lib/rails_ai_context/tools/validate.rb
+++ b/lib/rails_ai_context/tools/validate.rb
@@ -289,8 +289,10 @@ module RailsAiContext
       # Prism AST Visitor — walks the AST once, extracts data for all checks
       class RailsSemanticVisitor < Prism::Visitor
         attr_reader :render_calls, :route_helper_calls, :validates_calls,
-                    :permit_calls, :callback_registrations, :has_many_calls
+                    :permit_calls, :callback_registrations, :has_many_calls,
+                    :local_method_names_by_scope, :singleton_method_names_by_scope
 
+        TOP_LEVEL_SCOPE = "__top_level__"
         CALLBACK_NAMES = %i[
           before_validation after_validation before_save after_save
           before_create after_create before_update after_update
@@ -305,6 +307,36 @@ module RailsAiContext
           @permit_calls = []
           @callback_registrations = []
           @has_many_calls = []
+          @local_method_names_by_scope = Hash.new { |hash, key| hash[key] = Set.new }
+          @singleton_method_names_by_scope = Hash.new { |hash, key| hash[key] = Set.new }
+          @scope_stack = [ TOP_LEVEL_SCOPE ]
+          @method_context_stack = []
+        end
+
+        def local_route_method_defined?(helper, scope, method_kind)
+          case method_kind
+          when :singleton
+            @singleton_method_names_by_scope[scope].include?(helper)
+          when :instance
+            @local_method_names_by_scope[scope].include?(helper)
+          else
+            @local_method_names_by_scope[scope].include?(helper) ||
+              @singleton_method_names_by_scope[scope].include?(helper)
+          end
+        end
+
+        def visit_class_node(node)
+          with_scope(node.constant_path&.slice) { super }
+        end
+
+        def visit_module_node(node)
+          with_scope(node.constant_path&.slice) { super }
+        end
+
+        def visit_def_node(node)
+          method_kind = node.receiver ? :singleton : :instance
+          method_names_for(method_kind, current_scope) << node.name.to_s
+          with_method_context(method_kind) { super }
         end
 
         def visit_call_node(node)
@@ -315,7 +347,12 @@ module RailsAiContext
           when :has_many   then extract_has_many(node)
           else
             if node.name.to_s.end_with?("_path", "_url") && node.receiver.nil?
-              @route_helper_calls << { name: node.name.to_s, line: node.location.start_line }
+              @route_helper_calls << {
+                name: node.name.to_s,
+                line: node.location.start_line,
+                scope: current_scope,
+                method_kind: current_method_kind
+              }
             elsif CALLBACK_NAMES.include?(node.name) && node.receiver.nil?
               extract_callback(node)
             end
@@ -324,6 +361,32 @@ module RailsAiContext
         end
 
         private
+
+        def with_scope(scope_name)
+          @scope_stack << scope_name.to_s
+          yield
+        ensure
+          @scope_stack.pop
+        end
+
+        def with_method_context(method_kind)
+          @method_context_stack << method_kind
+          yield
+        ensure
+          @method_context_stack.pop
+        end
+
+        def method_names_for(method_kind, scope)
+          method_kind == :singleton ? @singleton_method_names_by_scope[scope] : @local_method_names_by_scope[scope]
+        end
+
+        def current_scope
+          @scope_stack.join("::")
+        end
+
+        def current_method_kind
+          @method_context_stack.last
+        end
 
         def extract_render(node)
           args = node.arguments&.arguments || []
@@ -524,6 +587,7 @@ module RailsAiContext
           helper = call[:name]
           next if seen.include?(helper)
           seen << helper
+          next if visitor.local_route_method_defined?(helper, call[:scope], call[:method_kind])
 
           name = helper.sub(/_(path|url)\z/, "")
           next if ASSET_HELPER_PREFIXES.any? { |p| name.start_with?(p) }
@@ -544,17 +608,23 @@ module RailsAiContext
         return warnings if valid_names.empty?
 
         seen = Set.new
+        local_method_names = local_route_like_method_names(content)
         content.scan(/\b(\w+)_(path|url)\b/).each do |match|
           name, suffix = match
           helper = "#{name}_#{suffix}"
           next if seen.include?(helper)
           seen << helper
+          next if local_method_names.include?(helper)
           next if ASSET_HELPER_PREFIXES.any? { |p| name.start_with?(p) }
           next if DEVISE_HELPER_NAMES.include?(name)
           next if %w[edit new polymorphic].include?(name)
           warnings << "#{helper} \u2014 route helper not found" unless valid_names.include?(name)
         end
         warnings
+      end
+
+      private_class_method def self.local_route_like_method_names(content)
+        content.scan(/^\s*(?:(?:private|protected|public|private_class_method)\s+)*def\s+(?:self\.)?(\w+_(?:path|url))\b/).flatten.to_set
       end
 
       private_class_method def self.build_route_name_set(routes)

--- a/spec/lib/generators/rails_ai_context/install_generator_spec.rb
+++ b/spec/lib/generators/rails_ai_context/install_generator_spec.rb
@@ -107,4 +107,23 @@ RSpec.describe RailsAiContext::Generators::InstallGenerator do
       expect(content).not_to include("\n  config.tool_mode = :mcp   # MCP primary + CLI fallback")
     end
   end
+
+  describe "#install_validation_hook" do
+    let(:hook_path) { File.join(tmpdir, ".git/hooks/pre-commit") }
+
+    before do
+      FileUtils.mkdir_p(File.join(tmpdir, ".git"))
+      allow(generator).to receive(:ask).and_return("y")
+    end
+
+    it "passes staged files to validation without collapsing newlines into spaces" do
+      generator.install_validation_hook
+
+      content = File.read(hook_path)
+
+      expect(content).to include("files=$(printf '%s\\n' \"$changed_files\" | tr '\\n' ',')")
+      expect(content).to include("rails 'ai:tool[validate]' files=\"$files\"")
+      expect(content).not_to include("echo $changed_files")
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/tools/validate_spec.rb
+++ b/spec/lib/rails_ai_context/tools/validate_spec.rb
@@ -114,6 +114,82 @@ RSpec.describe RailsAiContext::Tools::Validate do
     end
   end
 
+  describe "route helper validation", skip: (!defined?(Prism) && "requires Prism (Ruby 3.3+)") do
+    let(:tmp_dir) { File.join(Rails.root, "tmp") }
+    let(:file_path) { File.join(tmp_dir, "local_route_helper_test.rb") }
+
+    before { FileUtils.mkdir_p(tmp_dir) }
+
+    after do
+      File.delete(file_path) if File.exist?(file_path)
+    end
+
+    it "does not report locally defined _url methods as missing route helpers" do
+      File.write(file_path, <<~RUBY)
+        class LocalRouteHelperTest
+          def call
+            provider_metadata_url
+          end
+
+          private
+
+          def provider_metadata_url
+            "https://example.test/.well-known/openid-configuration"
+          end
+        end
+      RUBY
+
+      result = described_class.call(files: [ "tmp/local_route_helper_test.rb" ], level: "rails")
+      text = result.content.first[:text]
+
+      expect(text).not_to include("provider_metadata_url — route helper not found")
+      expect(text).to include("1/1 files passed")
+    end
+
+    it "still reports route-like calls when the local method is defined in another class" do
+      File.write(file_path, <<~RUBY)
+        class LocalRouteDefinition
+          def provider_metadata_url
+            "https://example.test/.well-known/openid-configuration"
+          end
+        end
+
+        class OtherRouteCaller
+          def call
+            provider_metadata_url
+          end
+        end
+      RUBY
+
+      result = described_class.call(files: [ "tmp/local_route_helper_test.rb" ], level: "rails")
+      text = result.content.first[:text]
+
+      expect(text).to include("provider_metadata_url — route helper not found")
+    end
+
+    it "does not report private inline _url method definitions in regex fallback mode" do
+      allow(described_class).to receive(:parse_and_visit).and_return(nil)
+
+      File.write(file_path, <<~RUBY)
+        class LocalRouteHelperTest
+          def call
+            provider_metadata_url
+          end
+
+          private def provider_metadata_url
+            "https://example.test/.well-known/openid-configuration"
+          end
+        end
+      RUBY
+
+      result = described_class.call(files: [ "tmp/local_route_helper_test.rb" ], level: "rails")
+      text = result.content.first[:text]
+
+      expect(text).not_to include("provider_metadata_url — route helper not found")
+      expect(text).to include("1/1 files passed")
+    end
+  end
+
   describe "JavaScript fallback validator" do
     let(:tmp_dir) { File.join(Rails.root, "tmp") }
 


### PR DESCRIPTION
## Summary
- Skip locally defined Ruby methods ending in _path or _url when checking route helper calls.
- Preserve staged file newlines in the generated pre-commit validation hook before passing files to the CLI.
- Add regression coverage and changelog notes.

## Test plan
- bundle exec rspec
- bundle exec rubocop --parallel