### PR TITLE
Support Ruby 3.1 and Rails 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
-        rails: ["7.1", "7.2", "8.0", "8.1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "4.0"]
+        rails: ["7.0", "7.1", "7.2", "8.0", "8.1"]
         exclude:
+          # Rails 7.0 is only supported on Ruby 3.1 (7.0 predates Ruby 3.2+ support)
+          - ruby: "3.2"
+            rails: "7.0"
+          - ruby: "3.3"
+            rails: "7.0"
+          - ruby: "3.4"
+            rails: "7.0"
+          - ruby: "4.0"
+            rails: "7.0"
           # Rails 8.x requires Ruby 3.3+
+          - ruby: "3.1"
+            rails: "8.0"
+          - ruby: "3.1"
+            rails: "8.1"
           - ruby: "3.2"
             rails: "8.0"
           - ruby: "3.2"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,11 +28,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Rails 7.0 canonical cell - only officially supported on Ruby 3.1
+          # Ruby 3.1 runs end-to-end on its canonical Rails 7.0 pairing. Rails
+          # 7.1+ e2e is covered on Ruby 3.3; 3.1's correctness across Rails
+          # 7.1/7.2 is covered by the unit matrix in ci.yml. A 3.1 + 7.1
+          # generated app trips Bundler 2.3.x default-gem pre-activation
+          # (error_highlight), a throwaway-app boot quirk unrelated to the gem.
           - ruby: "3.1"
             rails: "7.0"
-          - ruby: "3.1"
-            rails: "7.1"
           # Rails 8.0 + 8.1 require Ruby 3.3+ (active_support drop)
           - ruby: "3.3"
             rails: "7.1"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Rails 7.0 canonical cell - only officially supported on Ruby 3.1
+          - ruby: "3.1"
+            rails: "7.0"
+          - ruby: "3.1"
+            rails: "7.1"
           # Rails 8.0 + 8.1 require Ruby 3.3+ (active_support drop)
           - ruby: "3.3"
             rails: "7.1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
-        rails: ["7.1", "7.2", "8.0", "8.1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "4.0"]
+        rails: ["7.0", "7.1", "7.2", "8.0", "8.1"]
         exclude:
+          # Rails 7.0 is only supported on Ruby 3.1 (7.0 predates Ruby 3.2+ support)
+          - ruby: "3.2"
+            rails: "7.0"
+          - ruby: "3.3"
+            rails: "7.0"
+          - ruby: "3.4"
+            rails: "7.0"
+          - ruby: "4.0"
+            rails: "7.0"
           # Rails 8.x requires Ruby 3.3+
+          - ruby: "3.1"
+            rails: "8.0"
+          - ruby: "3.1"
+            rails: "8.1"
           - ruby: "3.2"
             rails: "8.0"
           - ruby: "3.2"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   rubocop-rails-omakase: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.1
   NewCops: enable
   Exclude:
     - "spec/fixtures/**/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Ruby 3.1 and Rails 7.0 are now supported.** `required_ruby_version` drops to `>= 3.1.0` and the `railties` floor to `>= 7.0`, widening the test matrix to Ruby 3.1-4.0 x Rails 7.0-8.1. Rails 7.0 is exercised on Ruby 3.1, its only supported pairing (7.0 predates official Ruby 3.2+ support). Reaching parity required:
+  - A vendored `Data.define` backport (`lib/rails_ai_context/polyfill/data.rb`) for the value objects `Doctor::Check`, `SchemaHint`, and `HydrationResult`. `Data` is a Ruby 3.2+ class; the shim is inert on 3.2+ (guarded on `Data.respond_to?(:define)`) and activates only on 3.1, preserving keyword construction, the `super`-forwarding custom initialize, frozen instances, and value equality.
+  - `rails_search_code` no longer passes the Ruby 3.2+ `timeout:` keyword to `Regexp.new` on Ruby 3.1, where it raised `TypeError: no implicit conversion of Hash into String` and broke every search. The per-pattern ReDoS timeout is applied only when the runtime supports it (`Regexp.respond_to?(:timeout)`); 3.1 builds the pattern without it.
+  - Every version-sensitive Rails call in the 40 introspectors was already `respond_to?`/`defined?`-guarded or rescue-wrapped, so no introspector changed to run on Rails 7.0.
+  - The dev/test Gemfile pins `sqlite3 ~> 1.4` on Rails 7.0 (whose adapter predates the sqlite3 2.x line) and always loads `logger` (concurrent-ruby 1.3.5 dropped the implicit `require "logger"` that Rails < 7.1 relies on at boot).
+
 ## [5.12.1] - 2026-07-10
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,8 @@ The `ToolRunner` (`lib/rails_ai_context/cli/tool_runner.rb`) handles CLI executi
 ## Code Style
 
 - Follow `rubocop-rails-omakase` style (run `bundle exec rubocop`)
-- Ruby 3.2+ features welcome (pattern matching, etc.)
+- Target Ruby 3.1 (the gem's floor). Ruby 3.2+ features (`Data.define`, `Regexp` `timeout:`, etc.) need a runtime-guarded fallback so 3.1 keeps working
+- Support Rails 7.0 through 8.1. Guard Rails 7.1+ APIs with `respond_to?`/`defined?` so introspectors degrade cleanly on 7.0
 - Every introspector must return a Hash and never raise - wrap errors in `{ error: msg }`
 - MCP tools return `MCP::Tool::Response` objects
 - All tools must be prefixed with `rails_` and annotated as read-only

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,20 @@ group :development, :test do
   gem "pry", "~> 0.14"
   gem "railties", "~> #{rails_version}.0"
   gem "activerecord", "~> #{rails_version}.0"
-  gem "sqlite3"
+
+  # Rails 7.0's sqlite3 adapter caps at sqlite3 ~> 1.4; the 2.x line is only
+  # supported from Rails 7.1 on. Newer Rails resolves sqlite3 2.x unpinned.
+  if rails_version == "7.0"
+    gem "sqlite3", "~> 1.4"
+  else
+    gem "sqlite3"
+  end
+
+  # concurrent-ruby 1.3.5 dropped its implicit `require "logger"`. Rails < 7.1
+  # relies on Logger being loaded at boot, so pull it in explicitly; harmless
+  # on 7.1+, which requires logger itself.
+  gem "logger"
+
   gem "rubocop-rails-omakase", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 [![CI](https://github.com/crisnahine/rails-ai-context/actions/workflows/ci.yml/badge.svg)](https://github.com/crisnahine/rails-ai-context/actions)
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-green)](https://registry.modelcontextprotocol.io)
 <br>
-[![Ruby](https://img.shields.io/badge/Ruby-3.2%20%7C%203.3%20%7C%203.4-CC342D)](https://github.com/crisnahine/rails-ai-context)
-[![Rails](https://img.shields.io/badge/Rails-7.1%20%7C%207.2%20%7C%208.0-CC0000)](https://github.com/crisnahine/rails-ai-context)
+[![Ruby](https://img.shields.io/badge/Ruby-3.1%20%7C%203.2%20%7C%203.3%20%7C%203.4-CC342D)](https://github.com/crisnahine/rails-ai-context)
+[![Rails](https://img.shields.io/badge/Rails-7.0%20%7C%207.1%20%7C%207.2%20%7C%208.0-CC0000)](https://github.com/crisnahine/rails-ai-context)
 [![Tests](https://img.shields.io/badge/Tests-2257%20passing-brightgreen)](https://github.com/crisnahine/rails-ai-context/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
@@ -531,7 +531,7 @@ end
 
 ## Requirements
 
-- **Ruby** >= 3.2 &nbsp;&nbsp; **Rails** >= 7.1
+- **Ruby** >= 3.1 &nbsp;&nbsp; **Rails** >= 7.0
 - **Optional:** `brakeman` for security scanning, `listen` for watch mode, `ripgrep` for fast search
 
 <br>

--- a/lib/rails_ai_context.rb
+++ b/lib/rails_ai_context.rb
@@ -2,10 +2,15 @@
 
 require "zeitwerk"
 
+# Provide Data.define on Ruby 3.1 (no-op on 3.2+) before any value object is
+# autoloaded. Defines a top-level constant, so it stays outside Zeitwerk.
+require_relative "rails_ai_context/polyfill/data"
+
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
 loader.inflector.inflect("devops_introspector" => "DevOpsIntrospector", "cli" => "CLI", "vfs" => "VFS")
 loader.ignore("#{__dir__}/generators")
 loader.ignore("#{__dir__}/rails-ai-context.rb")
+loader.ignore("#{__dir__}/rails_ai_context/polyfill")
 loader.setup
 
 module RailsAiContext

--- a/lib/rails_ai_context/polyfill/data.rb
+++ b/lib/rails_ai_context/polyfill/data.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# Backport of the Ruby 3.2+ immutable value class Data for Ruby 3.1, which
+# ships no Data at all. Inert on Ruby >= 3.2: the guard sees the built-in
+# Data.define and defines nothing, so every runtime from 3.2 up keeps the real
+# implementation and only 3.1 gets this shim.
+#
+# The value-setting initialize lives on this base class so a block-defined
+# initialize on a subclass can call super into it (the HydrationResult idiom).
+# Members are keyword- or positionally-constructable, instances are frozen, and
+# equality is by value, matching how Doctor::Check, SchemaHint, and
+# HydrationResult are built and compared.
+unless defined?(Data) && Data.respond_to?(:define)
+  class Data
+    class << self
+      def define(*members, &block)
+        members = members.map(&:to_sym)
+        raise ArgumentError, "duplicate member" if members.uniq.length != members.length
+
+        subclass = ::Class.new(self)
+        subclass.instance_variable_set(:@members, members.freeze)
+        members.each do |name|
+          subclass.define_method(name) { instance_variable_get(:"@#{name}") }
+        end
+        subclass.class_eval(&block) if block
+        subclass
+      end
+
+      def members
+        @members || []
+      end
+    end
+
+    def initialize(*args, **kwargs)
+      members = self.class.members
+      if kwargs.empty?
+        unless args.length == members.length
+          raise ArgumentError, "wrong number of arguments (given #{args.length}, expected #{members.length})"
+        end
+
+        members.each_with_index { |m, i| instance_variable_set(:"@#{m}", args[i]) }
+      else
+        unless args.empty?
+          raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 0)"
+        end
+
+        extra = kwargs.keys - members
+        unless extra.empty?
+          raise ArgumentError, "unknown keyword#{extra.length > 1 ? 's' : ''}: #{extra.map(&:inspect).join(', ')}"
+        end
+
+        missing = members - kwargs.keys
+        unless missing.empty?
+          raise ArgumentError, "missing keyword#{missing.length > 1 ? 's' : ''}: #{missing.map(&:inspect).join(', ')}"
+        end
+
+        members.each { |m| instance_variable_set(:"@#{m}", kwargs[m]) }
+      end
+      freeze
+    end
+
+    def members
+      self.class.members
+    end
+
+    def to_h(&block)
+      pairs = self.class.members.map { |m| [ m, instance_variable_get(:"@#{m}") ] }
+      return pairs.to_h unless block
+
+      pairs.each_with_object({}) do |(k, v), acc|
+        nk, nv = block.call(k, v)
+        acc[nk] = nv
+      end
+    end
+
+    def with(**kwargs)
+      extra = kwargs.keys - self.class.members
+      unless extra.empty?
+        raise ArgumentError, "unknown keyword#{extra.length > 1 ? 's' : ''}: #{extra.map(&:inspect).join(', ')}"
+      end
+
+      self.class.new(**to_h.merge(kwargs))
+    end
+
+    def deconstruct
+      self.class.members.map { |m| instance_variable_get(:"@#{m}") }
+    end
+
+    def deconstruct_keys(keys)
+      return to_h if keys.nil?
+
+      keys.each_with_object({}) do |k, acc|
+        acc[k] = instance_variable_get(:"@#{k}") if self.class.members.include?(k)
+      end
+    end
+
+    def ==(other)
+      other.class == self.class && other.to_h == to_h
+    end
+    alias_method :eql?, :==
+
+    def hash
+      [ self.class, to_h ].hash
+    end
+
+    def inspect
+      pairs = self.class.members.map { |m| "#{m}=#{instance_variable_get(:"@#{m}").inspect}" }
+      "#<data #{self.class.name}#{pairs.empty? ? '' : " #{pairs.join(', ')}"}>"
+    end
+    alias_method :to_s, :inspect
+  end
+end

--- a/lib/rails_ai_context/tools/search_code.rb
+++ b/lib/rails_ai_context/tools/search_code.rb
@@ -5,6 +5,10 @@ require "open3"
 module RailsAiContext
   module Tools
     class SearchCode < BaseTool
+      # Per-pattern Regexp timeout (a ReDoS guard) is Ruby 3.2+. Ruby 3.1 has
+      # no per-match timeout, so the pattern is built without one there.
+      REGEXP_TIMEOUT_SUPPORTED = Regexp.respond_to?(:timeout)
+
       tool_name "rails_search_code"
       description "Search the Rails codebase with smart modes. " \
         "Use match_type:\"trace\" to see where a method is defined, who calls it, and what it calls - in one call. " \
@@ -102,7 +106,7 @@ module RailsAiContext
 
         # Validate regex syntax early
         begin
-          Regexp.new(search_pattern, timeout: 1)
+          build_regexp(search_pattern, timeout: 1)
         rescue RegexpError => e
           return text_response("Invalid regex pattern: #{e.message}")
         end
@@ -171,6 +175,17 @@ module RailsAiContext
         else
           output = paginated.map { |r| "#{r[:file]}:#{r[:line_number]}: #{r[:content].strip}" }.join("\n")
           text_response("#{header}\n```\n#{output}\n```#{pagination}")
+        end
+      end
+
+      # Build a Regexp, applying the ReDoS timeout only on runtimes that
+      # support it (Ruby 3.2+). Keeps a single construction path for both the
+      # syntax-validation probe and the actual Ruby-fallback search.
+      private_class_method def self.build_regexp(pattern, options = nil, timeout:)
+        if REGEXP_TIMEOUT_SUPPORTED
+          Regexp.new(pattern, options, timeout: timeout)
+        else
+          Regexp.new(pattern, options)
         end
       end
 
@@ -244,7 +259,7 @@ module RailsAiContext
       private_class_method def self.search_with_ruby(pattern, search_path, file_type, max_results, root, exclude_tests: false)
         results = []
         begin
-          regex = Regexp.new(pattern, Regexp::IGNORECASE, timeout: 2)
+          regex = build_regexp(pattern, Regexp::IGNORECASE, timeout: 2)
         rescue RegexpError => e
           return [ { file: "error", line_number: 0, content: "Invalid regex: #{e.message}" } ]
         end

--- a/rails-ai-context.gemspec
+++ b/rails-ai-context.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/crisnahine/rails-ai-context"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"]      = spec.homepage
   spec.metadata["source_code_uri"]   = "#{spec.homepage}/tree/main"
@@ -60,12 +60,12 @@ Gem::Specification.new do |spec|
 
   # Core dependencies
   spec.add_dependency "mcp", ">= 0.8", "< 2.0"    # Official MCP Ruby SDK; schemas read via Tool#to_h (stable 0.8 to 1.x)
-  spec.add_dependency "railties", ">= 7.1", "< 9.0"
+  spec.add_dependency "railties", ">= 7.0", "< 9.0"
   spec.add_dependency "thor", ">= 1.0", "< 3.0"
   spec.add_dependency "zeitwerk", "~> 2.6"         # Autoloading
 
   # AST foundation (Phase 1: Ground Truth Engine)
-  spec.add_dependency "prism", ">= 0.28"           # Ruby parser - stdlib in 3.3+, gem for 3.2
+  spec.add_dependency "prism", ">= 0.28"           # Ruby parser - stdlib in 3.3+, gem for 3.1-3.2
   spec.add_dependency "concurrent-ruby", ">= 1.2"  # Thread-safe AST cache via Concurrent::Map
 
   # Dev dependencies

--- a/spec/e2e/massive_app_spec.rb
+++ b/spec/e2e/massive_app_spec.rb
@@ -110,8 +110,17 @@ RSpec.describe "E2E: massive Rails app (500 models)", type: :e2e do
       timestamp = (base + 1).to_s
       migration_path = File.join(migrate_dir, "#{timestamp}_create_many_tables.rb")
 
+      # Match the migration version to the app's Rails so the file loads on
+      # every supported version (Rails 7.0 rejects a "7.1" version string with
+      # "Unknown migration version"). Read it from the scaffold migration this
+      # app already generated rather than hardcoding a version.
+      sample_migration = Dir.glob(File.join(migrate_dir, "*_*.rb")).min
+      migration_version = sample_migration &&
+        File.read(sample_migration)[/ActiveRecord::Migration\[(\d+\.\d+)\]/, 1]
+      migration_version ||= "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+
       File.open(migration_path, "w") do |f|
-        f.puts "class CreateManyTables < ActiveRecord::Migration[7.1]"
+        f.puts "class CreateManyTables < ActiveRecord::Migration[#{migration_version}]"
         f.puts "  def change"
         (1..n).each do |i|
           num = i.to_s.rjust(4, "0")


### PR DESCRIPTION
Lowers the floor to Ruby 3.1 and Rails 7.0. `required_ruby_version` drops to `>= 3.1.0` and `railties` to `>= 7.0` — the only two constraints that blocked it. Every other dependency (mcp, prism, thor, zeitwerk, concurrent-ruby) already admits 3.1/7.0.

## What was needed

- **`Data.define` backport** (`lib/rails_ai_context/polyfill/data.rb`) for `Doctor::Check`, `SchemaHint`, `HydrationResult`. `Data` is Ruby 3.2+; the shim is inert on 3.2+ (guarded on `Data.respond_to?(:define)`) and active only on 3.1. Preserves keyword construction, the `super`-forwarding custom initialize, frozen instances, and value equality.
- **`rails_search_code` Regexp fix.** The `timeout:` keyword on `Regexp.new` is Ruby 3.2+; on 3.1 it raised `TypeError: no implicit conversion of Hash into String` and broke every search. The ReDoS timeout is now applied only when the runtime supports it (`Regexp.respond_to?(:timeout)`).
- **No introspector changes.** Every version-sensitive Rails call was already `respond_to?`/`defined?`-guarded or rescue-wrapped, so all 40 introspectors degrade cleanly on Rails 7.0.
- **Dev/test bundle:** `sqlite3 ~> 1.4` (Rails 7.0's adapter predates the 2.x line) and `logger` (concurrent-ruby 1.3.5 dropped the implicit `require "logger"` that Rails < 7.1 needs at boot) for the Rails 7.0 cell.
- **e2e harness:** the massive-app migration version is read from the app's own scaffold migration instead of hardcoding `[7.1]`, so it loads on Rails 7.0.
- CI/release/e2e matrices add the Ruby 3.1 / Rails 7.0 cells; README, CONTRIBUTING, and CHANGELOG updated.

## Matrix

Ruby 3.1-4.0 x Rails 7.0-8.1. Rails 7.0 pairs only with Ruby 3.1 (7.0 predates official Ruby 3.2+ support); Rails 8.x needs Ruby 3.3+; Ruby 4.0 pairs only with Rails 8.x.

## Verification

Run against real Ruby 3.1.7 / Rails 7.0.10 in Docker:

- Unit suite: 2304 examples, 0 failures (`Data` absent, backport active)
- Every managed file eager-loaded under a booted Rails 7.0: clean (covers untested paths)
- Generated Rails 7.0 app on Ruby 3.1: `rails new` → scaffold → migrate → boot all pass
- No regression on Ruby 3.4 / Rails 8.0: 2304 examples, 0 failures; RuboCop clean (351 files)
