### PR TITLE
fix: run SET TRANSACTION READ ONLY before the transaction opens on MySQL (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `rails_query` no longer fails on MySQL with `Transaction characteristics can't be changed while a transaction is in progress`. `execute_mysql` issued `SET TRANSACTION READ ONLY` inside `conn.transaction`, but Rails materializes the lazy `BEGIN` before the first in-block statement, so MySQL (error 1568) rejected the SET on every call -- a 100% failure rate for plain queries and `explain: true`. The SET now runs before the transaction opens; without `GLOBAL`/`SESSION` scope it applies only to the next transaction, which the query transaction immediately consumes, so the read-only guard still holds and nothing leaks onto the pooled connection. PostgreSQL (where `SET TRANSACTION` applies to the current transaction) and SQLite are unaffected. (#89)
+
 ## [5.12.0] - 2026-06-29
 
 ### Fixed

--- a/lib/rails_ai_context/tools/query.rb
+++ b/lib/rails_ai_context/tools/query.rb
@@ -307,9 +307,16 @@ module RailsAiContext
           sql
         end
 
+        # The SET must run BEFORE the transaction opens: Rails materializes
+        # the lazy BEGIN ahead of the first in-block statement, and MySQL
+        # rejects changing transaction characteristics mid-transaction
+        # (error 1568). Without GLOBAL/SESSION scope the SET applies only to
+        # the next transaction, which the block below immediately consumes,
+        # so the read-only characteristic cannot leak onto the pooled
+        # connection. (#89)
         result = nil
+        conn.execute("SET TRANSACTION READ ONLY")
         conn.transaction do
-          conn.execute("SET TRANSACTION READ ONLY")
           result = conn.select_all(hinted_sql)
           raise ActiveRecord::Rollback
         end

--- a/spec/lib/rails_ai_context/tools/query_spec.rb
+++ b/spec/lib/rails_ai_context/tools/query_spec.rb
@@ -692,6 +692,81 @@ RSpec.describe RailsAiContext::Tools::Query do
     end
   end
 
+  describe "MySQL execution (execute_mysql)" do
+    # The Combustion test app runs on SQLite, so execute_mysql is exercised
+    # against a fake connection that enforces MySQL's rule: transaction
+    # characteristics cannot change once a transaction is in progress
+    # (error 1568, ER_CANT_CHANGE_TX_CHARACTERISTICS). Rails materializes
+    # the lazy BEGIN before the first in-block statement reaches the server,
+    # so a SET TRANSACTION issued inside `conn.transaction` always arrives
+    # mid-transaction and fails. Regression coverage for #89.
+    let(:query_result) { ActiveRecord::Result.new(%w[x], [ [ 1 ] ]) }
+
+    let(:fake_mysql_conn_class) do
+      Class.new do
+        attr_reader :statements
+
+        def initialize(result)
+          @result = result
+          @statements = []
+          @in_transaction = false
+        end
+
+        def execute(sql)
+          if @in_transaction && sql.match?(/\ASET\s+TRANSACTION/i)
+            raise ActiveRecord::StatementInvalid,
+              "Mysql2::Error: Transaction characteristics can't be changed " \
+              "while a transaction is in progress"
+          end
+          @statements << sql
+        end
+
+        def transaction
+          @statements << "BEGIN"
+          @in_transaction = true
+          yield
+          @statements << "COMMIT"
+        rescue ActiveRecord::Rollback
+          @statements << "ROLLBACK"
+        ensure
+          @in_transaction = false
+        end
+
+        def select_all(sql)
+          @statements << sql
+          @result
+        end
+      end
+    end
+
+    let(:conn) { fake_mysql_conn_class.new(query_result) }
+
+    it "issues SET TRANSACTION READ ONLY before the transaction opens" do
+      result = described_class.send(:execute_mysql, conn, "SELECT 1 AS x", 5)
+
+      expect(result).to eq(query_result)
+      set_index = conn.statements.index { |s| s.match?(/\ASET\s+TRANSACTION READ ONLY/i) }
+      begin_index = conn.statements.index("BEGIN")
+      expect(set_index).not_to be_nil
+      expect(begin_index).not_to be_nil
+      expect(set_index).to be < begin_index
+    end
+
+    it "injects the MAX_EXECUTION_TIME hint for the per-query timeout" do
+      described_class.send(:execute_mysql, conn, "SELECT 1 AS x", 5)
+
+      select = conn.statements.find { |s| s.match?(/\ASELECT/i) }
+      expect(select).to include("MAX_EXECUTION_TIME(5000)")
+    end
+
+    it "rolls the transaction back instead of committing" do
+      described_class.send(:execute_mysql, conn, "SELECT 1 AS x", 5)
+
+      expect(conn.statements).to include("ROLLBACK")
+      expect(conn.statements).not_to include("COMMIT")
+    end
+  end
+
   describe "CSV format" do
     it "escapes newlines in cell values" do
       columns = %w[id note]


### PR DESCRIPTION
Fixes #89.

## Problem

On MySQL, every `rails_query` call fails with:

```
SQL error: Mysql2::Error: Transaction characteristics can't be changed while a transaction is in progress
```

`execute_mysql` issues `SET TRANSACTION READ ONLY` **inside** `conn.transaction`. Rails materializes the lazy `BEGIN` immediately before the first statement executed inside the block, so the server receives `BEGIN` followed by the SET, and MySQL rejects changing transaction characteristics mid-transaction (error 1568, `ER_CANT_CHANGE_TX_CHARACTERISTICS`). The failure is deterministic — a 100% failure rate for plain queries and for `explain: true`, which routes through the same wrapper.

## Fix

Run the SET before the transaction opens. In MySQL, `SET TRANSACTION READ ONLY` (without `GLOBAL`/`SESSION` scope) applies only to the *next* transaction, so this is both valid and still safe: the `select_all` is the first statement inside the block, so the materialized `BEGIN` immediately consumes the read-only characteristic — nothing can leak onto the pooled connection, and writes inside the query transaction still fail.

PostgreSQL (where `SET TRANSACTION` applies to the *current* transaction) and SQLite are unaffected.

## Tests

The suite runs on SQLite (Combustion), so the new regression specs exercise `execute_mysql` against a fake connection that enforces MySQL's error-1568 rule — SET issued while a transaction is open raises. All three specs fail against the previous code with exactly the production error, and pass with the fix. They also pin the statement order (SET before BEGIN), the `MAX_EXECUTION_TIME` hint injection, and the rollback-not-commit behavior.

## Verification

Verified live against MySQL 8.x (`mysql2` adapter), Rails 8.1.3:

- queries succeed, repeated calls succeed;
- `explain: true` works;
- the read-only guard still holds (a write inside the query transaction raises `Cannot execute statement in a READ ONLY transaction`);
- the connection is back to read-write after the tool returns.

`bundle exec rspec` (2269 examples) and `bundle exec rubocop --parallel` pass. `E2E=1 bundle exec rspec spec/e2e`: 109/119 pass; the 10 failures are in the standalone/zero-config install harness and fail identically on `main` in my environment (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
