### PR TITLE
Recognize PostgreSQL timestamptz and tsvector schema columns

### DIFF
--- a/lib/rails_ai_context/introspectors/listeners/schema_dsl_listener.rb
+++ b/lib/rails_ai_context/introspectors/listeners/schema_dsl_listener.rb
@@ -8,10 +8,10 @@ module RailsAiContext
       class SchemaDslListener < BaseListener
         COLUMN_TYPES = %w[
           string integer text boolean datetime date decimal float binary
-          references belongs_to jsonb json uuid bigint timestamp time
+          references belongs_to jsonb json uuid bigint timestamp timestamptz time
           inet cidr macaddr hstore ltree numrange tsrange daterange
           bit bit_varying money oid xml point line lseg box path
-          polygon circle interval serial virtual primary_key
+          polygon circle interval serial tsvector virtual primary_key
         ].to_set.freeze
 
         def on_call_node_enter(node)

--- a/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
               t.string "email"
               t.string "name"
               t.integer "role"
+              t.timestamptz "last_seen_at"
+              t.tsvector "search_vector"
               t.timestamps
             end
 
@@ -103,6 +105,8 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
         user_cols = result[:tables]["users"][:columns]
         expect(user_cols).to include(a_hash_including(name: "email", type: "string"))
         expect(user_cols).to include(a_hash_including(name: "role", type: "integer"))
+        expect(user_cols).to include(a_hash_including(name: "last_seen_at", type: "timestamptz"))
+        expect(user_cols).to include(a_hash_including(name: "search_vector", type: "tsvector"))
       end
     end
 


### PR DESCRIPTION
## Summary
- Add `timestamptz` and `tsvector` to the schema DSL column type allowlist.
- Cover static `db/schema.rb` parsing so PostgreSQL-specific columns are preserved without a live DB connection.

## Verification
- `bundle exec rspec spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb`
- `RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache bundle exec rubocop --no-server lib/rails_ai_context/introspectors/listeners/schema_dsl_listener.rb spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb`