### PR TITLE
Static tier, app shapes, and the published compatibility contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,10 @@ jobs:
             rails: "7.0"
           - ruby: "4.0"
             rails: "7.0"
-          # Rails 8.x requires Ruby 3.3+
+          # Rails 8.x requires Ruby 3.2+
           - ruby: "3.1"
             rails: "8.0"
           - ruby: "3.1"
-            rails: "8.1"
-          - ruby: "3.2"
-            rails: "8.0"
-          - ruby: "3.2"
             rails: "8.1"
           # Rails 7.x is not Ruby 4.0 compatible (no upstream support)
           - ruby: "4.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - structure.sql parsing is dialect-aware: MySQL (backticks, inline
   KEY/CONSTRAINT definitions, ENGINE trailers) and SQLite (quoted
   identifiers, IF NOT EXISTS) now parse; output gains a `dialect` key.
+- Shape-aware discovery: models and controllers are found in packwerk
+  `packs/`, in-repo `engines/`, and configured `extra_app_paths`.
+- Multi-database schema dumps (`db/*_schema.rb`, `db/*_structure.sql`)
+  reported under `secondary_databases`.
+- Mongoid detection: honest `[UNAVAILABLE]` schema signal and basic static
+  model extraction (fields, embeds, store_in) for Mongoid apps.
+- API-only apps get explicit "not applicable" answers from view/frontend
+  tools instead of empty listings.
 
 ### Changed
 
 - Boot failure in `tool`/`serve` no longer exits 1; it degrades to the
   static tier with a stderr notice. `doctor` keeps requiring a bootable app.
+
+### Fixed
+
+- `config.auto_mount = true` set in a user initializer now takes effect
+  (the middleware initializer ran before user initializers loaded).
 
 ## [5.14.0] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.15.0] - Unreleased
+
+### Added
+
+- Static tier: `serve` and `tool` fall back to source-file analysis when the
+  app cannot boot, instead of exiting. Routes (new `config/routes.rb` Prism
+  walker), models, controllers, schema, and migrations answer statically;
+  other sections report `[UNAVAILABLE]` with the reason; every response
+  carries a tier banner.
+- CLI flags: `--no-boot` (serve/tool), `--app-path` and `--environment`
+  (all commands).
+- `[STATIC]` and `[UNAVAILABLE: <reason>]` confidence tags.
+- structure.sql parsing is dialect-aware: MySQL (backticks, inline
+  KEY/CONSTRAINT definitions, ENGINE trailers) and SQLite (quoted
+  identifiers, IF NOT EXISTS) now parse; output gains a `dialect` key.
+
+### Changed
+
+- Boot failure in `tool`/`serve` no longer exits 1; it degrades to the
+  static tier with a stderr notice. `doctor` keeps requiring a bootable app.
+
 ## [5.14.0] - 2026-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   walker), models, controllers, schema, and migrations answer statically;
   other sections report `[UNAVAILABLE]` with the reason; every response
   carries a tier banner.
-- CLI flags: `--no-boot` (serve/tool), `--app-path` and `--environment`
-  (all commands).
+- CLI flags: `--no-boot` (serve/tool), `--app-path` (all app-reading
+  commands), and `--environment` (all commands).
 - `[STATIC]` and `[UNAVAILABLE: <reason>]` confidence tags.
 - structure.sql parsing is dialect-aware: MySQL (backticks, inline
   KEY/CONSTRAINT definitions, ENGINE trailers) and SQLite (quoted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,16 +28,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   model extraction (fields, embeds, store_in) for Mongoid apps.
 - API-only apps get explicit "not applicable" answers from view/frontend
   tools instead of empty listings.
+- **Loud Rails 9 warning in the standalone CLI.** In-Gemfile installs already
+  fail Bundler resolution against Rails 9 (`railties < 9.0`); the standalone
+  CLI has no such check, so it used to boot silently against an untested
+  Rails version. It now prints a stderr warning naming the installed Rails
+  version and pointing at checking for a newer gem release.
+- **`docs/COMPATIBILITY.md`** publishes the supported-version matrix, the CI
+  version grid, the RUNTIME/STATIC tier contract with the confidence-tag
+  vocabulary, and a shape-by-introspector matrix that cites the spec or QA
+  run proving every cell.
 
 ### Changed
 
 - Boot failure in `tool`/`serve` no longer exits 1; it degrades to the
   static tier with a stderr notice. `doctor` keeps requiring a bootable app.
+- CI runs Rails 8.x on Ruby 3.2 again. The exclusion assumed Rails 8
+  required Ruby 3.3+; both railties 8.0.5 and 8.1.3 declare
+  `required_ruby_version >= 3.2.0`.
 
 ### Fixed
 
 - `config.auto_mount = true` set in a user initializer now takes effect
   (the middleware initializer ran before user initializers loaded).
+- `prism` and `concurrent-ruby` are now capped below their next majors
+  (`< 2.0`, `< 3.0`) instead of an open-ended floor.
+- A syntax error in one model file now costs exactly that model - the rest
+  of the models section, and every other section, still answers normally
+  (verified end-to-end in the static tier).
 
 ## [5.14.0] - 2026-07-11
 

--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ empty listings.
 | **[Standalone](docs/STANDALONE.md)** | Use without Gemfile entry |
 | **[Troubleshooting](docs/TROUBLESHOOTING.md)** | Common issues and fixes |
 | **[FAQ](docs/FAQ.md)** | Frequently asked questions |
+| **[Compatibility](docs/COMPATIBILITY.md)** | Supported versions, operating tiers, and the shape matrix with proof sources |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -448,6 +448,30 @@ Both paths ask which AI tools you use (Claude Code, Cursor, GitHub Copilot, Open
 
 <br>
 
+## Static tier: works even when the app can't boot
+
+`rails-ai-context` attempts a full boot for live reflection. When boot fails
+(missing ENV vars, unreachable services, a broken initializer) the `serve`
+and `tool` commands fall back to the **static tier** instead of dying:
+routes come from parsing `config/routes.rb`, schema from `db/schema.rb` /
+`db/structure.sql` / migrations, models and controllers from their source
+files. Every response carries a banner explaining the degradation, static
+data is tagged `[STATIC]`, and sections that genuinely need a booted app
+report `[UNAVAILABLE]` with the reason.
+
+Flags:
+
+- `--no-boot` (serve, tool) - skip the boot attempt entirely and serve
+  static analysis. Fast, and immune to boot-time side effects.
+- `--app-path PATH` (all commands) - run against a Rails app in another
+  directory.
+- `--environment ENV` (all commands) - set RAILS_ENV for the boot attempt.
+
+`rails-ai-context doctor` still requires a bootable app: its job is
+diagnosing why boot fails.
+
+<br>
+
 ## Documentation
 
 | | |

--- a/README.md
+++ b/README.md
@@ -472,6 +472,20 @@ diagnosing why boot fails.
 
 <br>
 
+## App shapes
+
+Beyond the conventional layout, code is discovered in packwerk packs
+(`packs/*/app/*`), in-repo engines (`engines/*/app/*`), and any directories
+listed in `extra_app_paths` in `.rails-ai-context.yml`. Rails multi-database
+schema dumps (`db/queue_schema.rb` and friends) are reported under a
+`Secondary databases` section. Mongoid apps get an honest
+`[UNAVAILABLE]` schema signal plus basic static model data (fields, embedded
+relations) instead of misleading empty output, and API-only apps get
+"not applicable" answers from view and frontend tools instead of silent
+empty listings.
+
+<br>
+
 ## Documentation
 
 | | |

--- a/README.md
+++ b/README.md
@@ -463,8 +463,8 @@ Flags:
 
 - `--no-boot` (serve, tool) - skip the boot attempt entirely and serve
   static analysis. Fast, and immune to boot-time side effects.
-- `--app-path PATH` (all commands) - run against a Rails app in another
-  directory.
+- `--app-path PATH` (all app-reading commands) - run against a Rails app in
+  another directory.
 - `--environment ENV` (all commands) - set RAILS_ENV for the boot attempt.
 
 `rails-ai-context doctor` still requires a bootable app: its job is

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -116,8 +116,9 @@ genuinely doesn't exist for this app.
 
 ## Shape matrix
 
-Rows are app shapes; columns are the five introspectors with any static
-reach. `n/a` means the shape doesn't change that introspector's behavior - see
+Rows are app shapes; columns are schema, models, routes, and controllers
+(the four whose static behavior varies by shape), plus views for contrast.
+`n/a` means the shape doesn't change that introspector's behavior - see
 the stock full-stack row for its baseline proof. Reference numbers point at
 the proof list below the table.
 
@@ -132,7 +133,7 @@ the proof list below the table.
 | Packwerk `packs/` | n/a | static [5] | n/a | n/a | n/a |
 | In-repo `engines/` | n/a | n/a | n/a | static [5] | n/a |
 | Mongoid | `[UNAVAILABLE]`, honest signal [6] | static (fields + embeds) [6] | n/a | n/a | n/a |
-| Broken-boot (any full-stack app) | static [7] | static, per-file isolation [7] | static [7] | static [5] | `[UNAVAILABLE]` [8] |
+| Broken-boot (any full-stack app) | static [7] | static, per-file isolation [7] | static [7] | static [7] | `[UNAVAILABLE]` [8] |
 | Packs + engines under `--no-boot` | n/a | static [5] | n/a | static [5] | n/a |
 | Empty/greenfield app (no scaffold) | graceful, no crash [9] | graceful, no crash [9] | graceful, no crash [9] | graceful, no crash [9] | graceful, no crash [9] |
 | Massive app (500 models/tables) | no crash at scale [10] | no crash at scale [10] | no crash at scale [10] | n/a | n/a |
@@ -140,8 +141,8 @@ the proof list below the table.
 Proof sources:
 
 1. `spec/e2e/in_gemfile_install_spec.rb`, `standalone_install_spec.rb`,
-   `zero_config_install_spec.rb` (schema/routes/model_details/controllers tool
-   invocations against the default scaffold, across all three install paths);
+   `zero_config_install_spec.rb` (schema, routes, model_details, and controllers
+   exercised across the install-path suite - in-Gemfile, standalone, zero-config);
    real Rails 8.0 apps in the v5.14.0 release QA (`blog`, `sandbox`).
 2. Non-crash coverage for every built-in tool including `get_view` in
    `spec/e2e/in_gemfile_install_spec.rb`'s full-tool sweep; output correctness

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,218 @@
+<div align="center" markdown="1">
+
+# Compatibility
+
+**What's actually supported, what's actually proven, and where each claim comes from.**
+
+[Architecture](ARCHITECTURE.md) · [Introspectors](INTROSPECTORS.md) · [Troubleshooting](TROUBLESHOOTING.md) · [FAQ](FAQ.md)
+
+</div>
+
+---
+
+Every claim below cites the spec file or release that proves it. No entry in this
+document is aspirational.
+
+## Supported versions
+
+- **Ruby:** 3.1 - 4.0 (gemspec: `required_ruby_version >= 3.1.0`, no upper cap)
+- **Rails (railties):** 7.0 - 8.1 (gemspec: `railties >= 7.0, < 9.0`)
+- **mcp gem:** `>= 0.8, < 2.0`
+- **thor:** `>= 1.0, < 3.0`
+- **prism:** `>= 0.28, < 2.0`
+- **concurrent-ruby:** `>= 1.2, < 3.0`
+
+The gemspec's `railties` bound is wider than the CI matrix: point releases inside
+7.0-8.1 and any future 8.x minor satisfy Bundler's constraint without a gem
+release, but only the combinations in the table below are actually exercised by
+CI.
+
+### CI matrix
+
+Source: `.github/workflows/ci.yml`. 17 of 25 possible Ruby x Rails combinations
+run (`fail-fast: false`, so one failing cell doesn't hide the rest):
+
+| Ruby \ Rails | 7.0 | 7.1 | 7.2 | 8.0 | 8.1 |
+|:---|:---:|:---:|:---:|:---:|:---:|
+| 3.1 | yes | yes | yes | - | - |
+| 3.2 | - | yes | yes | yes | yes |
+| 3.3 | - | yes | yes | yes | yes |
+| 3.4 | - | yes | yes | yes | yes |
+| 4.0 | - | - | - | yes | yes |
+
+- Rails 7.0 runs only on Ruby 3.1 (7.0 predates upstream Ruby 3.2+ support).
+- Rails 8.0/8.1 run on Ruby 3.2+ (both declare `required_ruby_version >= 3.2.0`
+  upstream; they never needed 3.3).
+- Ruby 4.0 runs only against Rails 8.0/8.1 (7.x has no upstream Ruby 4
+  support).
+- RuboCop runs once inside the matrix (Ruby 3.3 / Rails 8.0) and again in a
+  dedicated `lint` job pinned to Ruby 3.3.
+
+### Rails 9
+
+Not supported, and the two install paths fail differently:
+
+- **In-Gemfile:** the gemspec's `railties < 9.0` constraint makes `bundle
+  install`/`bundle exec` fail dependency resolution outright when the host
+  app's Gemfile locks Rails 9 - the gem never loads.
+- **Standalone:** the CLI pre-loads the gem into its own `GEM_HOME` before the
+  host app boots, so no Bundler constraint applies. `exe/rails-ai-context`
+  prints a stderr warning after a successful boot when
+  `Rails::VERSION::MAJOR >= 9`, naming the installed Rails version and
+  pointing at checking for a newer gem release. Introspection itself is
+  untested on Rails 9 either way.
+
+## Operating tiers
+
+Two tiers, both reachable over the CLI and MCP (stdio and HTTP):
+
+**RUNTIME** - the app booted. Introspectors read live Rails reflection
+(ActiveRecord connections, `Rails.application.routes`, loaded classes) plus the
+Prism AST layer for source-level facts (scopes, callbacks, strong params).
+
+**STATIC** - the app didn't boot, or `--no-boot` was passed. Only introspectors
+that define a `static_call` path can answer without a booted app:
+
+| Introspector | Static source |
+|:---|:---|
+| `schema` | `db/schema.rb` / `db/structure.sql` / migration files |
+| `migrations` | migration file list + `db/structure.sql`'s trailing `schema_migrations` insert |
+| `routes` | `config/routes.rb` parsed with a dedicated Prism listener |
+| `models` | `app/models/**/*.rb` (plus packs/engines/extra paths) parsed, not constantized |
+| `controllers` | `app/controllers/**/*.rb` (plus packs/engines/extra paths) parsed, not constantized |
+
+The other 34 introspectors (views, jobs, gems, turbo, i18n, active_storage,
+auth, api, and the rest) have no static path and report `{ unavailable: reason
+}` in this tier - by construction, not by shape: `Introspector#run_introspector`
+(`lib/rails_ai_context/introspector.rb`) falls back to the same message
+regardless of what triggered the static tier.
+
+`doctor` never enters the static tier - its job is diagnosing why boot failed,
+so it always requires a bootable app.
+
+Boot failure degrades `serve`/`tool` to the static tier automatically (proven
+across four boot-failure modes - raises, prints to stdout, writes via the
+`STDOUT` constant, and hangs past the timeout - in
+`spec/e2e/boot_resilience_spec.rb`); `--no-boot` forces it without attempting a
+boot at all (`spec/e2e/static_tier_spec.rb`).
+
+### Confidence vocabulary
+
+Source: `lib/rails_ai_context/confidence.rb`.
+
+| Tag | Meaning |
+|:---|:---|
+| `[VERIFIED]` | Runtime-confirmed value, or a static literal the AST resolves with certainty |
+| `[STATIC]` | Derived from source files without a booted app - trustworthy structure, not runtime-confirmed |
+| `[INFERRED]` | Heuristic: a dynamic expression, metaprogramming, or a runtime-only construct the AST can't fully resolve |
+| `[UNAVAILABLE: reason]` | The data source is absent entirely |
+
+`[VERIFIED]`/`[INFERRED]` are per-value tags applied inside the schema, model,
+route, controller, and mailbox-routing introspectors as they walk the AST
+(`Confidence.for_node`). `[STATIC]`/`[UNAVAILABLE]` are whole-response tags:
+`[STATIC]` marks any answer that came from the static tier; `[UNAVAILABLE]`
+marks a section with no static path, or (in either tier) a data source that
+genuinely doesn't exist for this app.
+
+## Shape matrix
+
+Rows are app shapes; columns are the five introspectors with any static
+reach. `n/a` means the shape doesn't change that introspector's behavior - see
+the stock full-stack row for its baseline proof. Reference numbers point at
+the proof list below the table.
+
+| Shape | Schema | Models | Routes | Controllers | Views |
+|:---|:---|:---|:---|:---|:---|
+| Stock full-stack (`schema.rb`) | runtime + static [1] | runtime + static [1] | runtime + static [1] | runtime + static [1] | runtime only [2] |
+| API-only | runtime + static [1] | runtime + static [1] | runtime + static [1] | runtime + static [1] | runtime, "not applicable" [3] |
+| `structure.sql` - PostgreSQL dialect | static [4] | n/a | n/a | n/a | n/a |
+| `structure.sql` - MySQL/Trilogy dialect | static [4] | n/a | n/a | n/a | n/a |
+| `structure.sql` - SQLite dialect | static [4] | n/a | n/a | n/a | n/a |
+| Multi-DB `solid_*` schema dumps | static, `secondary_databases` [5] | n/a | n/a | n/a | n/a |
+| Packwerk `packs/` | n/a | static [5] | n/a | n/a | n/a |
+| In-repo `engines/` | n/a | n/a | n/a | static [5] | n/a |
+| Mongoid | `[UNAVAILABLE]`, honest signal [6] | static (fields + embeds) [6] | n/a | n/a | n/a |
+| Broken-boot (any full-stack app) | static [7] | static, per-file isolation [7] | static [7] | static [5] | `[UNAVAILABLE]` [8] |
+| Packs + engines under `--no-boot` | n/a | static [5] | n/a | static [5] | n/a |
+| Empty/greenfield app (no scaffold) | graceful, no crash [9] | graceful, no crash [9] | graceful, no crash [9] | graceful, no crash [9] | graceful, no crash [9] |
+| Massive app (500 models/tables) | no crash at scale [10] | no crash at scale [10] | no crash at scale [10] | n/a | n/a |
+
+Proof sources:
+
+1. `spec/e2e/in_gemfile_install_spec.rb`, `standalone_install_spec.rb`,
+   `zero_config_install_spec.rb` (schema/routes/model_details/controllers tool
+   invocations against the default scaffold, across all three install paths);
+   real Rails 8.0 apps in the v5.14.0 release QA (`blog`, `sandbox`).
+2. Non-crash coverage for every built-in tool including `get_view` in
+   `spec/e2e/in_gemfile_install_spec.rb`'s full-tool sweep; output correctness
+   (ivar cross-check, render-form detection, partial interfaces) verified
+   against the real `blog` app in the v5.14.0 release QA.
+3. Unit specs for the "not applicable" API-only messaging: `get_view_spec.rb`,
+   `get_component_catalog_spec.rb`, `get_turbo_map_spec.rb`,
+   `get_partial_interface_spec.rb`, `get_stimulus_spec.rb`, `get_api_spec.rb`;
+   real Rails 8 `--api` app (`api_app`) in the v5.14.0 release QA.
+4. `spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb`
+   ("with a valid structure.sql fixture", "with a MySQL (mysqldump)
+   structure.sql", "with a SQLite structure.sql"). Unit-proven only - no
+   committed e2e fixture writes a `structure.sql` file. The MySQL/Trilogy
+   adapter itself (live queries, not the dump format) was also run for real
+   against MySQL 9.6 in the v5.14.0 release QA (`store` app,
+   `schema_format = :sql`).
+5. `spec/e2e/shapes_spec.rb`: "packs and engines code discovery (static
+   tier)" and "multi-database schema dumps".
+6. `spec/e2e/shapes_spec.rb`: "Mongoid app (bare directory, --app-path, no
+   boot possible)".
+7. `spec/e2e/boot_resilience_spec.rb` (four boot-failure modes: raises,
+   prints to stdout, writes via the `STDOUT` constant, hangs past the
+   timeout) plus `spec/e2e/static_tier_spec.rb` ("broken-boot app over the
+   CLI", "broken-boot app over MCP stdio", "syntax error in one model file").
+8. No introspector outside the five in the operating-tiers table defines
+   `static_call` (`lib/rails_ai_context/introspectors/view_introspector.rb`
+   has none); `Introspector#run_introspector` reports `{ unavailable: reason
+   }` for every such section regardless of shape.
+9. `spec/e2e/empty_app_spec.rb` - all 39 built-in tools swept against an app
+   with no scaffold, no models, no controllers beyond
+   `ApplicationController`, no routes beyond root.
+10. `spec/e2e/massive_app_spec.rb` - `schema`, `model_details`, and `routes`
+    (plus `context`, `onboard`, `analyze_feature`, `get_turbo_map`, `get_env`)
+    sampled against 500 generated models/tables under a 180-second cap.
+
+Postgres itself - live query safety (read-only transactions, the
+`BLOCKED_FUNCTIONS` guard against `pg_read_file`/`dblink`/`COPY ... PROGRAM`,
+DDL rejection) alongside schema/routes - is proven end-to-end against a real
+Postgres instance in `spec/e2e/postgres_install_spec.rb`, opt-in via
+`TEST_POSTGRES=1` and skipped otherwise.
+
+## Known limits
+
+- **Concern-style Mongoid documents in runtime results.** Mongoid documents
+  are invisible to ActiveRecord reflection, so `ModelIntrospector#call` falls
+  back to the same source-parsing pass used in the static tier even when the
+  app is booted (`lib/rails_ai_context/introspectors/model_introspector.rb`).
+  Fields or associations defined in an included concern module rather than
+  directly in the document class body are not resolved, in either tier.
+- **Static-tier API-only detection.** `Tools::BaseTool#api_only_app?` reads
+  `app.config.api_only`. `RailsAiContext::StaticApp` exposes no `config`
+  method, so this check is always false in the static tier - the "not
+  applicable" messaging for view/frontend tools on API-only apps only fires
+  once the app has actually booted.
+- **Live multi-DB connections are not iterated, only dumps.**
+  `MultiDatabaseIntrospector` (replicas, sharding, per-model connection
+  assignment) has no static path and reports `[UNAVAILABLE]` in the static
+  tier. Only the schema introspector's own secondary-database dump parsing
+  (`db/*_schema.rb`, `db/*_structure.sql`) works without a boot.
+- **Constraints and lambda routes surface as a dynamic tally, not resolved
+  entries.** `RouteIntrospector#static_call` counts routes behind
+  `constraints do...end` blocks, lambdas, `devise_for`, and `concern`-based
+  route declarations into a `dynamic_routes` count rather than fabricating
+  per-route controller/action pairs it can't actually determine from source.
+
+<br>
+
+---
+
+<div align="center">
+
+[Back to README](../README.md)
+
+</div>

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -39,18 +39,23 @@ class RailsAiContextCLI < Thor
     # and `-v` fall through to "Could not find command" instead of the `version` task.
     map %w[--version -v] => :version
 
+    class_option :app_path, type: :string,
+      desc: "Path to the Rails app root (default: current directory)"
+    class_option :environment, type: :string,
+      desc: "RAILS_ENV to run under (default: the ambient RAILS_ENV or development)"
+
     desc "tool [NAME]", "Run an MCP tool. Use --list to see all."
     option :json, type: :boolean, default: false, desc: "Output as JSON envelope"
     option :list, type: :boolean, default: false, desc: "List available tools"
+    option :no_boot, type: :boolean, default: false, desc: "Skip booting the app; serve static analysis only"
     def tool(name = nil, *args)
       if options[:list] || name.nil?
         print_tool_list
         return
       end
 
-      boot_rails!
-
       if args.include?("--help") || args.include?("-h")
+        require "rails_ai_context"
         tool_class = ::RailsAiContext::CLI::ToolRunner.new(name, []).tool_class
         puts ::RailsAiContext::CLI::ToolRunner.tool_help(tool_class)
         return
@@ -63,6 +68,13 @@ class RailsAiContextCLI < Thor
       json_mode = options[:json]
       json_mode = true if args.delete("--json")
       json_mode = true if args.delete("-j")
+
+      # stop_on_unknown_option! passes post-name flags through into args;
+      # honor --no-boot in either position, mirroring the --json handling.
+      no_boot = options[:no_boot]
+      no_boot = true if args.delete("--no-boot")
+
+      boot_rails!(allow_static: true, no_boot: no_boot)
 
       runner = ::RailsAiContext::CLI::ToolRunner.new(name, args, json_mode: json_mode)
       puts runner.run
@@ -77,8 +89,9 @@ class RailsAiContextCLI < Thor
     desc "serve", "Start MCP server (stdio transport)"
     option :transport, type: :string, default: "stdio", desc: "Transport: stdio or http"
     option :port, type: :numeric, default: 6029, desc: "HTTP port (only for http transport)"
+    option :no_boot, type: :boolean, default: false, desc: "Skip booting the app; serve static analysis only"
     def serve
-      boot_rails!
+      boot_rails!(allow_static: true)
 
       transport = options[:transport].to_sym
       if transport == :http
@@ -577,11 +590,22 @@ class RailsAiContextCLI < Thor
     # capture references BEFORE Rails boot runs and re-register them afterwards.
     STANDALONE_REQUIRED_GEMS = %w[mcp json-schema addressable public_suffix].freeze
 
-    def boot_rails!(context: nil)
+    def boot_rails!(context: nil, allow_static: false, no_boot: false)
+      app_root = File.expand_path(options[:app_path] || Dir.pwd)
+      # Relative paths inside the app (log/, tmp/, sqlite files) assume the
+      # process cwd is the app root, so honor --app-path by moving there.
+      Dir.chdir(app_root) if options[:app_path]
+      ENV["RAILS_ENV"] = options[:environment] if options[:environment]
+
+      if allow_static && (no_boot || options[:no_boot])
+        enter_static_tier!("static mode requested with --no-boot")
+        return
+      end
+
       config_path = File.join(Dir.pwd, "config", "environment.rb")
       unless File.exist?(config_path)
         $stderr.puts "Error: No Rails app found in #{Dir.pwd}"
-        $stderr.puts "Run this command from your Rails app root directory."
+        $stderr.puts "Run this command from your Rails app root directory (or pass --app-path)."
         exit 1
       end
 
@@ -621,6 +645,18 @@ class RailsAiContextCLI < Thor
       result = ::RailsAiContext::BootManager.boot!(app_root: Dir.pwd, timeout: timeout)
 
       unless result.booted?
+        if allow_static
+          $stderr.puts "[rails-ai-context] App boot failed: #{result.failure_summary}"
+          if result.error.is_a?(::RailsAiContext::BootManager::BootTimeoutError)
+            $stderr.puts "[rails-ai-context]   If the app is healthy but slow, raise RAILS_AI_CONTEXT_BOOT_TIMEOUT (seconds, current: #{timeout})."
+          end
+          $stderr.puts "[rails-ai-context] Serving static analysis; runtime-only data is marked [UNAVAILABLE]."
+          $stderr.puts "[rails-ai-context] Run `rails-ai-context doctor` for boot diagnostics."
+          restore_standalone_environment!(pre_boot_paths, pre_boot_specs)
+          enter_static_tier!(result.failure_summary)
+          return
+        end
+
         $stderr.puts "Error: Rails app failed to boot in #{Dir.pwd}"
         $stderr.puts "  #{result.failure_summary}"
         if ENV["DEBUG"]
@@ -643,24 +679,38 @@ class RailsAiContextCLI < Thor
         exit 1
       end
 
-      # Restore paths and specs that Bundler.setup stripped (standalone mode).
-      # For Gemfile users, both restorations are no-ops.
-      (pre_boot_paths - $LOAD_PATH).each { |p| $LOAD_PATH << p }
-      pre_boot_specs.each { |name, spec| Gem.loaded_specs[name] ||= spec }
-
-      # Loud warning if any required spec couldn't be restored — silent failure
-      # here means tools will crash later with `undefined method 'full_gem_path'
-      # for nil` from inside the MCP SDK.
-      missing = STANDALONE_REQUIRED_GEMS.reject { |g| Gem.loaded_specs.key?(g) }
-      if missing.any? && !ENV["BUNDLE_BIN_PATH"]
-        $stderr.puts "[rails-ai-context] WARNING: standalone CLI could not restore gemspec(s): #{missing.join(', ')}."
-        $stderr.puts "[rails-ai-context]   Tool calls may crash with `undefined method 'full_gem_path' for nil`."
-        $stderr.puts "[rails-ai-context]   Try `gem install rails-ai-context` to ensure all transitive deps are installed."
-      end
+      restore_standalone_environment!(pre_boot_paths, pre_boot_specs)
 
       require "rails_ai_context"
 
       RailsAiContext::Configuration.auto_load!
+    end
+
+    # Bundler.setup during app boot strips $LOAD_PATH and the spec registry
+    # to Gemfile-resolved gems; in standalone mode our own transitive deps
+    # (mcp, json-schema) vanish. Splice back what was captured pre-boot.
+    def restore_standalone_environment!(pre_boot_paths, pre_boot_specs)
+      (pre_boot_paths - $LOAD_PATH).each { |p| $LOAD_PATH << p }
+      pre_boot_specs.each { |name, spec| Gem.loaded_specs[name] ||= spec }
+
+      missing = STANDALONE_REQUIRED_GEMS.reject { |g| Gem.loaded_specs.key?(g) }
+      return if missing.none? || ENV["BUNDLE_BIN_PATH"]
+
+      $stderr.puts "[rails-ai-context] WARNING: standalone CLI could not restore gemspec(s): #{missing.join(', ')}."
+      $stderr.puts "[rails-ai-context]   Tool calls may crash with `undefined method 'full_gem_path' for nil`."
+      $stderr.puts "[rails-ai-context]   Try `gem install rails-ai-context` to ensure all transitive deps are installed."
+    end
+
+    # Static tier: the gem loads standalone (no app constants), introspection
+    # runs against the filesystem, and every tool response carries the tier
+    # banner so consumers know runtime data is absent.
+    def enter_static_tier!(reason)
+      require "rails_ai_context"
+      ::RailsAiContext.tier = :static
+      ::RailsAiContext.static_reason = reason
+      ::RailsAiContext.configuration.app_root = Dir.pwd
+      ::RailsAiContext::Configuration.auto_load!
+      $stderr.puts "[rails-ai-context] static tier active: #{reason}"
     end
 
     # Look up each required gem via Gem::Specification.find_by_name BEFORE

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -563,7 +563,7 @@ class RailsAiContextCLI < Thor
         require "rails_ai_context"
         puts ::RailsAiContext::CLI::ToolRunner.tool_list
         puts ""
-        puts "Run inside a Rails app to execute tools."
+        puts "Run inside a Rails app to execute tools - static source analysis works even when the app can't boot (see --no-boot)."
       rescue LoadError, StandardError => e
         $stderr.puts "Error: No Rails app found in #{Dir.pwd}"
         $stderr.puts "Run this command from your Rails app root directory."

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -683,6 +683,12 @@ class RailsAiContextCLI < Thor
 
       require "rails_ai_context"
 
+      if defined?(Rails::VERSION::MAJOR) && Rails::VERSION::MAJOR >= 9
+        $stderr.puts "[rails-ai-context] WARNING: Rails #{Rails.version} is newer than this gem supports (< 9.0)."
+        $stderr.puts "[rails-ai-context]   Introspection is untested on this version and may be wrong or incomplete."
+        $stderr.puts "[rails-ai-context]   Check for a newer rails-ai-context release."
+      end
+
       RailsAiContext::Configuration.auto_load!
     end
 

--- a/lib/rails_ai_context.rb
+++ b/lib/rails_ai_context.rb
@@ -2,6 +2,18 @@
 
 require "zeitwerk"
 
+# Introspectors and tools lean on ActiveSupport's core extensions (camelize,
+# underscore, deep_dup, presence, ...) without requiring them individually.
+# In runtime tier that's harmless - booting the host Rails app loads all of
+# ActiveSupport as a side effect before any of this code runs. In static
+# tier nothing boots Rails, so those methods are only defined by accident of
+# which introspector happens to run first. Requiring them here up front
+# makes both tiers behave the same regardless of load order.
+require "active_support/core_ext/string/inflections"
+require "active_support/core_ext/string/filters"
+require "active_support/core_ext/object/deep_dup"
+require "active_support/core_ext/object/blank"
+
 # Provide Data.define on Ruby 3.1 (no-op on 3.2+) before any value object is
 # autoloaded. Defines a top-level constant, so it stays outside Zeitwerk.
 require_relative "rails_ai_context/polyfill/data"

--- a/lib/rails_ai_context.rb
+++ b/lib/rails_ai_context.rb
@@ -46,24 +46,54 @@ module RailsAiContext
       end
     end
 
+    # Operating tier. :runtime means the host app booted and live reflection
+    # is available; :static means only source files are being analyzed.
+    # Defaults to :runtime because in-app usage (railtie, rake tasks) only
+    # reaches this code after a successful boot.
+    attr_writer :tier
+
+    def tier
+      @tier || :runtime
+    end
+
+    def static_tier?
+      tier == :static
+    end
+
+    # One-line explanation of why the static tier is active (boot failure
+    # summary, or a note that --no-boot was requested). Nil in runtime tier.
+    attr_accessor :static_reason
+
     # Quick access to introspect the current Rails app
     # Returns a hash of all discovered context
     def introspect(app = nil)
-      app ||= Rails.application
+      app ||= default_app
       Introspector.new(app).call
     end
 
     # Generate context files (CLAUDE.md, .cursor/rules/, etc.)
     def generate_context(app = nil, format: :all)
-      app ||= Rails.application
+      app ||= default_app
       context = introspect(app)
       Serializers::ContextFileSerializer.new(context, format: format).call
     end
 
     # Start the MCP server programmatically
     def start_mcp_server(app = nil, transport: :stdio)
-      app ||= Rails.application
+      app ||= default_app
       Server.new(app, transport: transport).start
+    end
+
+    private
+
+    # The app object introspection runs against: the booted Rails app in
+    # runtime tier, a filesystem-rooted stand-in in static tier.
+    def default_app
+      if static_tier?
+        StaticApp.new(configuration.app_root || Dir.pwd)
+      else
+        Rails.application
+      end
     end
   end
 end

--- a/lib/rails_ai_context.rb
+++ b/lib/rails_ai_context.rb
@@ -84,8 +84,6 @@ module RailsAiContext
       Server.new(app, transport: transport).start
     end
 
-    private
-
     # The app object introspection runs against: the booted Rails app in
     # runtime tier, a filesystem-rooted stand-in in static tier.
     def default_app

--- a/lib/rails_ai_context/app_kind.rb
+++ b/lib/rails_ai_context/app_kind.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RailsAiContext
+  # Detects app-level facts that change which introspection applies, from
+  # artifacts that exist without booting (config files, Gemfile.lock).
+  module AppKind
+    module_function
+
+    # The four-space indent plus "(" matches Bundler's resolved-spec line
+    # exactly, so gems that merely contain the name do not false-positive.
+    def mongoid?(root)
+      root = root.to_s
+      return true if File.exist?(File.join(root, "config", "mongoid.yml"))
+
+      lock = File.join(root, "Gemfile.lock")
+      return false unless File.exist?(lock)
+
+      content = RailsAiContext::SafeFile.read(lock)
+      !!content&.include?("    mongoid (")
+    end
+  end
+end

--- a/lib/rails_ai_context/confidence.rb
+++ b/lib/rails_ai_context/confidence.rb
@@ -5,13 +5,32 @@ module RailsAiContext
   # Shared across tools and introspectors without creating
   # cross-layer dependencies.
   #
-  # VERIFIED: value extracted from a static, deterministic AST node
-  #           (symbol literals, string literals, integers, booleans).
+  # VERIFIED: value extracted from a runtime-confirmed source (e.g. inspection of
+  #           a loaded Rails environment).
+  # STATIC: value derived from source files without a booted app - trustworthy
+  #         structure, but not runtime-confirmed (e.g. a routes.rb entry may
+  #         still be disabled by a constraint the parser cannot evaluate).
   # INFERRED: value involves dynamic expressions, metaprogramming,
   #           or runtime-only constructs that AST cannot fully resolve.
+  # UNAVAILABLE: data source is absent entirely; use the reasoned form to tell
+  #              consumers what would unlock the data.
   module Confidence
     VERIFIED = "[VERIFIED]"
     INFERRED = "[INFERRED]"
+    # STATIC marks data derived from source files without a booted app -
+    # trustworthy structure, but not runtime-confirmed (a routes.rb entry may
+    # still be disabled by a constraint the parser cannot evaluate).
+    STATIC = "[STATIC]"
+    # UNAVAILABLE marks data whose source is absent entirely; prefer the
+    # reasoned form so consumers learn what would unlock the data.
+    UNAVAILABLE = "[UNAVAILABLE]"
+
+    # Reasoned unavailability tag: "[UNAVAILABLE: requires a booted Rails app]".
+    # Reasons are collapsed to their first line so a raised exception message
+    # can be passed through without flooding the tag.
+    def self.unavailable(reason)
+      "[UNAVAILABLE: #{reason.to_s.lines.first.to_s.strip}]"
+    end
 
     # Determine confidence level for a Prism call node's arguments.
     # Returns VERIFIED if all arguments are static literals,

--- a/lib/rails_ai_context/confidence.rb
+++ b/lib/rails_ai_context/confidence.rb
@@ -5,24 +5,17 @@ module RailsAiContext
   # Shared across tools and introspectors without creating
   # cross-layer dependencies.
   #
-  # VERIFIED: value extracted from a runtime-confirmed source (e.g. inspection of
-  #           a loaded Rails environment).
-  # STATIC: value derived from source files without a booted app - trustworthy
-  #         structure, but not runtime-confirmed (e.g. a routes.rb entry may
-  #         still be disabled by a constraint the parser cannot evaluate).
-  # INFERRED: value involves dynamic expressions, metaprogramming,
-  #           or runtime-only constructs that AST cannot fully resolve.
-  # UNAVAILABLE: data source is absent entirely; use the reasoned form to tell
-  #              consumers what would unlock the data.
+  # VERIFIED: value the gem can assert with certainty - runtime-confirmed data,
+  #           or a static literal the AST resolves deterministically (see for_node).
+  # STATIC: derived from source files without a booted app - trustworthy structure,
+  #         not runtime-confirmed.
+  # INFERRED: heuristic - dynamic expressions, metaprogramming, or runtime-only
+  #           constructs the AST cannot fully resolve.
+  # UNAVAILABLE: the data source is absent entirely; the reasoned form says why.
   module Confidence
     VERIFIED = "[VERIFIED]"
     INFERRED = "[INFERRED]"
-    # STATIC marks data derived from source files without a booted app -
-    # trustworthy structure, but not runtime-confirmed (a routes.rb entry may
-    # still be disabled by a constraint the parser cannot evaluate).
     STATIC = "[STATIC]"
-    # UNAVAILABLE marks data whose source is absent entirely; prefer the
-    # reasoned form so consumers learn what would unlock the data.
     UNAVAILABLE = "[UNAVAILABLE]"
 
     # Reasoned unavailability tag: "[UNAVAILABLE: requires a booted Rails app]".

--- a/lib/rails_ai_context/configuration.rb
+++ b/lib/rails_ai_context/configuration.rb
@@ -107,6 +107,12 @@ module RailsAiContext
     # Output directory for generated context files
     attr_accessor :output_dir
 
+    # Filesystem root of the app under analysis. Set by the CLI (--app-path
+    # or the working directory) for the static tier; nil means "ask Rails".
+    # Deliberately not a YAML key: the config file lives inside the app it
+    # would point at.
+    attr_accessor :app_root
+
     # Models/tables to exclude from introspection
     attr_accessor :excluded_models
 

--- a/lib/rails_ai_context/configuration.rb
+++ b/lib/rails_ai_context/configuration.rb
@@ -18,7 +18,7 @@ module RailsAiContext
       live_reload live_reload_debounce auto_mount http_path http_bind http_port
       output_dir skip_tools excluded_models excluded_controllers
       excluded_route_prefixes excluded_filters excluded_middleware excluded_association_names excluded_paths
-      sensitive_patterns search_extensions concern_paths frontend_paths
+      sensitive_patterns search_extensions concern_paths frontend_paths extra_app_paths
       max_file_size max_test_file_size max_schema_file_size max_view_total_size
       max_view_file_size max_search_results max_validate_files
       query_timeout query_row_limit query_redacted_columns allow_query_in_production
@@ -235,6 +235,12 @@ module RailsAiContext
     # Frontend framework detection (optional overrides - auto-detected if nil)
     attr_accessor :frontend_paths         # User-declared frontend dirs (e.g. ["app/frontend", "../web-client"])
 
+    # Additional app-root-relative directories that contain Rails app code
+    # beyond the conventional layout and the built-in packs/ and engines/
+    # globs (e.g. ["src", "vendor/internal"]). Each entry is scanned for
+    # app/models, app/controllers, and app/views subdirectories.
+    attr_accessor :extra_app_paths
+
     # Database query tool settings (rails_query)
     attr_accessor :query_timeout              # Statement timeout in seconds (default: 5)
     attr_accessor :query_row_limit            # Max rows returned (default: 100, hard cap: 1000)
@@ -303,6 +309,7 @@ module RailsAiContext
       @search_extensions        = %w[rb js erb yml yaml json ts tsx vue svelte haml slim]
       @concern_paths            = %w[app/models/concerns app/controllers/concerns]
       @frontend_paths           = nil
+      @extra_app_paths          = []
       @query_timeout            = 5
       @query_row_limit          = 100
       @query_redacted_columns   = %w[

--- a/lib/rails_ai_context/configuration.rb
+++ b/lib/rails_ai_context/configuration.rb
@@ -235,10 +235,9 @@ module RailsAiContext
     # Frontend framework detection (optional overrides - auto-detected if nil)
     attr_accessor :frontend_paths         # User-declared frontend dirs (e.g. ["app/frontend", "../web-client"])
 
-    # Additional app-root-relative directories that contain Rails app code
-    # beyond the conventional layout and the built-in packs/ and engines/
-    # globs (e.g. ["src", "vendor/internal"]). Each entry is scanned for
-    # app/models, app/controllers, and app/views subdirectories.
+    # Additional app-root-relative directories that also contain Rails app
+    # code (e.g. ["src", "vendor/internal"]). Code discovery scans each
+    # entry's app/models, app/controllers, and app/views subdirectories.
     attr_accessor :extra_app_paths
 
     # Database query tool settings (rails_query)

--- a/lib/rails_ai_context/engine.rb
+++ b/lib/rails_ai_context/engine.rb
@@ -9,7 +9,11 @@ module RailsAiContext
     end
 
     # Auto-mount MCP HTTP middleware when configured
-    initializer "rails_ai_context.middleware" do |app|
+    # Must run after config/initializers so a user's
+    # `config.auto_mount = true` is visible when the mount decision is made;
+    # the middleware stack is built later in the boot finisher, so adding to
+    # it here still takes effect.
+    initializer "rails_ai_context.middleware", after: :load_config_initializers do |app|
       if RailsAiContext.configuration.auto_mount
         require_relative "middleware"
         app.middleware.use RailsAiContext::Middleware

--- a/lib/rails_ai_context/introspector.rb
+++ b/lib/rails_ai_context/introspector.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "time"
+
 module RailsAiContext
   # Orchestrates all sub-introspectors to build a complete
   # picture of the Rails application for AI consumption.
@@ -18,15 +20,15 @@ module RailsAiContext
       context = {
         app_name: app_name,
         ruby_version: RUBY_VERSION,
-        rails_version: Rails.version,
-        environment: Rails.env,
-        generated_at: Time.current.iso8601,
+        rails_version: rails_version,
+        environment: environment_name,
+        generated_at: Time.now.utc.iso8601,
         generator: "rails-ai-context v#{RailsAiContext::VERSION}"
       }
 
       config.introspectors.each do |name|
         introspector = resolve_introspector(name)
-        context[name] = introspector.call
+        context[name] = run_introspector(introspector)
       rescue => e
         context[name] = { error: e.message }
         RailsAiContext.log_warn "[rails-ai-context] #{name} introspection failed: #{e.message}"
@@ -94,10 +96,42 @@ module RailsAiContext
     private
 
     def app_name
+      return File.basename(app.root.to_s) if app.is_a?(RailsAiContext::StaticApp)
+
       if app.class.respond_to?(:module_parent_name)
         app.class.module_parent_name
       else
         app.class.name.deconstantize
+      end
+    end
+
+    # Static tier: only introspectors that declare a static_call can produce
+    # data without a booted app; everything else is honestly unavailable
+    # rather than crashing into a misleading per-section error.
+    def run_introspector(introspector)
+      return introspector.call unless RailsAiContext.static_tier?
+      return introspector.static_call if introspector.respond_to?(:static_call)
+
+      { unavailable: unavailable_reason }
+    end
+
+    def unavailable_reason
+      reason = RailsAiContext.static_reason
+      base = "requires a booted Rails app"
+      reason ? "#{base} (#{reason})" : base
+    end
+
+    def rails_version
+      return Rails.version if defined?(Rails) && Rails.respond_to?(:version) && !RailsAiContext.static_tier?
+
+      Confidence.unavailable("app not booted")
+    end
+
+    def environment_name
+      if defined?(Rails) && Rails.respond_to?(:env) && !RailsAiContext.static_tier?
+        Rails.env.to_s
+      else
+        ENV["RAILS_ENV"] || "development"
       end
     end
 

--- a/lib/rails_ai_context/introspector.rb
+++ b/lib/rails_ai_context/introspector.rb
@@ -129,7 +129,7 @@ module RailsAiContext
 
     def environment_name
       if defined?(Rails) && Rails.respond_to?(:env) && !RailsAiContext.static_tier?
-        Rails.env.to_s
+        Rails.env
       else
         ENV["RAILS_ENV"] || "development"
       end

--- a/lib/rails_ai_context/introspectors/controller_introspector.rb
+++ b/lib/rails_ai_context/introspectors/controller_introspector.rb
@@ -86,15 +86,14 @@ module RailsAiContext
 
       # Scan filesystem for controller files not yet loaded as classes
       def discover_from_filesystem
-        controllers_dir = File.join(app.root, "app", "controllers")
-        return {} unless Dir.exist?(controllers_dir)
-
-        Dir.glob(File.join(controllers_dir, "**/*_controller.rb")).each_with_object({}) do |path, hash|
-          relative = path.sub("#{controllers_dir}/", "")
-          class_name = relative.sub(/\.rb\z/, "").split("/").map(&:camelize).join("::")
-          next if class_name == "ApplicationController"
-          next if class_name.start_with?("Rails::", "ActionMailbox::", "ActiveStorage::")
-          hash[class_name] = path
+        RailsAiContext::PathResolver.controller_dirs(app.root).each_with_object({}) do |controllers_dir, result|
+          Dir.glob(File.join(controllers_dir, "**", "*_controller.rb")).sort.each do |path|
+            relative = path.sub("#{controllers_dir}/", "")
+            class_name = relative.sub(/\.rb\z/, "").split("/").map(&:camelize).join("::")
+            next if class_name == "ApplicationController"
+            next if class_name.start_with?("Rails::", "ActionMailbox::", "ActiveStorage::")
+            result[class_name] ||= path
+          end
         end
       end
 

--- a/lib/rails_ai_context/introspectors/controller_introspector.rb
+++ b/lib/rails_ai_context/introspectors/controller_introspector.rb
@@ -38,6 +38,22 @@ module RailsAiContext
         { error: e.message }
       end
 
+      # Static tier: every controller goes through the source-only extractor;
+      # class loading and reflection never run.
+      def static_call
+        result = discover_from_filesystem.each_with_object({}) do |(name, path), hash|
+          hash[name] = extract_details_from_source(path).merge(confidence: Confidence::STATIC)
+        rescue => e
+          hash[name] = { error: e.message }
+        end
+        {
+          controllers: result,
+          note: "Parsed statically from app/controllers (app not booted)"
+        }
+      rescue => e
+        { error: e.message }
+      end
+
       private
 
       def eager_load_controllers!

--- a/lib/rails_ai_context/introspectors/gem_introspector.rb
+++ b/lib/rails_ai_context/introspectors/gem_introspector.rb
@@ -63,6 +63,7 @@ module RailsAiContext
 
         # Database
         "pg"              => { category: :database, note: "PostgreSQL adapter." },
+        "mongoid"         => { category: :database, note: "MongoDB ODM - schema lives in the documents, not db/schema.rb" },
         "mysql2"          => { category: :database, note: "MySQL adapter." },
         "trilogy"         => { category: :database, note: "MySQL adapter (pure Ruby, Rails 8 default over mysql2)." },
         "sqlite3"         => { category: :database, note: "SQLite adapter." },

--- a/lib/rails_ai_context/introspectors/gem_introspector.rb
+++ b/lib/rails_ai_context/introspectors/gem_introspector.rb
@@ -63,7 +63,7 @@ module RailsAiContext
 
         # Database
         "pg"              => { category: :database, note: "PostgreSQL adapter." },
-        "mongoid"         => { category: :database, note: "MongoDB ODM - schema lives in the documents, not db/schema.rb" },
+        "mongoid"         => { category: :database, note: "MongoDB ODM - schema lives in the documents, not db/schema.rb." },
         "mysql2"          => { category: :database, note: "MySQL adapter." },
         "trilogy"         => { category: :database, note: "MySQL adapter (pure Ruby, Rails 8 default over mysql2)." },
         "sqlite3"         => { category: :database, note: "SQLite adapter." },

--- a/lib/rails_ai_context/introspectors/listeners/mongoid_fields_listener.rb
+++ b/lib/rails_ai_context/introspectors/listeners/mongoid_fields_listener.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RailsAiContext
+  module Introspectors
+    module Listeners
+      # Detects Mongoid document macros via Prism AST: field declarations,
+      # embedded-document relations, and custom collection names. Regular
+      # relations (belongs_to/has_many) share ActiveRecord's macro names and
+      # are captured by AssociationsListener.
+      class MongoidFieldsListener < BaseListener
+        MONGOID_MACROS = %i[field embeds_many embeds_one embedded_in store_in].to_set.freeze
+
+        def on_call_node_enter(node)
+          return unless node.receiver.nil? && MONGOID_MACROS.include?(node.name)
+
+          @results << {
+            macro:      node.name,
+            args:       extract_symbol_args(node),
+            options:    extract_keyword_options(node),
+            location:   node.location.start_line,
+            confidence: confidence_for(node)
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener.rb
+++ b/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener.rb
@@ -1,0 +1,346 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/string/inflections"
+
+module RailsAiContext
+  module Introspectors
+    module Listeners
+      # Static walker for config/routes.rb. Resolves the routing DSL's block
+      # nesting (namespace/scope/resources/member/collection) into flat route
+      # records so "does this route exist and which controller serves it" can
+      # be answered without booting the app. Constructs whose routes depend on
+      # runtime state (devise_for, draw, computed names) are recorded as
+      # :dynamic markers rather than guessed at. Leading-slash paths and
+      # constraints are simplified: paths anchor at the accumulated prefix,
+      # constraints are ignored.
+      class RoutesDslListener < BaseListener
+        VERB_METHODS = %i[get post put patch delete].freeze
+        PLURAL_ACTIONS = %i[index create new edit show update destroy].freeze
+        SINGULAR_ACTIONS = %i[create new edit show update destroy].freeze
+        RESTFUL_ACTIONS = %w[index show new create edit update destroy].freeze
+        DYNAMIC_MACROS = %i[devise_for draw direct resolve concerns match].freeze
+
+        def initialize
+          super
+          @stack = []
+        end
+
+        def on_call_node_enter(node)
+          return unless node.receiver.nil?
+
+          case node.name
+          when :namespace then enter_namespace(node)
+          when :scope then enter_scope(node)
+          when :resources then handle_resources(node, singular: false)
+          when :resource then handle_resources(node, singular: true)
+          when :member then enter_member_collection(node, :member)
+          when :collection then enter_member_collection(node, :collection)
+          when :concern then push_frame(node, suppress: true) if node.block
+          when :root then emit_root(node)
+          when *VERB_METHODS then emit_verb_route(node)
+          when *DYNAMIC_MACROS then emit_dynamic(node)
+          end
+        end
+
+        def on_call_node_leave(node)
+          @stack.pop if @stack.last && @stack.last[:node].equal?(node)
+        end
+
+        private
+
+        def push_frame(node, **attrs)
+          @stack << { node: node }.merge(attrs)
+        end
+
+        def suppressed?
+          @stack.any? { |f| f[:suppress] }
+        end
+
+        # Each scope-introducing frame precomputes the absolute path prefix
+        # its children see, so nesting composes in any order (namespace
+        # inside resources, resources inside scope, ...).
+        def current_prefix
+          frame = @stack.reverse.find { |f| f[:prefix] }
+          frame ? frame[:prefix] : "/"
+        end
+
+        def enter_namespace(node)
+          name = literal_first_arg(node)
+          return emit_dynamic(node) unless name
+          return unless node.block
+
+          opts = extract_keyword_options(node)
+          push_frame(node,
+                     prefix: join_path(current_prefix, (opts[:path] || name).to_s),
+                     mod: name.to_s,
+                     name_prefix: name.to_s)
+        end
+
+        def enter_scope(node)
+          return unless node.block
+
+          opts = extract_keyword_options(node)
+          first = literal_first_arg(node)
+          path = (first || opts[:path])&.to_s
+          push_frame(node,
+                     prefix: path ? join_path(current_prefix, path) : current_prefix,
+                     mod: opts[:module]&.to_s,
+                     name_prefix: opts[:as]&.to_s)
+        end
+
+        def handle_resources(node, singular:)
+          return if suppressed?
+
+          names = extract_symbol_args(node)
+          if names.empty?
+            emit_dynamic(node)
+          else
+            opts = extract_keyword_options(node)
+            names.each { |n| emit_resource_routes(node, n.to_s, opts, singular: singular) }
+          end
+
+          return unless node.block && names.size == 1
+
+          name = names.first.to_s
+          opts = extract_keyword_options(node)
+          base = join_path(current_prefix, (opts[:path] || name).to_s)
+          nested = singular ? base : "#{base}/:#{name.singularize}_id"
+          # Routes nested under this resource inherit its singular route key as
+          # a name prefix (resources :posts { resources :comments } -> the
+          # comments index route is named "post_comments", not "comments").
+          push_frame(node,
+                     prefix: nested,
+                     name_prefix: singular ? name : name.singularize,
+                     resource: {
+                       name: name,
+                       singular: singular,
+                       controller: resource_controller(name, opts, singular: singular),
+                       base: base,
+                       member_path: singular ? base : "#{base}/:id",
+                       singular_route_name: singular ? route_name_for(name) : route_name_for(name.singularize),
+                       plural_route_name: route_name_for(name)
+                     })
+        end
+
+        def emit_resource_routes(node, name, opts, singular:)
+          base = join_path(current_prefix, (opts[:path] || name).to_s)
+          controller = resource_controller(name, opts, singular: singular)
+          actions = requested_actions(singular ? SINGULAR_ACTIONS : PLURAL_ACTIONS, opts)
+          plural_name = route_name_for(name)
+          singular_name = route_name_for(singular ? name : name.singularize)
+
+          actions.each do |action|
+            case action
+            when :index   then emit(node, "GET", base, controller, "index", plural_name)
+            when :create  then emit(node, "POST", base, controller, "create", singular ? singular_name : plural_name)
+            when :new     then emit(node, "GET", "#{base}/new", controller, "new", "new_#{singular_name}")
+            when :edit    then emit(node, "GET", edit_path(base, singular), controller, "edit", "edit_#{singular_name}")
+            when :show    then emit(node, "GET", member_path(base, singular), controller, "show", singular_name)
+            when :update
+              emit(node, "PATCH", member_path(base, singular), controller, "update", nil)
+              emit(node, "PUT", member_path(base, singular), controller, "update", nil)
+            when :destroy then emit(node, "DELETE", member_path(base, singular), controller, "destroy", nil)
+            end
+          end
+        end
+
+        def member_path(base, singular)
+          singular ? base : "#{base}/:id"
+        end
+
+        def edit_path(base, singular)
+          singular ? "#{base}/edit" : "#{base}/:id/edit"
+        end
+
+        def emit_verb_route(node)
+          return if suppressed?
+
+          opts = route_options(node)
+          segment = literal_first_arg(node)&.to_s
+          rocket_key = opts.keys.find { |k| k.is_a?(String) }
+          segment ||= rocket_key
+          return emit_dynamic(node) unless segment
+
+          target = opts[:to] || (rocket_key && opts[rocket_key])
+          controller, action = resolve_target(target, segment)
+          return emit_dynamic(node) unless controller && action
+
+          emit(node, node.name.to_s.upcase, verb_route_path(segment, opts[:on]),
+               controller, action, verb_route_name(opts[:as], segment, opts[:on]))
+        end
+
+        # member/collection blocks push their own prefix, so inside them the
+        # general prefix already points at the right base; only the explicit
+        # on: keyword needs special handling.
+        def enter_member_collection(node, kind)
+          return unless node.block
+
+          resource = current_resource
+          return unless resource
+
+          prefix = kind == :member ? resource[:member_path] : resource[:base]
+          push_frame(node, prefix: prefix, kind: kind)
+        end
+
+        # The member/collection frame a verb route sits in, if any - either
+        # from an enclosing member/collection block or an explicit on: keyword.
+        def member_collection_kind(on_option)
+          return on_option.to_sym if on_option
+
+          frame = @stack.reverse.find { |f| f[:kind] }
+          frame && frame[:kind]
+        end
+
+        def verb_route_path(segment, on_option)
+          resource = current_resource
+          if on_option && resource
+            base = on_option.to_sym == :member ? resource[:member_path] : resource[:base]
+            return join_path(base, segment)
+          end
+
+          join_path(current_prefix, segment)
+        end
+
+        def resolve_target(target, segment)
+          if target.is_a?(String) && target.include?("#")
+            controller, action = target.split("#", 2)
+            [ prefixed_controller(controller), action ]
+          elsif current_resource
+            [ current_resource[:controller], segment.delete_prefix("/") ]
+          else
+            parts = segment.delete_prefix("/").split("/")
+            return [ nil, nil ] if parts.size < 2
+
+            [ prefixed_controller(parts[0..-2].join("/")), parts.last ]
+          end
+        end
+
+        def emit_root(node)
+          return if suppressed?
+
+          target = literal_first_arg(node)&.to_s || route_options(node)[:to]
+          return emit_dynamic(node) unless target.is_a?(String) && target.include?("#")
+
+          controller, action = target.split("#", 2)
+          emit(node, "GET", current_prefix, prefixed_controller(controller), action,
+               [ current_name_prefix, "root" ].compact.reject(&:empty?).join("_"))
+        end
+
+        def emit(node, verb, path, controller, action, name)
+          record = {
+            type: :route,
+            verb: verb,
+            path: path,
+            controller: controller,
+            action: action.to_s,
+            location: node.location.start_line,
+            confidence: confidence_for(node)
+          }
+          record[:name] = name if name && !name.empty?
+          params = path.scan(/:(\w+)/).flatten
+          record[:params] = params if params.any?
+          record[:restful] = RESTFUL_ACTIONS.include?(record[:action])
+          @results << record
+        end
+
+        def emit_dynamic(node)
+          return if suppressed?
+
+          @results << { type: :dynamic, macro: node.name, location: node.location.start_line }
+        end
+
+        # Keyword options including hash-rocket string keys, so
+        # `get "up" => "rails/health#show", as: :x` yields
+        # {"up" => "rails/health#show", as: :x}.
+        def route_options(node)
+          args = node.arguments&.arguments || []
+          hash = args.find { |a| a.is_a?(Prism::KeywordHashNode) || a.is_a?(Prism::HashNode) }
+          return {} unless hash
+
+          hash.elements.each_with_object({}) do |assoc, acc|
+            next unless assoc.is_a?(Prism::AssocNode)
+
+            key = case assoc.key
+            when Prism::SymbolNode then assoc.key.unescaped.to_sym
+            when Prism::StringNode then assoc.key.unescaped
+            end
+            acc[key] = extract_value(assoc.value) if key
+          end
+        end
+
+        # First positional argument when it is a plain symbol/string literal.
+        def literal_first_arg(node)
+          arg = node.arguments&.arguments&.first
+          case arg
+          when Prism::SymbolNode, Prism::StringNode then arg.unescaped
+          end
+        end
+
+        def requested_actions(all, opts)
+          actions = all
+          actions &= Array(opts[:only]).map(&:to_sym) if opts[:only]
+          actions -= Array(opts[:except]).map(&:to_sym) if opts[:except]
+          actions
+        end
+
+        # Rails maps a singular resource to the plural controller
+        # (resource :profile -> ProfilesController).
+        def resource_controller(name, opts, singular: false)
+          controller = (opts[:controller] || (singular ? name.pluralize : name)).to_s
+          prefixed_controller(controller)
+        end
+
+        def prefixed_controller(controller)
+          controller = controller.delete_prefix("/")
+          mods = @stack.filter_map { |f| f[:mod] }
+          ([ *mods, controller ] - [ "" ]).join("/")
+        end
+
+        def current_name_prefix
+          parts = @stack.filter_map { |f| f[:name_prefix] }
+          parts.empty? ? nil : parts.join("_")
+        end
+
+        def current_resource
+          frame = @stack.reverse.find { |f| f[:resource] }
+          frame && frame[:resource]
+        end
+
+        def route_name_for(resource_name)
+          [ current_name_prefix, resource_name ].compact.reject(&:empty?).join("_")
+        end
+
+        # Member/collection-scoped verb routes name themselves "<action>_<resource>"
+        # (preview_post, archived_posts) rather than the ordinary
+        # "<prefix>_<action>" pattern used elsewhere, and an as: override
+        # replaces only the action part, not the whole name.
+        def verb_route_name(as_option, segment, on_option)
+          kind = member_collection_kind(on_option)
+          resource = current_resource
+          if kind && resource
+            resource_key = kind == :member ? resource[:singular_route_name] : resource[:plural_route_name]
+            base = as_option ? as_option.to_s : plain_segment_name(segment)
+            return nil unless base && resource_key && !resource_key.empty?
+
+            return "#{base}_#{resource_key}"
+          end
+
+          return route_name_for(as_option.to_s) if as_option
+
+          plain = plain_segment_name(segment)
+          plain ? route_name_for(plain) : nil
+        end
+
+        def plain_segment_name(segment)
+          plain = segment.to_s.delete_prefix("/").tr("/", "_")
+          plain.empty? || plain.include?(":") ? nil : plain
+        end
+
+        def join_path(*segments)
+          cleaned = segments.compact.map { |s| s.to_s.gsub(%r{\A/+|/+\z}, "") }.reject(&:empty?)
+          "/#{cleaned.join('/')}"
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener.rb
+++ b/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener.rb
@@ -161,7 +161,10 @@ module RailsAiContext
           segment ||= rocket_key
           return emit_dynamic(node) unless segment
 
+          target_given = opts.key?(:to) || !rocket_key.nil?
           target = opts[:to] || (rocket_key && opts[rocket_key])
+          return emit_dynamic(node) if target_given && unreadable_target?(target)
+
           controller, action = resolve_target(target, segment)
           return emit_dynamic(node) unless controller && action
 
@@ -199,6 +202,14 @@ module RailsAiContext
           end
 
           join_path(current_prefix, segment)
+        end
+
+        # A to: value the parser can't read as a literal "controller#action"
+        # string (a helper call like redirect(...), a symbol, a constant, or
+        # a string with no "#") can't be split into a controller and action,
+        # so it must not feed the segment-based guessing in resolve_target.
+        def unreadable_target?(target)
+          !(target.is_a?(String) && target.include?("#"))
         end
 
         def resolve_target(target, segment)

--- a/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener.rb
+++ b/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener.rb
@@ -66,7 +66,16 @@ module RailsAiContext
 
         def enter_namespace(node)
           name = literal_first_arg(node)
-          return emit_dynamic(node) unless name
+          unless name
+            emit_dynamic(node)
+            # A block whose name we can't read still opens a nested scope -
+            # without suppressing it, children resolve against the OUTER
+            # prefix and get tagged as verified routes, when in fact they
+            # live under an unknown namespace. Treat it like a concern: mark
+            # the whole subtree dynamic instead of guessing.
+            push_frame(node, suppress: true) if node.block
+            return
+          end
           return unless node.block
 
           opts = extract_keyword_options(node)
@@ -94,10 +103,16 @@ module RailsAiContext
           names = extract_symbol_args(node)
           if names.empty?
             emit_dynamic(node)
-          else
-            opts = extract_keyword_options(node)
-            names.each { |n| emit_resource_routes(node, n.to_s, opts, singular: singular) }
+            # Same reasoning as the namespace case: a block we can't attach
+            # resource info to still opens a nested scope, so its children
+            # must be suppressed rather than resolved against the outer
+            # prefix and misreported as verified routes.
+            push_frame(node, suppress: true) if node.block
+            return
           end
+
+          opts = extract_keyword_options(node)
+          names.each { |n| emit_resource_routes(node, n.to_s, opts, singular: singular) }
 
           return unless node.block && names.size == 1
 

--- a/lib/rails_ai_context/introspectors/migration_introspector.rb
+++ b/lib/rails_ai_context/introspectors/migration_introspector.rb
@@ -24,6 +24,10 @@ module RailsAiContext
         { error: e.message }
       end
 
+      # The file-parsing paths in call already degrade cleanly when the
+      # database is unreachable, so the static tier runs the same code.
+      alias_method :static_call, :call
+
       private
 
       def root

--- a/lib/rails_ai_context/introspectors/model_introspector.rb
+++ b/lib/rails_ai_context/introspectors/model_introspector.rb
@@ -20,6 +20,8 @@ module RailsAiContext
 
       # @return [Hash] model metadata keyed by model name
       def call
+        return mongoid_static_models if RailsAiContext::AppKind.mongoid?(app.root)
+
         eager_load_models!
         models = discover_models
 
@@ -39,6 +41,8 @@ module RailsAiContext
       # resolved. When the same class name is found in more than one
       # directory, the first discovery wins.
       def static_call
+        return mongoid_static_models if RailsAiContext::AppKind.mongoid?(app.root)
+
         RailsAiContext::PathResolver.model_dirs(app.root).each_with_object({}) do |models_dir, result|
           Dir.glob(File.join(models_dir, "**", "*.rb")).sort.each do |path|
             relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
@@ -538,6 +542,59 @@ module RailsAiContext
           macros: data[:macros],
           methods: data[:methods]
         }
+      end
+
+      # Mongoid documents are invisible to ActiveRecord reflection, so both
+      # tiers parse them from source. Fields and embedded relations come from
+      # the Mongoid listener; shared-name macros (belongs_to, has_many,
+      # validates, scope) come from the regular listener stack.
+      def mongoid_static_models
+        RailsAiContext::PathResolver.model_dirs(app.root).each_with_object({}) do |models_dir, result|
+          Dir.glob(File.join(models_dir, "**", "*.rb")).sort.each do |path|
+            relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
+            next if relative == "application_record" || relative.start_with?("concerns/")
+
+            class_name = relative.camelize
+            next if result.key?(class_name)
+            next if config.excluded_models.include?(class_name)
+
+            begin
+              next if File.size(path) > RailsAiContext.configuration.max_file_size
+
+              result[class_name] = mongoid_model_details(path)
+            rescue => e
+              result[class_name] = { error: e.message }
+            end
+          end
+        end
+      end
+
+      def mongoid_model_details(path)
+        data = SourceIntrospector.walk(path, {
+          mongoid: -> { Listeners::MongoidFieldsListener.new },
+          associations: Listeners::AssociationsListener,
+          validations: Listeners::ValidationsListener,
+          scopes: Listeners::ScopesListener,
+          callbacks: Listeners::CallbacksListener,
+          methods: Listeners::MethodsListener
+        })
+        macros = data[:mongoid] || []
+        details = {
+          confidence: Confidence::STATIC,
+          mongoid: true,
+          fields: macros.select { |m| m[:macro] == :field }
+                        .map { |m| { name: m[:args].first, type: m[:options][:type] }.compact },
+          embeds: macros.select { |m| %i[embeds_many embeds_one embedded_in].include?(m[:macro]) }
+                        .map { |m| { type: m[:macro], name: m[:args].first } },
+          associations: data[:associations],
+          validations: data[:validations],
+          scopes: data[:scopes],
+          callbacks: data[:callbacks],
+          methods: data[:methods]
+        }
+        collection = macros.find { |m| m[:macro] == :store_in }&.dig(:options, :collection)
+        details[:collection] = collection if collection
+        details
       end
     end
   end

--- a/lib/rails_ai_context/introspectors/model_introspector.rb
+++ b/lib/rails_ai_context/introspectors/model_introspector.rb
@@ -20,16 +20,30 @@ module RailsAiContext
 
       # @return [Hash] model metadata keyed by model name
       def call
-        return mongoid_static_models if RailsAiContext::AppKind.mongoid?(app.root)
-
         eager_load_models!
         models = discover_models
 
-        models.each_with_object({}) do |model, hash|
+        result = models.each_with_object({}) do |model, hash|
           hash[model.name] = extract_model_details(model)
         rescue => e
           hash[model.name] = { error: e.message }
         end
+
+        # A hybrid app (ActiveRecord primary, Mongoid gem present too) has
+        # documents that AR reflection can never see - they don't descend
+        # from ActiveRecord::Base. Supplement rather than replace, so a
+        # pure-AR model in a hybrid app keeps its full reflection-based
+        # details instead of being reduced to Mongoid's blanket static pass.
+        if RailsAiContext::AppKind.mongoid?(app.root)
+          mongoid_static_models.each do |class_name, details|
+            next if result.key?(class_name)
+            next unless details[:mongoid]
+
+            result[class_name] = details
+          end
+        end
+
+        result
       end
 
       # Static tier: models are discovered by globbing every model directory
@@ -561,12 +575,26 @@ module RailsAiContext
             begin
               next if File.size(path) > RailsAiContext.configuration.max_file_size
 
-              result[class_name] = mongoid_model_details(path)
+              result[class_name] = if mongoid_document_source?(path)
+                mongoid_model_details(path)
+              else
+                static_model_details(path, class_name)
+              end
             rescue => e
               result[class_name] = { error: e.message }
             end
           end
         end
+      end
+
+      # A hybrid app (ActiveRecord primary, Mongoid gem present) mixes
+      # AR-backed models in with actual Mongoid documents under the same
+      # model directories. Only files that really `include Mongoid::Document`
+      # get the Mongoid listener stack; everything else falls back to the
+      # regular AR-style static pass so it still gets a table_name.
+      def mongoid_document_source?(path)
+        content = RailsAiContext::SafeFile.read(path)
+        !!content&.include?("Mongoid::Document")
       end
 
       def mongoid_model_details(path)

--- a/lib/rails_ai_context/introspectors/model_introspector.rb
+++ b/lib/rails_ai_context/introspectors/model_introspector.rb
@@ -30,27 +30,31 @@ module RailsAiContext
         end
       end
 
-      # Static tier: models are discovered by globbing app/models and parsed
-      # with the source listeners; nothing is constantized. The table name is
-      # inferred from the class name (Rails convention), which is why every
-      # entry is tagged STATIC rather than VERIFIED - custom table_name= calls
-      # surface in :macros but are not resolved.
+      # Static tier: models are discovered by globbing every model directory
+      # PathResolver resolves (conventional app/models, packs, engines, and
+      # configured extras) and parsed with the source listeners; nothing is
+      # constantized. The table name is inferred from the class name (Rails
+      # convention), which is why every entry is tagged STATIC rather than
+      # VERIFIED - custom table_name= calls surface in :macros but are not
+      # resolved. When the same class name is found in more than one
+      # directory, the first discovery wins.
       def static_call
-        models_dir = File.join(app.root.to_s, "app", "models")
-        return {} unless Dir.exist?(models_dir)
+        RailsAiContext::PathResolver.model_dirs(app.root).each_with_object({}) do |models_dir, result|
+          Dir.glob(File.join(models_dir, "**", "*.rb")).sort.each do |path|
+            relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
+            next if relative == "application_record" || relative.start_with?("concerns/")
 
-        Dir.glob(File.join(models_dir, "**", "*.rb")).sort.each_with_object({}) do |path, result|
-          relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
-          next if relative == "application_record" || relative.start_with?("concerns/")
+            class_name = relative.camelize
+            next if result.key?(class_name)
+            next if config.excluded_models.include?(class_name)
 
-          class_name = relative.camelize
-          next if config.excluded_models.include?(class_name)
+            begin
+              next if File.size(path) > RailsAiContext.configuration.max_file_size
 
-          begin
-            next if File.size(path) > RailsAiContext.configuration.max_file_size
-            result[class_name] = static_model_details(path, class_name)
-          rescue => e
-            result[class_name] = { error: e.message }
+              result[class_name] = static_model_details(path, class_name)
+            rescue => e
+              result[class_name] = { error: e.message }
+            end
           end
         end
       end
@@ -81,9 +85,8 @@ module RailsAiContext
             config.excluded_models.include?(model.name)
         end
 
-        models_dir = File.join(app.root.to_s, "app", "models")
-        if Dir.exist?(models_dir)
-          known = models.map(&:name).to_set
+        known = models.map(&:name).to_set
+        RailsAiContext::PathResolver.model_dirs(app.root.to_s).each do |models_dir|
           Dir.glob(File.join(models_dir, "**", "*.rb")).each do |path|
             relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
             class_name = relative.camelize

--- a/lib/rails_ai_context/introspectors/model_introspector.rb
+++ b/lib/rails_ai_context/introspectors/model_introspector.rb
@@ -115,6 +115,7 @@ module RailsAiContext
               klass = class_name.constantize
               next unless klass < ActiveRecord::Base && !klass.abstract_class?
               models << klass
+              known << class_name
             rescue NameError, LoadError
               # Not a valid model class
             end

--- a/lib/rails_ai_context/introspectors/model_introspector.rb
+++ b/lib/rails_ai_context/introspectors/model_introspector.rb
@@ -30,6 +30,31 @@ module RailsAiContext
         end
       end
 
+      # Static tier: models are discovered by globbing app/models and parsed
+      # with the source listeners; nothing is constantized. The table name is
+      # inferred from the class name (Rails convention), which is why every
+      # entry is tagged STATIC rather than VERIFIED - custom table_name= calls
+      # surface in :macros but are not resolved.
+      def static_call
+        models_dir = File.join(app.root.to_s, "app", "models")
+        return {} unless Dir.exist?(models_dir)
+
+        Dir.glob(File.join(models_dir, "**", "*.rb")).sort.each_with_object({}) do |path, result|
+          relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
+          next if relative == "application_record" || relative.start_with?("concerns/")
+
+          class_name = relative.camelize
+          next if config.excluded_models.include?(class_name)
+          next if File.size(path) > RailsAiContext.configuration.max_file_size
+
+          begin
+            result[class_name] = static_model_details(path, class_name)
+          rescue => e
+            result[class_name] = { error: e.message }
+          end
+        end
+      end
+
       private
 
       def eager_load_models!
@@ -495,6 +520,21 @@ module RailsAiContext
       def sanitize_options(options)
         options.reject { |_k, v| v.is_a?(Proc) || v.is_a?(Regexp) }
                .transform_values(&:to_s)
+      end
+
+      def static_model_details(path, class_name)
+        data = SourceIntrospector.call(path)
+        {
+          confidence: Confidence::STATIC,
+          table_name: class_name.demodulize.underscore.pluralize,
+          associations: data[:associations],
+          validations: data[:validations],
+          scopes: data[:scopes],
+          enums: data[:enums],
+          callbacks: data[:callbacks],
+          macros: data[:macros],
+          methods: data[:methods]
+        }
       end
     end
   end

--- a/lib/rails_ai_context/introspectors/model_introspector.rb
+++ b/lib/rails_ai_context/introspectors/model_introspector.rb
@@ -45,9 +45,9 @@ module RailsAiContext
 
           class_name = relative.camelize
           next if config.excluded_models.include?(class_name)
-          next if File.size(path) > RailsAiContext.configuration.max_file_size
 
           begin
+            next if File.size(path) > RailsAiContext.configuration.max_file_size
             result[class_name] = static_model_details(path, class_name)
           rescue => e
             result[class_name] = { error: e.message }

--- a/lib/rails_ai_context/introspectors/route_introspector.rb
+++ b/lib/rails_ai_context/introspectors/route_introspector.rb
@@ -27,6 +27,38 @@ module RailsAiContext
         { error: e.message }
       end
 
+      # Static tier: answer route questions from config/routes.rb alone.
+      # Output mirrors the runtime shape exactly so tools, resources, and
+      # serializers need no static-awareness of their own. Routes behind
+      # dynamic constructs (devise_for, draw, concerns) are counted in
+      # :dynamic_routes rather than fabricated.
+      def static_call
+        routes_path = File.join(app.root.to_s, "config", "routes.rb")
+        return { error: "config/routes.rb not found in #{app.root}" } unless File.exist?(routes_path)
+
+        ast = SourceIntrospector.walk(routes_path, {
+          routes: -> { Listeners::RoutesDslListener.new },
+          mounts: -> { Listeners::MountListener.new }
+        })
+        records = ast[:routes] || []
+        entries = records.select { |r| r[:type] == :route }
+        dynamic = records.count { |r| r[:type] == :dynamic }
+
+        result = {
+          total_routes: entries.size,
+          by_controller: static_by_controller(entries),
+          api_namespaces: static_api_namespaces(entries),
+          mounted_engines: (ast[:mounts] || []).map { |m| { engine: m[:engine], path: m[:path] } },
+          root_route: static_root_route(entries),
+          note: "Parsed statically from config/routes.rb (app not booted)",
+          confidence: Confidence::STATIC
+        }
+        result[:dynamic_routes] = dynamic if dynamic.positive?
+        result
+      rescue => e
+        { error: e.message }
+      end
+
       private
 
       def extract_routes
@@ -102,6 +134,26 @@ module RailsAiContext
             $stderr.puts "[rails-ai-context] detect_mounted_engines failed: #{e.message}" if ENV["DEBUG"]
             nil
           end
+      end
+
+      def static_by_controller(entries)
+        entries.group_by { |e| e[:controller] }.transform_values do |routes|
+          routes.map do |r|
+            entry = { verb: r[:verb], path: r[:path], action: r[:action], name: r[:name] }
+            entry[:params] = r[:params] if r[:params]
+            entry[:restful] = r[:restful] unless r[:restful].nil?
+            entry.compact
+          end
+        end
+      end
+
+      def static_api_namespaces(entries)
+        entries.filter_map { |e| e[:path][%r{\A/api(?:/v\d+)?}] }.uniq.sort
+      end
+
+      def static_root_route(entries)
+        root = entries.find { |e| e[:path] == "/" && e[:verb] == "GET" }
+        root && "#{root[:controller]}##{root[:action]}"
       end
     end
   end

--- a/lib/rails_ai_context/introspectors/route_introspector.rb
+++ b/lib/rails_ai_context/introspectors/route_introspector.rb
@@ -46,7 +46,7 @@ module RailsAiContext
 
         result = {
           total_routes: entries.size,
-          by_controller: static_by_controller(entries),
+          by_controller: group_by_controller(entries),
           api_namespaces: static_api_namespaces(entries),
           mounted_engines: (ast[:mounts] || []).map { |m| { engine: m[:engine], path: m[:path] } },
           root_route: static_root_route(entries),
@@ -136,18 +136,8 @@ module RailsAiContext
           end
       end
 
-      def static_by_controller(entries)
-        entries.group_by { |e| e[:controller] }.transform_values do |routes|
-          routes.map do |r|
-            entry = { verb: r[:verb], path: r[:path], action: r[:action], name: r[:name] }
-            entry[:params] = r[:params] if r[:params]
-            entry[:restful] = r[:restful] unless r[:restful].nil?
-            entry.compact
-          end
-        end
-      end
-
       def static_api_namespaces(entries)
+        # Match path prefixes anchored at /api and sort for deterministic output.
         entries.filter_map { |e| e[:path][%r{\A/api(?:/v\d+)?}] }.uniq.sort
       end
 

--- a/lib/rails_ai_context/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_context/introspectors/schema_introspector.rb
@@ -334,36 +334,95 @@ module RailsAiContext
         }
       end
 
+      # Identifier quoting differs per dump tool: pg_dump uses bare or
+      # "quoted" names with a public. prefix, mysqldump uses `backticks` and
+      # terminates CREATE TABLE with ") ENGINE=...;", sqlite uses "quotes"
+      # and IF NOT EXISTS. The body is captured up to the closing paren at
+      # line start because MySQL's trailer means ");" alone never appears.
+      # The negative lookahead in the body keeps a single-line CREATE TABLE
+      # (e.g. sqlite's schema_migrations) from swallowing every table that
+      # follows it: without it, the lazy scan has no "\n)" to stop at inside
+      # that one-line statement, so it keeps consuming lines - including the
+      # next CREATE TABLE - until it finds one.
       def parse_structure_sql(path) # rubocop:disable Metrics/MethodLength
         content = RailsAiContext::SafeFile.read(path, max_size: RailsAiContext.configuration.max_schema_file_size)
         return { error: "structure.sql too large (#{File.size(path)} bytes)" } unless content
+
+        dialect = detect_sql_dialect(content)
         tables = {}
 
-        # Match CREATE TABLE blocks
-        content.scan(/CREATE TABLE (?:public\.)?(\w+)\s*\((.*?)\);/m) do |table_name, body|
+        content.scan(/CREATE TABLE\s+(?:IF NOT EXISTS\s+)?(?:public\.)?[`"]?(\w+)[`"]?\s*\(((?:(?!CREATE TABLE).)*?)^\)/m) do |table_name, body|
           next if table_name.start_with?("ar_internal_metadata", "schema_migrations")
 
-          columns = parse_sql_columns(body)
-          tables[table_name] = { columns: columns, indexes: [], foreign_keys: [] }
+          tables[table_name] = parse_sql_table_body(body, table_name)
         end
 
-        # Match CREATE INDEX / CREATE UNIQUE INDEX
-        content.scan(/CREATE (UNIQUE )?INDEX (\w+) ON (?:public\.)?(\w+).*?\((.+?)\)/m) do |unique, idx_name, table, cols|
-          col_list = cols.scan(/\w+/)
+        # Single-line CREATE TABLE statements (sqlite emits these for tiny
+        # tables) close with ");" on the same line and miss the multi-line
+        # scan above.
+        content.scan(/CREATE TABLE\s+(?:IF NOT EXISTS\s+)?(?:public\.)?[`"]?(\w+)[`"]?\s*\(([^\n]*)\);/) do |table_name, body|
+          next if table_name.start_with?("ar_internal_metadata", "schema_migrations")
+
+          tables[table_name] ||= parse_sql_table_body(body, table_name)
+        end
+
+        content.scan(/CREATE (UNIQUE )?INDEX\s+(?:IF NOT EXISTS\s+)?[`"]?(\w+)[`"]?\s+ON\s+(?:public\.)?[`"]?(\w+)[`"]?.*?\((.+?)\)/m) do |unique, idx_name, table, cols|
+          col_list = cols.scan(/\w+/) - %w[btree gin gist hash]
           tables[table]&.dig(:indexes)&.push({ name: idx_name, columns: col_list, unique: !!unique })
         end
 
-        # Match ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY (handles multi-line)
-        content.scan(/ALTER TABLE\s+(?:ONLY\s+)?(?:public\.)?(\w+)\s+ADD CONSTRAINT.*?FOREIGN KEY\s*\((\w+)\)\s*REFERENCES\s+(?:public\.)?(\w+)\((\w+)\)/m) do |from, col, to, pk|
+        content.scan(/ALTER TABLE\s+(?:ONLY\s+)?(?:public\.)?[`"]?(\w+)[`"]?\s+ADD CONSTRAINT.*?FOREIGN KEY\s*\([`"]?(\w+)[`"]?\)\s*REFERENCES\s+(?:public\.)?[`"]?(\w+)[`"]?\s*\([`"]?(\w+)[`"]?\)/m) do |from, col, to, pk|
           tables[from]&.dig(:foreign_keys)&.push({ from_table: from, to_table: to, column: col, primary_key: pk })
         end
 
         {
           adapter: "static_parse",
+          dialect: dialect.to_s,
           tables: tables,
           total_tables: tables.size,
           note: "Parsed from db/structure.sql (no DB connection)"
         }
+      end
+
+      # mysqldump always terminates CREATE TABLE with ") ENGINE=..." and
+      # quotes identifiers with backticks; pg_dump wraps FK updates in
+      # "ALTER TABLE ONLY", qualifies types with "::", and uses search_path /
+      # extension setup that the other two dialects never emit; sqlite
+      # marks autoincrementing primary keys and keeps its own sequence table.
+      # Order matters: check MySQL and PostgreSQL markers before sqlite's
+      # generic double-quoted CREATE TABLE, which would otherwise also match
+      # pg_dump's ANSI-quoted identifiers.
+      def detect_sql_dialect(content)
+        return :mysql if content.match?(/\)\s*ENGINE=/i) || content.match?(/CREATE TABLE\s+`/)
+        return :postgresql if content.match?(/SET search_path|CREATE EXTENSION|ALTER TABLE ONLY|::\w+/)
+        return :sqlite if content.match?(/sqlite_sequence|AUTOINCREMENT|CREATE TABLE\s+(?:IF NOT EXISTS\s+)?"/)
+
+        :unknown
+      end
+
+      # MySQL keeps indexes and foreign keys inside the CREATE TABLE body as
+      # KEY / UNIQUE KEY / CONSTRAINT lines; the other dialects emit separate
+      # statements, so those lines simply never match here.
+      def parse_sql_table_body(body, table_name)
+        table = { columns: parse_sql_columns(body), indexes: [], foreign_keys: [] }
+
+        body.each_line do |line|
+          line = line.strip.chomp(",")
+          case line
+          when /\ACONSTRAINT\s+[`"]?\w+[`"]?\s+FOREIGN KEY\s*\([`"]?(\w+)[`"]?\)\s*REFERENCES\s+[`"]?(\w+)[`"]?\s*\([`"]?(\w+)[`"]?\)/i
+            table[:foreign_keys] << { from_table: table_name, to_table: $2, column: $1, primary_key: $3 }
+          when /\A(UNIQUE\s+)?KEY\s+[`"]?(\w+)[`"]?\s*\(([^)]*)\)/i
+            # $1/$2/$3 must be captured to locals before any further regex
+            # call: String#scan below re-runs matching and would otherwise
+            # clobber $~ (and so $1) before the hash literal reads it.
+            unique = !$1.nil?
+            idx_name = $2
+            cols = $3.scan(/\w+/)
+            table[:indexes] << { name: idx_name, columns: cols, unique: unique }
+          end
+        end
+
+        table
       end
 
       # Parse column definitions from a CREATE TABLE body
@@ -372,14 +431,16 @@ module RailsAiContext
         body.each_line do |line|
           line = line.strip.chomp(",").strip
           next if line.empty?
-          next if line.match?(/\A(PRIMARY|CONSTRAINT|CHECK|UNIQUE|EXCLUDE|FOREIGN)\b/i)
+          next if line.match?(/\A(PRIMARY|CONSTRAINT|CHECK|UNIQUE|EXCLUDE|FOREIGN|KEY|INDEX)\b/i)
 
           # Match: column_name type_with_params [constraints]
-          if (match = line.match(/\A"?(\w+)"?\s+(.+)/))
+          if (match = line.match(/\A[`"]?(\w+)[`"]?\s+(.+)/))
             col_name = match[1]
             rest = match[2]
             # Extract type: everything before NOT NULL, NULL, DEFAULT, etc.
-            col_type = rest.split(/\s+(?:NOT\s+NULL|NULL|DEFAULT|PRIMARY|UNIQUE|CONSTRAINT|CHECK)\b/i).first&.strip&.downcase
+            col_type = rest.split(
+              /\s+(?:NOT\s+NULL|NULL|DEFAULT|PRIMARY|UNIQUE|CONSTRAINT|CHECK|AUTO_INCREMENT|AUTOINCREMENT|CHARACTER\s+SET|COLLATE|COMMENT|GENERATED|REFERENCES)\b/i
+            ).first&.strip&.downcase
             next unless col_type && !col_type.empty?
             columns << { name: col_name, type: normalize_sql_type(col_type) }
           end
@@ -690,15 +751,22 @@ module RailsAiContext
         end
       end
 
-      def normalize_sql_type(type)
-        case type
-        when /\Ainteger\z/i, /\Aint\z/i, /\Aint4\z/i then "integer"
+      def normalize_sql_type(type) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+        # MySQL's boolean columns are a sized tinyint. This has to run
+        # before the size-stripping below (and before the generic tinyint
+        # match) because bare tinyint is a real 1-byte integer column.
+        return "boolean" if type.start_with?("tinyint(1)")
+
+        base = type.sub(/\(.+\z/m, "").strip
+
+        case base
+        when /\Ainteger\z/i, /\Aint\z/i, /\Aint4\z/i, /\Atinyint\z/i, /\Amediumint\z/i then "integer"
         when /\Abigint\z/i, /\Aint8\z/i then "bigint"
         when /\Asmallint\z/i, /\Aint2\z/i then "smallint"
         when /\Acharacter varying\z/i, /\Avarchar\z/i then "string"
-        when /\Atext\z/i then "text"
+        when /\Atext\z/i, /\Alongtext\z/i, /\Amediumtext\z/i, /\Atinytext\z/i then "text"
         when /\Aboolean\z/i, /\Abool\z/i then "boolean"
-        when /\Atimestamp/i then "datetime"
+        when /\Atimestamp/i, /\Adatetime\z/i then "datetime"
         when /\Adate\z/i then "date"
         when /\Atime\z/i then "time"
         when /\Anumeric\z/i, /\Adecimal\z/i then "decimal"
@@ -709,6 +777,7 @@ module RailsAiContext
         when /\Acitext\z/i then "citext"
         when /\Aarray\z/i then "array"
         when /\Ahstore\z/i then "hstore"
+        when /\Alongblob\z/i, /\Amediumblob\z/i, /\Ablob\z/i, /\Abinary\z/i, /\Avarbinary\z/i then "binary"
         else type
         end
       end

--- a/lib/rails_ai_context/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_context/introspectors/schema_introspector.rb
@@ -13,8 +13,8 @@ module RailsAiContext
 
       # @return [Hash] database schema context
       def call
-        return static_schema_parse unless active_record_connected?
-        return static_schema_parse if table_names.empty?
+        return attach_secondary_databases(static_schema_parse) unless active_record_connected?
+        return attach_secondary_databases(static_schema_parse) if table_names.empty?
 
         schema_content = File.exist?(schema_file_path) ? (RailsAiContext::SafeFile.read(schema_file_path, max_size: RailsAiContext.configuration.max_schema_file_size) || "") : ""
 
@@ -196,6 +196,18 @@ module RailsAiContext
         nil
       end
 
+      # Reads the version stamp from the schema.rb file actually being parsed,
+      # rather than the app's primary db/schema.rb. Secondary database dumps
+      # (db/queue_schema.rb, etc.) carry their own version: keyword, and
+      # current_schema_version would otherwise report the primary database's
+      # version on every secondary entry.
+      def schema_version_for(path)
+        RailsAiContext::SchemaVersion.from_schema_rb(path)
+      rescue => e
+        $stderr.puts "[rails-ai-context] schema_version_for failed: #{e.message}" if ENV["DEBUG"]
+        nil
+      end
+
       def schema_file_path
         File.join(app.root, "db", "schema.rb")
       end
@@ -365,7 +377,7 @@ module RailsAiContext
           adapter: "static_parse",
           tables: tables,
           total_tables: tables.size,
-          schema_version: current_schema_version,
+          schema_version: schema_version_for(path),
           check_constraints: check_constraints,
           enum_types: enum_types,
           generated_columns: parse_generated_columns(content),

--- a/lib/rails_ai_context/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_context/introspectors/schema_introspector.rb
@@ -411,7 +411,7 @@ module RailsAiContext
           case line
           when /\ACONSTRAINT\s+[`"]?\w+[`"]?\s+FOREIGN KEY\s*\([`"]?(\w+)[`"]?\)\s*REFERENCES\s+[`"]?(\w+)[`"]?\s*\([`"]?(\w+)[`"]?\)/i
             table[:foreign_keys] << { from_table: table_name, to_table: $2, column: $1, primary_key: $3 }
-          when /\A(UNIQUE\s+)?KEY\s+[`"]?(\w+)[`"]?\s*\(([^)]*)\)/i
+          when /\A(UNIQUE\s+)?(?:KEY|INDEX)\s+[`"](\w+)[`"]\s*\(([^)]*)\)/i
             # $1/$2/$3 must be captured to locals before any further regex
             # call: String#scan below re-runs matching and would otherwise
             # clobber $~ (and so $1) before the hash literal reads it.
@@ -431,7 +431,13 @@ module RailsAiContext
         body.each_line do |line|
           line = line.strip.chomp(",").strip
           next if line.empty?
-          next if line.match?(/\A(PRIMARY|CONSTRAINT|CHECK|UNIQUE|EXCLUDE|FOREIGN|KEY|INDEX)\b/i)
+          next if line.match?(/\A(PRIMARY|CONSTRAINT|CHECK|UNIQUE|EXCLUDE|FOREIGN)\b/i)
+          # KEY/INDEX are non-reserved words in PostgreSQL, so pg_dump emits
+          # bare `key` or `index` columns unquoted. mysqldump always backticks
+          # inline index names ("KEY `name` (...)"), so a quoted name after
+          # KEY/INDEX is the reliable signal that this line is an index
+          # definition rather than a column named "key" or "index".
+          next if line.match?(/\A(?:UNIQUE\s+)?(?:KEY|INDEX)\s+[`"]/i)
 
           # Match: column_name type_with_params [constraints]
           if (match = line.match(/\A[`"]?(\w+)[`"]?\s+(.+)/))

--- a/lib/rails_ai_context/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_context/introspectors/schema_introspector.rb
@@ -275,7 +275,7 @@ module RailsAiContext
           parsed = parse_schema_rb(path)
           next unless parsed[:total_tables].to_i.positive?
 
-          parsed[:note] = "Parsed from db/#{File.basename(path)} (no DB connection)"
+          parsed[:note] = "Parsed from db/#{File.basename(path)} (from committed dump, not a live connection)"
           dumps[name] = parsed
         end
         Dir.glob(File.join(app.root.to_s, "db", "*_structure.sql")).sort.each do |path|
@@ -285,7 +285,7 @@ module RailsAiContext
           parsed = parse_structure_sql(path)
           next unless parsed[:total_tables].to_i.positive?
 
-          parsed[:note] = "Parsed from db/#{File.basename(path)} (no DB connection)"
+          parsed[:note] = "Parsed from db/#{File.basename(path)} (from committed dump, not a live connection)"
           dumps[name] = parsed
         end
         dumps

--- a/lib/rails_ai_context/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_context/introspectors/schema_introspector.rb
@@ -38,7 +38,7 @@ module RailsAiContext
           end
         end
 
-        {
+        attach_secondary_databases({
           adapter: adapter_name,
           tables: extract_tables,
           total_tables: table_names.size,
@@ -46,13 +46,13 @@ module RailsAiContext
           check_constraints: check_constraints,
           enum_types: enum_types,
           generated_columns: parse_generated_columns(schema_content)
-        }
+        })
       end
 
       # Static tier entry: skip the connection probe entirely and answer from
       # schema.rb / structure.sql / migration files.
       def static_call
-        static_schema_parse
+        attach_secondary_databases(static_schema_parse)
       end
 
       private
@@ -245,6 +245,45 @@ module RailsAiContext
         end
 
         { error: "No db/schema.rb, db/structure.sql, or migrations found" }
+      end
+
+      # Rails multi-database setups dump each secondary database to its own
+      # file named after the database.yml entry (db/queue_schema.rb for the
+      # queue database, db/cache_structure.sql for sql format). The primary
+      # dump keeps the top-level :tables shape; secondaries ride their own
+      # key so single-database consumers are unaffected.
+      def secondary_database_dumps
+        dumps = {}
+        Dir.glob(File.join(app.root.to_s, "db", "*_schema.rb")).sort.each do |path|
+          name = File.basename(path, ".rb").sub(/_schema\z/, "")
+          parsed = parse_schema_rb(path)
+          next unless parsed[:total_tables].to_i.positive?
+
+          parsed[:note] = "Parsed from db/#{File.basename(path)} (no DB connection)"
+          dumps[name] = parsed
+        end
+        Dir.glob(File.join(app.root.to_s, "db", "*_structure.sql")).sort.each do |path|
+          name = File.basename(path, ".sql").sub(/_structure\z/, "")
+          next if dumps.key?(name)
+
+          parsed = parse_structure_sql(path)
+          next unless parsed[:total_tables].to_i.positive?
+
+          parsed[:note] = "Parsed from db/#{File.basename(path)} (no DB connection)"
+          dumps[name] = parsed
+        end
+        dumps
+      end
+
+      # Additive: only sets :secondary_databases when at least one secondary
+      # dump parsed to tables, and only on a result that already has the
+      # primary :tables key, so error/unavailable results pass through untouched.
+      def attach_secondary_databases(result)
+        return result unless result.is_a?(Hash) && result[:tables]
+
+        secondary = secondary_database_dumps
+        result[:secondary_databases] = secondary if secondary.any?
+        result
       end
 
       def parse_schema_rb(path)

--- a/lib/rails_ai_context/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_context/introspectors/schema_introspector.rb
@@ -256,6 +256,10 @@ module RailsAiContext
           }
         end
 
+        if RailsAiContext::AppKind.mongoid?(app.root)
+          return { unavailable: "this app uses Mongoid; ActiveRecord schema introspection does not apply" }
+        end
+
         { error: "No db/schema.rb, db/structure.sql, or migrations found" }
       end
 

--- a/lib/rails_ai_context/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_context/introspectors/schema_introspector.rb
@@ -49,6 +49,12 @@ module RailsAiContext
         }
       end
 
+      # Static tier entry: skip the connection probe entirely and answer from
+      # schema.rb / structure.sql / migration files.
+      def static_call
+        static_schema_parse
+      end
+
       private
 
       def active_record_connected?

--- a/lib/rails_ai_context/path_resolver.rb
+++ b/lib/rails_ai_context/path_resolver.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module RailsAiContext
+  # Resolves where a kind of Rails app code can live for a given app root.
+  # Conventional layout first, then packwerk packs (packs/*/app/<kind>),
+  # then in-repo engines (engines/*/app/<kind>), then any configured
+  # extra_app_paths. Only existing directories are returned so callers can
+  # glob the list without their own existence guards.
+  module PathResolver
+    module_function
+
+    def model_dirs(root) = dirs_for(root, "app/models")
+
+    def controller_dirs(root) = dirs_for(root, "app/controllers")
+
+    def view_dirs(root) = dirs_for(root, "app/views")
+
+    def dirs_for(root, kind)
+      root = root.to_s
+      candidates = [ File.join(root, kind) ]
+      candidates += Dir.glob(File.join(root, "packs", "*", kind)).sort
+      candidates += Dir.glob(File.join(root, "engines", "*", kind)).sort
+      Array(RailsAiContext.configuration.extra_app_paths).each do |extra|
+        candidates << File.join(root, extra, kind)
+      end
+      candidates.uniq.select { |dir| Dir.exist?(dir) }
+    end
+  end
+end

--- a/lib/rails_ai_context/static_app.rb
+++ b/lib/rails_ai_context/static_app.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+module RailsAiContext
+  # Stand-in for Rails.application when serving the static tier (app not
+  # booted). Introspectors only need #root from the app object; any other
+  # method call is a genuine runtime dependency and should surface as
+  # NoMethodError so the per-section isolation reports it honestly.
+  class StaticApp
+    attr_reader :root
+
+    def initialize(root_path)
+      @root = Pathname.new(root_path.to_s)
+    end
+  end
+end

--- a/lib/rails_ai_context/tools/analyze_feature.rb
+++ b/lib/rails_ai_context/tools/analyze_feature.rb
@@ -445,7 +445,7 @@ module RailsAiContext
           end
 
           # Fallback: read source file
-          path = Rails.root.join("app", "controllers", "#{parent_class.underscore}.rb")
+          path = rails_app.root.join("app", "controllers", "#{parent_class.underscore}.rb")
           return [] unless File.exist?(path)
           source = RailsAiContext::SafeFile.read(path)
           return [] unless source

--- a/lib/rails_ai_context/tools/base_tool.rb
+++ b/lib/rails_ai_context/tools/base_tool.rb
@@ -95,9 +95,13 @@ module RailsAiContext
       SESSION_CONTEXT = { mutex: Mutex.new, queries: {} }
 
       class << self
-        # Convenience: access the Rails app and cached introspection
+        # Convenience: access the Rails app and cached introspection.
+        # Routes through RailsAiContext.default_app so this resolves to the
+        # booted app in runtime tier and to a StaticApp in static tier -
+        # tools that call rails_app directly (get_concern, analyze_feature,
+        # migration_advisor, ...) work in both tiers without their own checks.
         def rails_app
-          Rails.application
+          RailsAiContext.default_app
         end
 
         def config
@@ -235,6 +239,24 @@ module RailsAiContext
             "Data from those sections is missing, not empty._"
         end
 
+        # One banner per response in static tier: consumers must never
+        # mistake static analysis for runtime-confirmed data. Rides the
+        # suffix mechanism so it survives truncation.
+        def static_tier_banner
+          return nil unless RailsAiContext.static_tier?
+
+          reason = RailsAiContext.static_reason
+          headline = if reason.to_s.include?("--no-boot")
+            "Static mode (#{reason})"
+          elsif reason
+            "App boot failed (#{reason})"
+          else
+            "Static mode"
+          end
+          "\n\n---\n_#{headline}. Serving static analysis; runtime-only data is marked " \
+            "[UNAVAILABLE]. Run `rails-ai-context doctor` for details._"
+        end
+
         # Fuzzy match: find the closest available name by exact, underscore, substring, or prefix
         def find_closest_match(input, available)
           return nil if available.empty?
@@ -330,7 +352,12 @@ module RailsAiContext
         # `suffix:`, when given, is appended after the truncation footer (or after
         # the text itself when untruncated) so callers can attach a short trailing
         # note that must survive truncation instead of being cut off with the tail.
+        # In static tier, the tier banner rides along on the same mechanism so
+        # every response - caller-suffixed or not - ends with it.
         def text_response(text, suffix: nil)
+          suffix = [ suffix, static_tier_banner ].compact.join
+          suffix = nil if suffix.empty?
+
           # Auto-track: record this tool call in session context (skip SessionContext itself to avoid recursion)
           if respond_to?(:tool_name) && tool_name != "rails_session_context"
             summary = text.lines.first&.strip&.truncate(80)

--- a/lib/rails_ai_context/tools/base_tool.rb
+++ b/lib/rails_ai_context/tools/base_tool.rb
@@ -239,6 +239,18 @@ module RailsAiContext
             "Data from those sections is missing, not empty._"
         end
 
+        # Short honest line for a context section that could not be produced
+        # because the app isn't booted, as opposed to one that ran and found
+        # nothing. Tools check this before rendering "not found"/empty copy
+        # so a missing runtime capability never reads as a confirmed
+        # negative (e.g. "No notable gems found" when gems were never
+        # inspected at all).
+        def unavailable_note(section_data)
+          return nil unless section_data.is_a?(Hash) && section_data[:unavailable]
+
+          "[UNAVAILABLE: #{section_data[:unavailable]}]"
+        end
+
         # One banner per response in static tier: consumers must never
         # mistake static analysis for runtime-confirmed data. Rides the
         # suffix mechanism so it survives truncation.
@@ -387,6 +399,8 @@ module RailsAiContext
           # A failed call must not leak its recorded params into the next
           # call's session entry.
           Thread.current[:rails_ai_context_call_params] = nil
+          banner = static_tier_banner
+          text += banner if banner
           MCP::Tool::Response.new([ { type: "text", text: text } ], error: true)
         end
 

--- a/lib/rails_ai_context/tools/base_tool.rb
+++ b/lib/rails_ai_context/tools/base_tool.rb
@@ -261,6 +261,29 @@ module RailsAiContext
           "[UNAVAILABLE: #{section_data[:unavailable]}]"
         end
 
+        # API-only apps legitimately have no views, partials, Stimulus, or
+        # Turbo surface; a bare empty listing is indistinguishable from a
+        # full-stack app that has none yet, so name the reason.
+        def api_only_app?
+          api = cached_context[:api]
+          return api[:api_only] == true if api.is_a?(Hash) && api.key?(:api_only)
+
+          app = rails_app
+          app.respond_to?(:config) && app.config.respond_to?(:api_only) && app.config.api_only == true
+        rescue StandardError
+          false
+        end
+
+        # Short honest line for a view/frontend section that doesn't apply on
+        # an API-only app, or nil when the app has a view layer. Tools check
+        # this before rendering "no X found" copy so a legitimately absent
+        # surface never reads as "not built yet".
+        def api_only_note(section_label)
+          return nil unless api_only_app?
+
+          "Not applicable: this is an API-only app (config.api_only), so #{section_label} does not exist."
+        end
+
         # One banner per response in static tier: consumers must never
         # mistake static analysis for runtime-confirmed data. Rides the
         # suffix mechanism so it survives truncation.

--- a/lib/rails_ai_context/tools/base_tool.rb
+++ b/lib/rails_ai_context/tools/base_tool.rb
@@ -108,6 +108,16 @@ module RailsAiContext
           RailsAiContext.configuration
         end
 
+        # The current environment name without requiring a booted app:
+        # Rails.env when a real Rails is loaded and responds to it, the
+        # ambient RAILS_ENV otherwise. Tools that only need the environment
+        # name (not the full StringInquirer API) use this instead of a bare
+        # `Rails.env` reference, which would NameError under --no-boot or
+        # early boot death.
+        def rails_env_name
+          defined?(Rails) && Rails.respond_to?(:env) ? Rails.env : (ENV["RAILS_ENV"] || "development")
+        end
+
         # Cache introspection results with TTL + fingerprint invalidation.
         # Uses SHARED_CACHE so all tool subclasses share one introspection
         # result instead of each caching independently.

--- a/lib/rails_ai_context/tools/dependency_graph.rb
+++ b/lib/rails_ai_context/tools/dependency_graph.rb
@@ -42,6 +42,9 @@ module RailsAiContext
       def self.call(model: nil, depth: 2, format: "mermaid", show_cycles: false, show_sti: false, server_context: nil)
         models_data = cached_context[:models]
 
+        note = unavailable_note(models_data)
+        return text_response(note) if note
+
         unless models_data.is_a?(Hash) && !models_data[:error]
           return text_response("No model data available. Ensure :models introspector is enabled.")
         end

--- a/lib/rails_ai_context/tools/diagnose.rb
+++ b/lib/rails_ai_context/tools/diagnose.rb
@@ -467,7 +467,7 @@ module RailsAiContext
 
         def gather_git_context(file, file_refs)
           lines = []
-          root = Rails.root.to_s
+          root = rails_app.root.to_s
 
           files_to_check = [ file, *file_refs.map { |r| r[:file] } ].compact.uniq.first(3)
           return lines if files_to_check.empty?

--- a/lib/rails_ai_context/tools/generate_test.rb
+++ b/lib/rails_ai_context/tools/generate_test.rb
@@ -56,7 +56,7 @@ module RailsAiContext
         private
 
         def detect_framework
-          if Dir.exist?(File.join(Rails.root, "spec"))
+          if Dir.exist?(File.join(rails_app.root, "spec"))
             "rspec"
           else
             "minitest"
@@ -65,7 +65,7 @@ module RailsAiContext
 
         # Scan existing tests to learn project patterns
         def detect_patterns(framework) # rubocop:disable Metrics
-          root = Rails.root.to_s
+          root = rails_app.root.to_s
           real_root = File.realpath(root).to_s
           patterns = { factory_style: :create, let_style: true, expect_style: true, described_class: true }
 
@@ -979,7 +979,7 @@ module RailsAiContext
           keys = fixture_names[table] || fixture_names[table.to_sym]
           return keys.first.to_s if keys.is_a?(Array) && keys.any?
 
-          fixture_file = File.join(Rails.root, "test", "fixtures", "#{table}.yml")
+          fixture_file = File.join(rails_app.root, "test", "fixtures", "#{table}.yml")
           return nil unless File.exist?(fixture_file)
 
           content = RailsAiContext::SafeFile.read(fixture_file)

--- a/lib/rails_ai_context/tools/get_api.rb
+++ b/lib/rails_ai_context/tools/get_api.rb
@@ -28,6 +28,9 @@ module RailsAiContext
       def self.call(detail: "standard", server_context: nil)
         data = cached_context[:api]
 
+        note = unavailable_note(data)
+        return text_response(note) if note
+
         unless data.is_a?(Hash) && !data[:error]
           return text_response(
             "No API layer data available. Ensure the :api introspector is enabled in your " \

--- a/lib/rails_ai_context/tools/get_callbacks.rb
+++ b/lib/rails_ai_context/tools/get_callbacks.rb
@@ -54,6 +54,8 @@ module RailsAiContext
         models = cached_context[:models]
         return text_response("Model introspection not available. Add :models to introspectors.") unless models
         return text_response("Model introspection failed: #{models[:error]}") if models[:error]
+        note = unavailable_note(models)
+        return text_response(note) if note
 
         # Specific model - show callbacks in execution order
         if model

--- a/lib/rails_ai_context/tools/get_callbacks.rb
+++ b/lib/rails_ai_context/tools/get_callbacks.rb
@@ -228,7 +228,7 @@ module RailsAiContext
       end
 
       private_class_method def self.extract_callback_source(model_name, method_name)
-        path = Rails.root.join("app", "models", "#{model_name.underscore}.rb")
+        path = rails_app.root.join("app", "models", "#{model_name.underscore}.rb")
         extract_method_source_from_file(path, method_name)
       end
 
@@ -245,7 +245,7 @@ module RailsAiContext
 
           underscore = concern_name.underscore
           concern_path = RailsAiContext.configuration.concern_paths
-            .map { |dir| Rails.root.join(dir, "#{underscore}.rb") }
+            .map { |dir| rails_app.root.join(dir, "#{underscore}.rb") }
             .find { |p| File.exist?(p) }
           next unless concern_path
           next if File.size(concern_path) > max_size

--- a/lib/rails_ai_context/tools/get_component_catalog.rb
+++ b/lib/rails_ai_context/tools/get_component_catalog.rb
@@ -36,6 +36,9 @@ module RailsAiContext
       def self.call(component: nil, detail: "standard", offset: 0, limit: nil, server_context: nil)
         data = cached_context[:components]
 
+        note = unavailable_note(data)
+        return text_response(note) if note
+
         unless data.is_a?(Hash) && !data[:error]
           return text_response("No component data available. Ensure :components introspector is enabled and app/components/ exists.")
         end

--- a/lib/rails_ai_context/tools/get_component_catalog.rb
+++ b/lib/rails_ai_context/tools/get_component_catalog.rb
@@ -49,6 +49,9 @@ module RailsAiContext
           component = component.to_s.strip
 
           if components.empty?
+            note = api_only_note("app/components")
+            return text_response(note) if note
+
             return text_response("Component '#{component}' not found - no components exist in app/components/. Create ViewComponent or Phlex components first.")
           end
 
@@ -65,6 +68,9 @@ module RailsAiContext
           text_response(render_single(found, detail))
         else
           if components.empty?
+            note = api_only_note("app/components")
+            return text_response(note) if note
+
             return text_response(
               "No components found in app/components/.\n\n" \
               "This app may use ERB partials instead of ViewComponent/Phlex. Try:\n" \

--- a/lib/rails_ai_context/tools/get_config.rb
+++ b/lib/rails_ai_context/tools/get_config.rb
@@ -16,6 +16,8 @@ module RailsAiContext
         data = cached_context[:config]
         return text_response("Config introspection not available. Add :config to introspectors or use `config.preset = :full`.") unless data
         return text_response("Config introspection failed: #{data[:error]}") if data[:error]
+        note = unavailable_note(data)
+        return text_response(note) if note
 
         lines = [ "# Application Configuration", "" ]
 

--- a/lib/rails_ai_context/tools/get_config.rb
+++ b/lib/rails_ai_context/tools/get_config.rb
@@ -99,7 +99,7 @@ module RailsAiContext
       # A short note for a config/initializers file: flags files that are
       # entirely commented out, otherwise describes known stock initializers.
       private_class_method def self.initializer_note(name)
-        path = Rails.root.join("config", "initializers", name).to_s
+        path = rails_app.root.join("config", "initializers", name).to_s
         if File.exist?(path)
           content = RailsAiContext::SafeFile.read(path)
           if content
@@ -137,8 +137,8 @@ module RailsAiContext
           "Sorcery"
         elsif gem_names.include?("clearance")
           "Clearance"
-        elsif File.exist?(Rails.root.join("app/models/concerns/authentication.rb")) ||
-              File.exist?(Rails.root.join("app/controllers/concerns/authentication.rb"))
+        elsif File.exist?(rails_app.root.join("app/models/concerns/authentication.rb")) ||
+              File.exist?(rails_app.root.join("app/controllers/concerns/authentication.rb"))
           "Rails 8 authentication (built-in)"
         end
       end
@@ -168,7 +168,7 @@ module RailsAiContext
         # Asset pipeline detection (always check - not from introspector)
         parts << "Propshaft" if defined?(Propshaft)
         parts << "Sprockets" if defined?(Sprockets) && !defined?(Propshaft)
-        parts << "Import Maps" if File.exist?(Rails.root.join("config/importmap.rb"))
+        parts << "Import Maps" if File.exist?(rails_app.root.join("config/importmap.rb"))
 
         parts.uniq!
         parts.any? ? parts.join(", ") : nil
@@ -183,7 +183,7 @@ module RailsAiContext
         end
 
         # YAML fallback for older Rails or when config API isn't available
-        cable_yml = Rails.root.join("config/cable.yml")
+        cable_yml = rails_app.root.join("config/cable.yml")
         return nil unless File.exist?(cable_yml)
 
         content = RailsAiContext::SafeFile.read(cable_yml)

--- a/lib/rails_ai_context/tools/get_context.rb
+++ b/lib/rails_ai_context/tools/get_context.rb
@@ -176,22 +176,8 @@ module RailsAiContext
 
       # True when the app runs in API-only mode (no view layer), so ivar
       # cross-referencing can drop "view" language that wouldn't be truthful.
-      # Prefers cached introspection data; falls back to the live app config
-      # when the cache is unavailable.
       private_class_method def self.api_only?
-        ctx = begin
-          cached_context
-        rescue StandardError
-          nil
-        end
-        return true if ctx.is_a?(Hash) && ctx.dig(:api, :api_only) == true
-
-        arch = ctx.is_a?(Hash) ? ctx.dig(:conventions, :architecture) : nil
-        return true if arch.is_a?(Array) && arch.include?("api_only")
-
-        rails_app.config.api_only == true
-      rescue StandardError
-        false
+        api_only_app?
       end
 
       private_class_method def self.cross_reference_ivars(ctrl_ivars, view_ivars, rendered_templates: [], api_only: false)

--- a/lib/rails_ai_context/tools/get_controllers.rb
+++ b/lib/rails_ai_context/tools/get_controllers.rb
@@ -190,7 +190,7 @@ module RailsAiContext
         end
 
         # Detect skip_before_action declarations in the child controller source
-        source_path = Rails.root.join("app", "controllers", "#{controller_name.underscore}.rb")
+        source_path = rails_app.root.join("app", "controllers", "#{controller_name.underscore}.rb")
         skipped_filters = detect_skipped_filters(source_path, action_name)
 
         # Include inherited filters from parent controller, excluding skipped ones
@@ -347,7 +347,7 @@ module RailsAiContext
         end
 
         # Fallback: read ApplicationController source directly
-        path = Rails.root.join("app", "controllers", "#{parent_class.underscore}.rb")
+        path = rails_app.root.join("app", "controllers", "#{parent_class.underscore}.rb")
         return [] unless File.exist?(path)
         return [] if File.size(path) > RailsAiContext.configuration.max_file_size
 
@@ -546,7 +546,7 @@ module RailsAiContext
 
         # Hydrate with schema hints for models referenced in this controller
         if RailsAiContext.configuration.hydration_enabled
-          source_path = Rails.root.join("app", "controllers", "#{name.underscore}.rb")
+          source_path = rails_app.root.join("app", "controllers", "#{name.underscore}.rb")
           hydration = Hydrators::ControllerHydrator.call(source_path.to_s, context: cached_context)
           hydration_text = Hydrators::HydrationFormatter.format(hydration)
           lines << "" << hydration_text unless hydration_text.empty?

--- a/lib/rails_ai_context/tools/get_controllers.rb
+++ b/lib/rails_ai_context/tools/get_controllers.rb
@@ -40,6 +40,8 @@ module RailsAiContext
         data = cached_context[:controllers]
         return text_response("Controller introspection not available. Add :controllers to introspectors.") unless data
         return text_response("Controller introspection failed: #{data[:error]}") if data[:error]
+        note = unavailable_note(data)
+        return text_response(note) if note
 
         controllers = data[:controllers] || {}
 

--- a/lib/rails_ai_context/tools/get_conventions.rb
+++ b/lib/rails_ai_context/tools/get_conventions.rb
@@ -16,6 +16,8 @@ module RailsAiContext
         conventions = cached_context[:conventions]
         return text_response("Convention detection not available. Add :conventions to introspectors.") unless conventions
         return text_response("Convention detection failed: #{conventions[:error]}") if conventions[:error]
+        note = unavailable_note(conventions)
+        return text_response(note) if note
 
         lines = [ "# App Conventions & Architecture", "" ]
 

--- a/lib/rails_ai_context/tools/get_conventions.rb
+++ b/lib/rails_ai_context/tools/get_conventions.rb
@@ -136,7 +136,7 @@ module RailsAiContext
       end
 
       private_class_method def self.detect_frontend_stack
-        pkg_path = Rails.root.join("package.json")
+        pkg_path = rails_app.root.join("package.json")
         return [] unless File.exist?(pkg_path)
 
         content = RailsAiContext::SafeFile.read(pkg_path) || ""
@@ -170,19 +170,19 @@ module RailsAiContext
       end
 
       private_class_method def self.detect_package_manager
-        return "pnpm" if File.exist?(Rails.root.join("pnpm-lock.yaml"))
-        return "yarn" if File.exist?(Rails.root.join("yarn.lock"))
-        return "bun" if File.exist?(Rails.root.join("bun.lockb"))
-        return "npm" if File.exist?(Rails.root.join("package-lock.json"))
+        return "pnpm" if File.exist?(rails_app.root.join("pnpm-lock.yaml"))
+        return "yarn" if File.exist?(rails_app.root.join("yarn.lock"))
+        return "bun" if File.exist?(rails_app.root.join("bun.lockb"))
+        return "npm" if File.exist?(rails_app.root.join("package-lock.json"))
         nil
       end
 
       # Scan controllers for app-specific authorization, flash, and error-handling patterns
       private_class_method def self.detect_app_patterns
-        controllers_dir = Rails.root.join("app", "controllers").to_s
+        controllers_dir = rails_app.root.join("app", "controllers").to_s
         return [] unless Dir.exist?(controllers_dir)
 
-        real_root = File.realpath(Rails.root).to_s
+        real_root = File.realpath(rails_app.root).to_s
         auth_checks = []
         auth_denials = []
         flash_notices = []
@@ -194,7 +194,7 @@ module RailsAiContext
         json_response_count = 0
         html_response_count = 0
         show_only_controllers = []
-        has_services = Dir.exist?(Rails.root.join("app", "services"))
+        has_services = Dir.exist?(rails_app.root.join("app", "services"))
 
         safe_glob(controllers_dir, "**/*.rb", real_root).each do |path|
           content = RailsAiContext::SafeFile.read(path) or next
@@ -369,7 +369,7 @@ module RailsAiContext
         sections.concat(test_pattern) if test_pattern.any?
 
         if has_services
-          services_dir = Rails.root.join("app", "services").to_s
+          services_dir = rails_app.root.join("app", "services").to_s
           service_files = safe_glob(services_dir, "**/*.rb", real_root)
           if service_files.any?
             sections << "" << "### Service Objects"
@@ -387,10 +387,10 @@ module RailsAiContext
 
       private_class_method def self.detect_locale_info
         info = []
-        locales_dir = Rails.root.join("config", "locales").to_s
+        locales_dir = rails_app.root.join("config", "locales").to_s
         return info unless Dir.exist?(locales_dir)
 
-        real_root = File.realpath(Rails.root).to_s
+        real_root = File.realpath(rails_app.root).to_s
         locale_files = safe_glob(locales_dir, "**/*.{yml,yaml,rb}", real_root)
         locales = locale_files.map { |f| File.basename(f, ".*").split(".").first }.uniq.sort
 
@@ -399,7 +399,7 @@ module RailsAiContext
         info << "**Locales:** #{locales.join(', ')} (#{locales.size} total)"
 
         # Detect default locale from config
-        app_config = Rails.root.join("config", "application.rb")
+        app_config = rails_app.root.join("config", "application.rb")
         if File.exist?(app_config)
           content = RailsAiContext::SafeFile.read(app_config) || ""
           if (match = content.match(/config\.i18n\.default_locale\s*=\s*[:"'](\w+)/))
@@ -408,7 +408,7 @@ module RailsAiContext
         end
 
         # Detect primary UI language by sampling flash messages from controllers
-        controllers_dir = Rails.root.join("app", "controllers").to_s
+        controllers_dir = rails_app.root.join("app", "controllers").to_s
         if Dir.exist?(controllers_dir)
           samples = []
           safe_glob(controllers_dir, "**/*.rb", real_root).first(10).each do |path|
@@ -441,10 +441,10 @@ module RailsAiContext
 
       private_class_method def self.detect_test_pattern
         sections = []
-        test_dir = Rails.root.join("test", "controllers").to_s
+        test_dir = rails_app.root.join("test", "controllers").to_s
         return sections unless Dir.exist?(test_dir)
 
-        real_root = File.realpath(Rails.root).to_s
+        real_root = File.realpath(rails_app.root).to_s
         test_files = safe_glob(test_dir, "**/*_test.rb", real_root)
         return sections if test_files.empty?
 

--- a/lib/rails_ai_context/tools/get_edit_context.rb
+++ b/lib/rails_ai_context/tools/get_edit_context.rb
@@ -38,7 +38,7 @@ module RailsAiContext
           return text_response("The `near` parameter is required. Provide a method name, keyword, or string to find.")
         end
 
-        full_path = Rails.root.join(file)
+        full_path = rails_app.root.join(file)
 
         # Block access to sensitive files (secrets, keys, credentials)
         if sensitive_file?(file)
@@ -49,9 +49,9 @@ module RailsAiContext
         unless File.exist?(full_path)
           # Try to find a matching file to suggest
           basename = File.basename(file)
-          candidates = Dir.glob(File.join(Rails.root, "app", "**", basename)).first(5)
+          candidates = Dir.glob(File.join(rails_app.root, "app", "**", basename)).first(5)
           hint = if candidates.any?
-            suggestions = candidates.map { |c| c.sub("#{Rails.root}/", "") }
+            suggestions = candidates.map { |c| c.sub("#{rails_app.root}/", "") }
             " Did you mean: #{suggestions.join(', ')}? Use the full path relative to Rails root."
           else
             " Use the full path relative to Rails root (e.g., 'app/models/#{basename}')."
@@ -60,7 +60,7 @@ module RailsAiContext
         end
         begin
           real = File.realpath(full_path).to_s
-          rails_root_real = File.realpath(Rails.root).to_s
+          rails_root_real = File.realpath(rails_app.root).to_s
           # Separator-aware containment - matches the v5.8.1-r2 hardening in
           # get_view.rb / vfs.rb. Without `+ File::SEPARATOR`, a sibling-dir
           # like `/app/rails_evil/...` would prefix-match a Rails root at

--- a/lib/rails_ai_context/tools/get_env.rb
+++ b/lib/rails_ai_context/tools/get_env.rb
@@ -21,7 +21,7 @@ module RailsAiContext
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(detail: "standard", server_context: nil)
-        root = Rails.root.to_s
+        root = rails_app.root.to_s
 
         env_vars = scan_env_vars(root)
         env_example = scan_env_example(root)
@@ -526,7 +526,7 @@ module RailsAiContext
 
       private_class_method def self.parse_credentials_structure
         # Look for credentials template or example
-        root = Rails.root.to_s
+        root = rails_app.root.to_s
         candidates = %w[
           config/credentials.yml.example
           config/credentials.yml.sample

--- a/lib/rails_ai_context/tools/get_frontend_stack.rb
+++ b/lib/rails_ai_context/tools/get_frontend_stack.rb
@@ -24,6 +24,9 @@ module RailsAiContext
       def self.call(detail: "standard", server_context: nil) # rubocop:disable Metrics
         data = cached_context[:frontend_frameworks]
 
+        note = unavailable_note(data)
+        return text_response(note) if note
+
         unless data.is_a?(Hash) && !data[:error]
           return text_response(
             "No frontend framework data available. Ensure the :frontend_frameworks introspector is enabled in your " \

--- a/lib/rails_ai_context/tools/get_gems.rb
+++ b/lib/rails_ai_context/tools/get_gems.rb
@@ -56,6 +56,8 @@ module RailsAiContext
         gems = cached_context[:gems]
         return text_response("Gem introspection not available. Add :gems to introspectors.") unless gems
         return text_response("Gem introspection failed: #{gems[:error]}") if gems[:error]
+        note = unavailable_note(gems)
+        return text_response(note) if note
 
         notable = gems[:notable_gems] || []
         notable = notable.select { |g| g[:category] == category } unless category == "all"

--- a/lib/rails_ai_context/tools/get_gems.rb
+++ b/lib/rails_ai_context/tools/get_gems.rb
@@ -99,7 +99,7 @@ module RailsAiContext
         return hint if hint.is_a?(String)
         return nil unless hint.is_a?(Array)
 
-        root = defined?(Rails) && Rails.respond_to?(:root) && Rails.root ? Rails.root : Dir.pwd
+        root = rails_app.root
         present = hint.select { |path| File.exist?(File.join(root, path)) }
         present.any? ? present.join(", ") : nil
       end

--- a/lib/rails_ai_context/tools/get_job_pattern.rb
+++ b/lib/rails_ai_context/tools/get_job_pattern.rb
@@ -25,7 +25,7 @@ module RailsAiContext
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(job: nil, detail: "standard", server_context: nil)
-        root = Rails.root.to_s
+        root = rails_app.root.to_s
         jobs_dir = File.join(root, "app", "jobs")
         real_root = File.realpath(root).to_s
         jobs_dir_exists = Dir.exist?(jobs_dir)

--- a/lib/rails_ai_context/tools/get_job_pattern.rb
+++ b/lib/rails_ai_context/tools/get_job_pattern.rb
@@ -44,7 +44,10 @@ module RailsAiContext
         # Pull enriched channel data from the cached introspector context - this
         # gives us the v5.8.0 fields (identified_by, streams, periodic, actions)
         # that JobIntrospector#extract_channels populates.
-        channels = (cached_context.dig(:jobs, :channels) || []).reject { |c| c.is_a?(Hash) && c[:error] }
+        jobs_data = cached_context[:jobs]
+        channels = (jobs_data.is_a?(Hash) ? jobs_data[:channels] : nil) || []
+        channels = channels.reject { |c| c.is_a?(Hash) && c[:error] }
+        channels_note = unavailable_note(jobs_data)
 
         # Single-job query: requires jobs to be present.
         if job
@@ -54,8 +57,11 @@ module RailsAiContext
 
         # No jobs and no channels - bail out, but say honestly whether the
         # directory is missing or just has no job classes beyond ApplicationJob.
+        # Channel absence is only a real negative when the :jobs section
+        # actually ran - if it's unavailable (static tier), say so instead of
+        # claiming "no channels detected".
         if job_files.empty? && channels.empty?
-          return text_response(no_jobs_or_channels_message(jobs_dir_exists))
+          return text_response(no_jobs_or_channels_message(jobs_dir_exists, channels_note))
         end
 
         # Compose: jobs section (if any) + channels section (if any).
@@ -82,11 +88,16 @@ module RailsAiContext
 
       # Same distinction for the "nothing async at all" bail-out message,
       # phrased to keep reading naturally when appended to the channels clause.
-      private_class_method def self.no_jobs_or_channels_message(jobs_dir_exists)
+      # `channels_note` carries an [UNAVAILABLE: ...] marker when the :jobs
+      # section never ran (static tier) - in that case, asserting "no Action
+      # Cable channels detected" would be a fabricated negative rather than
+      # an observed one, so the note replaces that claim instead of joining it.
+      private_class_method def self.no_jobs_or_channels_message(jobs_dir_exists, channels_note)
+        channels_clause = channels_note || "no Action Cable channels detected"
         if jobs_dir_exists
-          "app/jobs/ exists but has no job classes beyond ApplicationJob, and no Action Cable channels detected. This app may not use background jobs."
+          "app/jobs/ exists but has no job classes beyond ApplicationJob, and #{channels_clause}. This app may not use background jobs."
         else
-          "No app/jobs/ directory found and no Action Cable channels detected. This app may not use background jobs."
+          "No app/jobs/ directory found and #{channels_clause}. This app may not use background jobs."
         end
       end
 

--- a/lib/rails_ai_context/tools/get_model_details.rb
+++ b/lib/rails_ai_context/tools/get_model_details.rb
@@ -37,6 +37,8 @@ module RailsAiContext
         models = cached_context[:models]
         return text_response("Model introspection not available. Add :models to introspectors.") unless models
         return text_response("Model introspection failed: #{models[:error]}") if models[:error]
+        note = unavailable_note(models)
+        return text_response(note) if note
 
         # Specific model - always full detail (strip whitespace for fuzzy input)
         if model

--- a/lib/rails_ai_context/tools/get_model_details.rb
+++ b/lib/rails_ai_context/tools/get_model_details.rb
@@ -135,6 +135,25 @@ module RailsAiContext
           end
         end
 
+        # Mongoid documents have no AR table/columns - render declared fields
+        # and embedded relations directly from the source-parsed macros instead.
+        if data[:mongoid]
+          if data[:fields]&.any?
+            lines << "" << "## Fields"
+            data[:fields].each do |f|
+              type_str = f[:type] ? ": #{f[:type]}" : ""
+              lines << "- `#{f[:name]}`#{type_str}"
+            end
+          end
+
+          if data[:embeds]&.any?
+            lines << "" << "## Embedded relations"
+            data[:embeds].each do |e|
+              lines << "- `#{e[:type]}` **#{e[:name]}**"
+            end
+          end
+        end
+
         # Associations
         if data[:associations]&.any?
           lines << "" << "## Associations"

--- a/lib/rails_ai_context/tools/get_model_details.rb
+++ b/lib/rails_ai_context/tools/get_model_details.rb
@@ -372,7 +372,7 @@ module RailsAiContext
 
       # Extract bodies of custom validate methods (single-line or first meaningful line)
       private_class_method def self.extract_custom_validate_bodies(model_name, method_names)
-        path = Rails.root.join("app", "models", "#{model_name.underscore}.rb")
+        path = rails_app.root.join("app", "models", "#{model_name.underscore}.rb")
         return {} unless File.exist?(path) && File.size(path) <= max_file_size
 
         source = RailsAiContext::SafeFile.read(path)
@@ -393,7 +393,7 @@ module RailsAiContext
 
       # Extract class methods defined in the model source (not inherited)
       private_class_method def self.extract_source_defined_methods(model_name, class_methods: false)
-        path = Rails.root.join("app", "models", "#{model_name.underscore}.rb")
+        path = rails_app.root.join("app", "models", "#{model_name.underscore}.rb")
         return nil unless File.exist?(path)
         return nil if File.size(path) > max_file_size
 
@@ -416,7 +416,7 @@ module RailsAiContext
 
       # Extract public method signatures (name + params) from model source
       private_class_method def self.extract_method_signatures(model_name)
-        path = Rails.root.join("app", "models", "#{model_name.underscore}.rb")
+        path = rails_app.root.join("app", "models", "#{model_name.underscore}.rb")
         return nil unless File.exist?(path)
         return nil if File.size(path) > max_file_size
 
@@ -447,7 +447,7 @@ module RailsAiContext
         underscore = concern_name.underscore
         # Search configurable concern paths
         path = RailsAiContext.configuration.concern_paths
-          .map { |dir| Rails.root.join(dir, "#{underscore}.rb") }
+          .map { |dir| rails_app.root.join(dir, "#{underscore}.rb") }
           .find { |p| File.exist?(p) }
         return nil unless path
         return nil if File.size(path) > max_size
@@ -475,7 +475,7 @@ module RailsAiContext
 
       private_class_method def self.extract_model_structure(model_name)
         path = "app/models/#{model_name.underscore}.rb"
-        full_path = Rails.root.join(path)
+        full_path = rails_app.root.join(path)
         return nil unless File.exist?(full_path)
         return nil if File.size(full_path) > max_file_size
 

--- a/lib/rails_ai_context/tools/get_partial_interface.rb
+++ b/lib/rails_ai_context/tools/get_partial_interface.rb
@@ -44,7 +44,7 @@ module RailsAiContext
           return text_response("Path not allowed: #{partial} (sensitive file)")
         end
 
-        root = Rails.root.to_s
+        root = rails_app.root.to_s
         views_dir = File.join(root, "app", "views")
 
         unless Dir.exist?(views_dir)

--- a/lib/rails_ai_context/tools/get_partial_interface.rb
+++ b/lib/rails_ai_context/tools/get_partial_interface.rb
@@ -48,6 +48,9 @@ module RailsAiContext
         views_dir = File.join(root, "app", "views")
 
         unless Dir.exist?(views_dir)
+          note = api_only_note("app/views")
+          return text_response(note) if note
+
           return text_response("No app/views/ directory found.")
         end
 

--- a/lib/rails_ai_context/tools/get_routes.rb
+++ b/lib/rails_ai_context/tools/get_routes.rb
@@ -44,6 +44,8 @@ module RailsAiContext
         routes = cached_context[:routes]
         return text_response("Route introspection not available. Add :routes to introspectors.") unless routes
         return text_response("Route introspection failed: #{routes[:error]}") if routes[:error]
+        note = unavailable_note(routes)
+        return text_response(note) if note
 
         by_controller = routes[:by_controller] || {}
         offset = [ offset.to_i, 0 ].max

--- a/lib/rails_ai_context/tools/get_schema.rb
+++ b/lib/rails_ai_context/tools/get_schema.rb
@@ -47,6 +47,8 @@ module RailsAiContext
         schema = cached_context[:schema]
         return text_response("Schema introspection not available. Add :schema to introspectors.") unless schema
         return text_response("Schema introspection not available: #{schema[:error]}") if schema[:error]
+        note = unavailable_note(schema)
+        return text_response(note) if note
 
         tables = schema[:tables] || {}
 

--- a/lib/rails_ai_context/tools/get_schema.rb
+++ b/lib/rails_ai_context/tools/get_schema.rb
@@ -101,6 +101,7 @@ module RailsAiContext
             idx_count = data[:indexes]&.size || 0
             lines << "- **#{name}** - #{col_count} #{col_count == 1 ? 'column' : 'columns'}, #{idx_count} #{idx_count == 1 ? 'index' : 'indexes'}"
           end
+          lines.concat(secondary_databases_lines(schema))
           if offset + limit < total
             lines << "" << "_Showing #{paginated.size} of #{total}. Use `offset:#{offset + limit}` for more, or `table:\"name\"` for full detail._"
             lines << "_cache_key: #{cache_key}_"
@@ -176,6 +177,7 @@ module RailsAiContext
             lines << ""
           end
 
+          lines.concat(secondary_databases_lines(schema))
           lines << "_Use `detail:\"summary\"` for all #{total} tables, `detail:\"full\"` for indexes/FKs, or `table:\"name\"` for one table._" if total > limit
           text_response(lines.join("\n"))
 
@@ -191,6 +193,7 @@ module RailsAiContext
             lines << format_table_markdown(name, tables[name])
             lines << ""
           end
+          lines.concat(secondary_databases_lines(schema))
           if offset + limit < total
             lines << "_Showing #{paginated.size} of #{total}. Use `offset:#{offset + limit}` for more._"
             lines << "_cache_key: #{cache_key}_"
@@ -210,6 +213,21 @@ module RailsAiContext
       rescue => e
         $stderr.puts "[rails-ai-context] models_for_table failed: #{e.message}" if ENV["DEBUG"]
         []
+      end
+
+      # Rails 8 multi-database apps dump each secondary database (queue,
+      # cache, cable) to its own schema/structure file. This tool targets
+      # the primary database's tables in detail, so secondaries get a
+      # compact one-line-per-database summary rather than full column detail.
+      private_class_method def self.secondary_databases_lines(schema)
+        secondary = schema[:secondary_databases]
+        return [] unless secondary
+
+        lines = [ "", "## Secondary databases", "" ]
+        secondary.each do |name, db|
+          lines << "- **#{name}**: #{db[:total_tables]} tables (#{db[:tables].keys.join(', ')}) - #{db[:note]}"
+        end
+        lines
       end
 
       private_class_method def self.format_table_markdown(name, data)
@@ -302,6 +320,7 @@ module RailsAiContext
           lines << ""
         end
 
+        lines.concat(secondary_databases_lines(schema))
         lines.join("\n")
       end
     end

--- a/lib/rails_ai_context/tools/get_service_pattern.rb
+++ b/lib/rails_ai_context/tools/get_service_pattern.rb
@@ -25,7 +25,7 @@ module RailsAiContext
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(service: nil, detail: "standard", server_context: nil)
-        root = Rails.root.to_s
+        root = rails_app.root.to_s
         services_dir = File.join(root, "app", "services")
 
         unless Dir.exist?(services_dir)

--- a/lib/rails_ai_context/tools/get_stimulus.rb
+++ b/lib/rails_ai_context/tools/get_stimulus.rb
@@ -226,10 +226,10 @@ module RailsAiContext
       end
 
       private_class_method def self.find_views_using(controller_name)
-        views_dir = Rails.root.join("app", "views").to_s
+        views_dir = rails_app.root.join("app", "views").to_s
         return [] unless Dir.exist?(views_dir)
 
-        real_root = File.realpath(Rails.root).to_s
+        real_root = File.realpath(rails_app.root).to_s
         real_views_dir = File.realpath(views_dir).to_s
 
         pattern = "data-controller=\"#{controller_name}\""
@@ -248,7 +248,7 @@ module RailsAiContext
 
       private_class_method def self.detect_lifecycle(relative_path)
         return nil unless relative_path
-        path = Rails.root.join("app/javascript/controllers", relative_path)
+        path = rails_app.root.join("app/javascript/controllers", relative_path)
         return nil unless File.exist?(path)
 
         content = RailsAiContext::SafeFile.read(path)

--- a/lib/rails_ai_context/tools/get_stimulus.rb
+++ b/lib/rails_ai_context/tools/get_stimulus.rb
@@ -36,6 +36,8 @@ module RailsAiContext
         data = cached_context[:stimulus]
         return text_response("Stimulus introspection not available. Add :stimulus to introspectors.") unless data
         return text_response("Stimulus introspection failed: #{data[:error]}") if data[:error]
+        note = unavailable_note(data)
+        return text_response(note) if note
 
         all_controllers = data[:controllers] || []
         return text_response("No Stimulus controllers found.") if all_controllers.empty?

--- a/lib/rails_ai_context/tools/get_stimulus.rb
+++ b/lib/rails_ai_context/tools/get_stimulus.rb
@@ -40,7 +40,12 @@ module RailsAiContext
         return text_response(note) if note
 
         all_controllers = data[:controllers] || []
-        return text_response("No Stimulus controllers found.") if all_controllers.empty?
+        if all_controllers.empty?
+          note = api_only_note("app/javascript/controllers")
+          return text_response(note) if note
+
+          return text_response("No Stimulus controllers found.")
+        end
 
         # Specific controller - accepts both dash and underscore naming
         # (HTML uses data-controller="weekly-chart", file is weekly_chart_controller.js)

--- a/lib/rails_ai_context/tools/get_test_info.rb
+++ b/lib/rails_ai_context/tools/get_test_info.rb
@@ -32,6 +32,8 @@ module RailsAiContext
         data = cached_context[:tests]
         return text_response("Test introspection not available. Add :tests to introspectors.") unless data
         return text_response("Test introspection failed: #{data[:error]}") if data[:error]
+        note = unavailable_note(data)
+        return text_response(note) if note
 
         # Specific model tests
         if model

--- a/lib/rails_ai_context/tools/get_test_info.rb
+++ b/lib/rails_ai_context/tools/get_test_info.rb
@@ -219,12 +219,12 @@ module RailsAiContext
         end
 
         candidates.each do |rel|
-          path = Rails.root.join(rel)
+          path = rails_app.root.join(rel)
           next unless File.exist?(path)
           # Path traversal protection
           begin
             real_path = File.realpath(path)
-            real_root = File.realpath(Rails.root)
+            real_root = File.realpath(rails_app.root)
             next unless real_path.start_with?(real_root)
           rescue Errno::ENOENT
             next
@@ -249,9 +249,9 @@ module RailsAiContext
         end
 
         # List nearby test files to help the agent find the right one
-        test_dirs = candidates.map { |c| File.dirname(Rails.root.join(c)) }.uniq
+        test_dirs = candidates.map { |c| File.dirname(rails_app.root.join(c)) }.uniq
         nearby = test_dirs.flat_map do |dir|
-          Dir.exist?(dir) ? Dir.glob(File.join(dir, "*")).map { |f| f.sub("#{Rails.root}/", "") }.first(10) : []
+          Dir.exist?(dir) ? Dir.glob(File.join(dir, "*")).map { |f| f.sub("#{rails_app.root}/", "") }.first(10) : []
         end
         hint = nearby.any? ? "\n\nFiles in test directory: #{nearby.join(', ')}" : ""
         "No test file found for #{name}. Searched: #{candidates.join(', ')}#{hint}"
@@ -284,9 +284,9 @@ module RailsAiContext
           # Detect Devise + sign_in pattern from existing tests
           has_devise = false
           has_sign_in = false
-          test_dir = Rails.root.join("test").to_s
+          test_dir = rails_app.root.join("test").to_s
           if Dir.exist?(test_dir)
-            real_root = File.realpath(Rails.root).to_s
+            real_root = File.realpath(rails_app.root).to_s
             safe_glob(test_dir, "**/*_test.rb", real_root).first(5).each do |path|
               content = RailsAiContext::SafeFile.read(path) or next
               has_devise = true if content.include?("Devise::Test")
@@ -346,10 +346,10 @@ module RailsAiContext
       private_class_method def self.parse_factory_details(relative_path)
         # Try common factory locations
         candidates = [
-          Rails.root.join("spec/factories/#{relative_path}"),
-          Rails.root.join("test/factories/#{relative_path}"),
-          Rails.root.join("spec/factories", relative_path),
-          Rails.root.join("test/factories", relative_path)
+          rails_app.root.join("spec/factories/#{relative_path}"),
+          rails_app.root.join("test/factories/#{relative_path}"),
+          rails_app.root.join("spec/factories", relative_path),
+          rails_app.root.join("test/factories", relative_path)
         ]
         path = candidates.find { |p| File.exist?(p) }
         return nil unless path
@@ -416,10 +416,10 @@ module RailsAiContext
       # Parse all fixture files, returning { "fixture_file" => { entry => attrs } }
       private_class_method def self.parse_all_fixture_contents
         fixture_dirs = [
-          Rails.root.join("test", "fixtures").to_s,
-          Rails.root.join("spec", "fixtures").to_s
+          rails_app.root.join("test", "fixtures").to_s,
+          rails_app.root.join("spec", "fixtures").to_s
         ]
-        real_root = File.realpath(Rails.root).to_s
+        real_root = File.realpath(rails_app.root).to_s
 
         results = {}
         fixture_dirs.each do |dir|

--- a/lib/rails_ai_context/tools/get_turbo_map.rb
+++ b/lib/rails_ai_context/tools/get_turbo_map.rb
@@ -47,7 +47,7 @@ module RailsAiContext
       def self.call(detail: "standard", stream: nil, controller: nil, server_context: nil)
         return text_response("Turbo is not installed in this app (no `turbo-rails` gem in Gemfile.lock).") if turbo_rails_absent?
 
-        root = Rails.root.to_s
+        root = rails_app.root.to_s
 
         # Collect all Turbo data
         model_broadcasts = scan_model_broadcasts(root)
@@ -111,7 +111,7 @@ module RailsAiContext
       # convention_introspector/migration_advisor gem_present? pattern of
       # trusting the lock file, not guessing when it's absent).
       private_class_method def self.turbo_rails_absent?
-        lock_path = File.join(Rails.root.to_s, "Gemfile.lock")
+        lock_path = File.join(rails_app.root.to_s, "Gemfile.lock")
         return false unless File.exist?(lock_path)
 
         content = RailsAiContext::SafeFile.read(lock_path)

--- a/lib/rails_ai_context/tools/get_turbo_map.rb
+++ b/lib/rails_ai_context/tools/get_turbo_map.rb
@@ -142,6 +142,9 @@ module RailsAiContext
           lines << "" << "**Warnings:** #{warnings.size} potential mismatch(es) detected"
         end
 
+        note = unavailable_note(turbo_data)
+        lines << "" << note if note
+
         lines << ""
         lines << "_Use `detail:\"standard\"` for stream wiring, or `stream:\"name\"` to filter._"
 
@@ -246,6 +249,8 @@ module RailsAiContext
         else
           lines << "_Use `detail:\"full\"` for DOM IDs and inline templates, or `stream:\"name\"` to filter._"
         end
+        note = unavailable_note(turbo_data)
+        lines << note if note
 
         text_response(lines.join("\n"))
       end
@@ -375,6 +380,8 @@ module RailsAiContext
             lines << "_No Turbo Streams or Frames detected in this app._"
           end
         end
+        note = unavailable_note(turbo_data)
+        lines << note if note
 
         text_response(lines.join("\n"))
       end

--- a/lib/rails_ai_context/tools/get_turbo_map.rb
+++ b/lib/rails_ai_context/tools/get_turbo_map.rb
@@ -241,6 +241,9 @@ module RailsAiContext
         has_stream_templates = turbo_data.is_a?(Hash) && turbo_data[:turbo_streams]&.any?
 
         if model_broadcasts.empty? && rb_broadcasts.empty? && view_subscriptions.empty? && view_frames.empty? && !has_turbo_stream_responses && !has_stream_templates
+          note = api_only_note("the Turbo Streams/Frames surface")
+          return text_response(note) if note
+
           if filter_label
             lines << "_No Turbo usage matching #{filter_label}. Try without filter to see all Turbo Streams and Frames._"
           else
@@ -374,6 +377,9 @@ module RailsAiContext
         has_stream_templates = turbo_data.is_a?(Hash) && turbo_data[:turbo_streams]&.any?
 
         if model_broadcasts.empty? && rb_broadcasts.empty? && view_subscriptions.empty? && view_frames.empty? && !has_turbo_stream_responses && !has_stream_templates
+          note = api_only_note("the Turbo Streams/Frames surface")
+          return text_response(note) if note
+
           if filter_label
             lines << "_No Turbo usage matching #{filter_label}. Try without filter to see all Turbo Streams and Frames._"
           else

--- a/lib/rails_ai_context/tools/get_view.rb
+++ b/lib/rails_ai_context/tools/get_view.rb
@@ -207,7 +207,7 @@ module RailsAiContext
       end
 
       private_class_method def self.list_layouts(detail)
-        layouts_dir = Rails.root.join("app", "views", "layouts")
+        layouts_dir = rails_app.root.join("app", "views", "layouts")
         return text_response("No app/views/layouts/ directory found.") unless Dir.exist?(layouts_dir)
 
         files = Dir.glob(File.join(layouts_dir, "*")).reject { |f| File.directory?(f) }.sort
@@ -275,7 +275,7 @@ module RailsAiContext
           return text_response("Access denied: #{path} is a sensitive file (secrets/keys/credentials).")
         end
 
-        views_dir = Rails.root.join("app", "views")
+        views_dir = rails_app.root.join("app", "views")
         full_path = views_dir.join(path)
 
         unless File.exist?(full_path)
@@ -391,7 +391,7 @@ module RailsAiContext
         return "(file not found)" if relative_path.nil? || relative_path.to_s.empty?
         return "(access denied)" if sensitive_file?(relative_path.to_s)
 
-        views_dir = Rails.root.join("app", "views")
+        views_dir = rails_app.root.join("app", "views")
         full_path = views_dir.join(relative_path)
         return "(file not found)" unless File.exist?(full_path)
 
@@ -495,7 +495,7 @@ module RailsAiContext
       end
 
       private_class_method def self.read_from_disk(controller:, path:, detail:)
-        views_dir = Rails.root.join("app", "views")
+        views_dir = rails_app.root.join("app", "views")
         return text_response("No app/views directory found.") unless Dir.exist?(views_dir)
 
         if path

--- a/lib/rails_ai_context/tools/get_view.rb
+++ b/lib/rails_ai_context/tools/get_view.rb
@@ -67,6 +67,9 @@ module RailsAiContext
           }
 
           if filtered_templates.empty? && filtered_partials.empty?
+            note = api_only_note("app/views")
+            return text_response(note) if note
+
             all_dirs = (templates.keys + partials.keys).map { |k| k.split("/").first }.uniq.sort
             suggestion = find_closest_match(ctrl_lower, all_dirs)
             hint = suggestion ? " Did you mean '#{suggestion}'?" : ""
@@ -496,7 +499,12 @@ module RailsAiContext
 
       private_class_method def self.read_from_disk(controller:, path:, detail:)
         views_dir = rails_app.root.join("app", "views")
-        return text_response("No app/views directory found.") unless Dir.exist?(views_dir)
+        unless Dir.exist?(views_dir)
+          note = api_only_note("app/views")
+          return text_response(note) if note
+
+          return text_response("No app/views directory found.")
+        end
 
         if path
           return read_view_file(path)

--- a/lib/rails_ai_context/tools/get_view.rb
+++ b/lib/rails_ai_context/tools/get_view.rb
@@ -67,8 +67,14 @@ module RailsAiContext
           }
 
           if filtered_templates.empty? && filtered_partials.empty?
-            note = api_only_note("app/views")
-            return text_response(note) if note
+            # Gate on the UNFILTERED maps, not the filter miss: an API-only
+            # app can still have real views (mailer templates, most
+            # commonly), so a controller filter that simply doesn't match
+            # anything must not be reported as "views don't exist here".
+            if templates.empty? && partials.empty?
+              note = api_only_note("app/views")
+              return text_response(note) if note
+            end
 
             all_dirs = (templates.keys + partials.keys).map { |k| k.split("/").first }.uniq.sort
             suggestion = find_closest_match(ctrl_lower, all_dirs)
@@ -79,6 +85,14 @@ module RailsAiContext
 
           templates = filtered_templates
           partials = filtered_partials
+        end
+
+        # Unfiltered zero-template case: no controller given and the app
+        # genuinely has no views anywhere (as opposed to a filter simply not
+        # matching anything, handled above).
+        if controller.nil? && templates.empty? && partials.empty?
+          note = api_only_note("app/views")
+          return text_response(note) if note
         end
 
         case detail

--- a/lib/rails_ai_context/tools/get_view.rb
+++ b/lib/rails_ai_context/tools/get_view.rb
@@ -31,8 +31,11 @@ module RailsAiContext
       def self.call(controller: nil, path: nil, detail: "standard", server_context: nil)
         data = cached_context[:view_templates]
 
-        # Fall back to reading from disk if introspector not in preset
-        if data.nil? || data[:error]
+        # Fall back to reading from disk if the introspector isn't in the
+        # preset, failed, or - in static tier - never ran at all. The disk
+        # read is real static analysis either way, so it beats rendering an
+        # empty listing from a section that was simply never inspected.
+        if data.nil? || data[:error] || data[:unavailable]
           return read_from_disk(controller: controller, path: path, detail: detail)
         end
 

--- a/lib/rails_ai_context/tools/onboard.rb
+++ b/lib/rails_ai_context/tools/onboard.rb
@@ -376,7 +376,7 @@ module RailsAiContext
           test_cmd = (ctx[:tests].is_a?(Hash) && ctx[:tests][:framework] == "rspec") ? "bundle exec rspec" : "rails test"
           # bin/dev only exists in apps generated with a JS/CSS watcher;
           # recommending it elsewhere sends readers to a missing script.
-          server_cmd = File.exist?(Rails.root.join("bin", "dev")) ? "bin/dev  # or rails server" : "rails server"
+          server_cmd = File.exist?(rails_app.root.join("bin", "dev")) ? "bin/dev  # or rails server" : "rails server"
           [
             "## Getting Started", "",
             "```bash",
@@ -504,7 +504,7 @@ module RailsAiContext
 
           # Fallback: check for Dockerfile/Procfile directly
           unless has_content
-            root = Rails.root.to_s
+            root = rails_app.root.to_s
             has_dockerfile = File.exist?(File.join(root, "Dockerfile")) || File.exist?(File.join(root, "Dockerfile.dev"))
             has_procfile = File.exist?(File.join(root, "Procfile")) || File.exist?(File.join(root, "Procfile.dev"))
             has_ci = Dir.exist?(File.join(root, ".github", "workflows")) || File.exist?(File.join(root, ".gitlab-ci.yml"))
@@ -676,10 +676,10 @@ module RailsAiContext
         end
 
         def extract_service_names
-          services_dir = File.join(Rails.root, "app", "services")
+          services_dir = File.join(rails_app.root, "app", "services")
           return [] unless Dir.exist?(services_dir)
 
-          real_root = File.realpath(Rails.root).to_s
+          real_root = File.realpath(rails_app.root).to_s
           safe_glob(services_dir, "**/*.rb", real_root).filter_map do |path|
             name = File.basename(path, ".rb").camelize
             name unless name == "ApplicationService" || name == "BaseService"

--- a/lib/rails_ai_context/tools/performance_check.rb
+++ b/lib/rails_ai_context/tools/performance_check.rb
@@ -34,6 +34,9 @@ module RailsAiContext
       def self.call(model: nil, category: "all", detail: "standard", server_context: nil)
         data = cached_context[:performance]
 
+        note = unavailable_note(data)
+        return text_response(note) if note
+
         unless data.is_a?(Hash) && !data[:error]
           return text_response("No performance data available. Ensure :performance introspector is enabled.")
         end

--- a/lib/rails_ai_context/tools/query.rb
+++ b/lib/rails_ai_context/tools/query.rb
@@ -130,7 +130,7 @@ module RailsAiContext
       def self.call(sql: nil, limit: nil, format: "table", explain: false, server_context: nil, **_extra)
         set_call_params(sql: sql&.truncate(60))
         # ── Environment guard ───────────────────────────────────────
-        unless config.allow_query_in_production || !Rails.env.production?
+        unless config.allow_query_in_production || rails_env_name != "production"
           return text_response(
             "rails_query is disabled in production for data privacy. " \
             "Set config.allow_query_in_production = true to override."

--- a/lib/rails_ai_context/tools/read_logs.rb
+++ b/lib/rails_ai_context/tools/read_logs.rb
@@ -108,7 +108,7 @@ module RailsAiContext
         available = available_log_files
         unless path
           msg = if available.any?
-            "Log file '#{file || "#{Rails.env}.log"}' not found.\nAvailable log files: #{available.join(', ')}"
+            "Log file '#{file || "#{rails_env_name}.log"}' not found.\nAvailable log files: #{available.join(', ')}"
           else
             "No log files found in log/. Your app may log to stdout (common in Docker/container environments)."
           end
@@ -167,7 +167,7 @@ module RailsAiContext
       # ── Log file resolution ─────────────────────────────────────────
 
       private_class_method def self.resolve_log_file(file_name)
-        root = Rails.root.to_s
+        root = rails_app.root.to_s
 
         if file_name
           # Strip .log suffix if provided, then re-add; sanitize null bytes and path separators
@@ -175,7 +175,7 @@ module RailsAiContext
           name = File.basename(name) # Prevent directory traversal via slashes
           path = File.join(root, "log", "#{name}.log")
         else
-          path = File.join(root, "log", "#{Rails.env}.log")
+          path = File.join(root, "log", "#{rails_env_name}.log")
         end
 
         # Path traversal protection: separator-aware containment so a sibling
@@ -293,7 +293,7 @@ module RailsAiContext
       # ── Available log files ─────────────────────────────────────────
 
       private_class_method def self.available_log_files
-        log_dir = File.join(Rails.root.to_s, "log")
+        log_dir = File.join(rails_app.root.to_s, "log")
         return [] unless Dir.exist?(log_dir)
         Dir.glob(File.join(log_dir, "*.log"))
           .map { |f| File.basename(f) }

--- a/lib/rails_ai_context/tools/review_changes.rb
+++ b/lib/rails_ai_context/tools/review_changes.rb
@@ -30,7 +30,7 @@ module RailsAiContext
       MAX_DIFF_LINES_PER_FILE = 30
 
       def self.call(ref: "HEAD", files: nil, server_context: nil)
-        root = Rails.root.to_s
+        root = rails_app.root.to_s
 
         # Verify git is available. Child stderr goes to File::NULL so git's own
         # "fatal: not a git repository" noise never reaches the server terminal;

--- a/lib/rails_ai_context/tools/runtime_info.rb
+++ b/lib/rails_ai_context/tools/runtime_info.rb
@@ -193,7 +193,7 @@ module RailsAiContext
         end
 
         def gather_pending_migrations
-          migrate_dir = File.join(Rails.root, "db/migrate")
+          migrate_dir = File.join(rails_app.root, "db/migrate")
           pending = RailsAiContext::MigrationStatus.pending(migrate_dir)
           return nil unless pending
 

--- a/lib/rails_ai_context/tools/search_code.rb
+++ b/lib/rails_ai_context/tools/search_code.rb
@@ -69,7 +69,7 @@ module RailsAiContext
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(pattern:, path: nil, file_type: nil, match_type: "any", exact_match: false, exclude_tests: false, group_by_file: false, offset: 0, limit: nil, context_lines: 2, server_context: nil) # rubocop:disable Metrics
-        root = Rails.root.to_s
+        root = rails_app.root.to_s
         original_pattern = pattern
 
         # Reject empty or whitespace-only patterns

--- a/lib/rails_ai_context/tools/search_docs.rb
+++ b/lib/rails_ai_context/tools/search_docs.rb
@@ -127,7 +127,7 @@ module RailsAiContext
         end
 
         def detect_rails_branch
-          lock_path = Rails.root.join("Gemfile.lock").to_s
+          lock_path = rails_app.root.join("Gemfile.lock").to_s
           return "main" unless File.exist?(lock_path)
 
           content = RailsAiContext::SafeFile.read(lock_path)
@@ -209,7 +209,7 @@ module RailsAiContext
         end
 
         def fetch_content(topic, branch, url)
-          cache_dir = Rails.root.join("tmp", "rails-ai-context", "docs")
+          cache_dir = rails_app.root.join("tmp", "rails-ai-context", "docs")
           FileUtils.mkdir_p(cache_dir)
 
           cache_key = "#{topic['id']}_#{branch}.md"

--- a/lib/rails_ai_context/tools/security_scan.rb
+++ b/lib/rails_ai_context/tools/security_scan.rb
@@ -68,7 +68,7 @@ module RailsAiContext
         min_confidence = CONFIDENCE_MAP[confidence] || 2
 
         options = {
-          app_path: Rails.root.to_s,
+          app_path: rails_app.root.to_s,
           quiet: true,
           report_progress: false,
           min_confidence: min_confidence,
@@ -90,7 +90,7 @@ module RailsAiContext
 
         if files&.any?
           # Check if specified files exist
-          missing = files.select { |f| !File.exist?(Rails.root.join(f)) }
+          missing = files.select { |f| !File.exist?(rails_app.root.join(f)) }
           if missing.any? && missing.size == files.size
             return text_response("File(s) not found: #{missing.join(', ')}. Provide paths relative to Rails root.")
           end

--- a/lib/rails_ai_context/tools/validate.rb
+++ b/lib/rails_ai_context/tools/validate.rb
@@ -65,7 +65,7 @@ module RailsAiContext
             next
           end
 
-          full_path = Rails.root.join(file)
+          full_path = rails_app.root.join(file)
 
           unless File.exist?(full_path)
             suggestion = find_file_suggestion(file)
@@ -77,7 +77,7 @@ module RailsAiContext
 
           begin
             real = File.realpath(full_path).to_s
-            rails_root_real = File.realpath(Rails.root).to_s
+            rails_root_real = File.realpath(rails_app.root).to_s
             # Separator-aware containment - matches the v5.8.1-r2 hardening in
             # get_view.rb / vfs.rb. Without `+ File::SEPARATOR`, a sibling-dir
             # like `/app/rails_evil/...` would prefix-match a Rails root at
@@ -157,12 +157,12 @@ module RailsAiContext
         %w[app/models app/controllers app/views app/helpers app/jobs app/mailers
            app/services app/channels lib config].each do |dir|
           candidate = File.join(dir, basename)
-          return candidate if File.exist?(Rails.root.join(candidate))
+          return candidate if File.exist?(rails_app.root.join(candidate))
         end
 
         # Broader recursive search
-        matches = Dir.glob(File.join(Rails.root, "app", "**", basename)).first(1)
-        return matches.first.sub("#{Rails.root}/", "") if matches.any?
+        matches = Dir.glob(File.join(rails_app.root, "app", "**", basename)).first(1)
+        return matches.first.sub("#{rails_app.root}/", "") if matches.any?
 
         nil
       rescue => e
@@ -542,7 +542,7 @@ module RailsAiContext
           ref = rc[:name]
           next if ref.include?("@") || ref.include?("#") || ref.include?("{")
           possible = resolve_partial_paths(file, ref)
-          unless possible.any? { |p| File.exist?(File.join(Rails.root, "app", "views", p)) }
+          unless possible.any? { |p| File.exist?(File.join(rails_app.root, "app", "views", p)) }
             warnings << "render \"#{ref}\" - partial not found (checked: #{possible.first(2).join(', ')})"
           end
         end
@@ -555,7 +555,7 @@ module RailsAiContext
         content.scan(/render\s+(?:partial:\s*)?["']([^"']+)["']/).flatten.uniq.each do |ref|
           next if ref.include?("@") || ref.include?("#") || ref.include?("{")
           possible = resolve_partial_paths(file, ref)
-          unless possible.any? { |p| File.exist?(File.join(Rails.root, "app", "views", p)) }
+          unless possible.any? { |p| File.exist?(File.join(rails_app.root, "app", "views", p)) }
             warnings << "render \"#{ref}\" - partial not found (checked: #{possible.first(2).join(', ')})"
           end
         end
@@ -773,7 +773,7 @@ module RailsAiContext
         # Build set of known methods (instance + from source content)
         known = Set.new(model_data[:instance_methods] || [])
         # Also check the file source for private methods
-        source = RailsAiContext::SafeFile.read(Rails.root.join(file))
+        source = RailsAiContext::SafeFile.read(rails_app.root.join(file))
         source&.scan(/\bdef\s+(\w+[?!]?)/)&.each { |m| known << m[0] }
 
         # Skip check if model has concerns (method may be in concern)
@@ -952,7 +952,7 @@ module RailsAiContext
         return warnings unless ctrl_data
 
         # Get all instance variables set across all actions
-        source_path = Rails.root.join("app", "controllers", "#{ctrl_class.underscore}.rb")
+        source_path = rails_app.root.join("app", "controllers", "#{ctrl_class.underscore}.rb")
         return warnings unless File.exist?(source_path)
 
         ctrl_source = RailsAiContext::SafeFile.read(source_path)
@@ -993,7 +993,7 @@ module RailsAiContext
         return warnings if broadcasts.empty?
 
         # Scan views for turbo_stream_from subscriptions
-        views_dir = Rails.root.join("app", "views")
+        views_dir = rails_app.root.join("app", "views")
         return warnings unless Dir.exist?(views_dir)
 
         subscriptions = Set.new
@@ -1031,7 +1031,7 @@ module RailsAiContext
         # and that a .turbo_stream.erb template exists
         base = file.sub(/\.html\.erb$/, "")
         turbo_template = "#{base}.turbo_stream.erb"
-        turbo_path = Rails.root.join(turbo_template)
+        turbo_path = rails_app.root.join(turbo_template)
 
         if content.include?("turbo_stream_from") && !File.exist?(turbo_path)
           # Only warn if the controller likely needs it
@@ -1105,7 +1105,7 @@ module RailsAiContext
         return [] unless brakeman_available?
 
         tracker = Brakeman.run(
-          app_path: Rails.root.to_s,
+          app_path: rails_app.root.to_s,
           quiet: true,
           report_progress: false,
           print_report: false

--- a/rails-ai-context.gemspec
+++ b/rails-ai-context.gemspec
@@ -65,8 +65,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "zeitwerk", "~> 2.6"         # Autoloading
 
   # AST foundation (Phase 1: Ground Truth Engine)
-  spec.add_dependency "prism", ">= 0.28"           # Ruby parser - stdlib in 3.3+, gem for 3.1-3.2
-  spec.add_dependency "concurrent-ruby", ">= 1.2"  # Thread-safe AST cache via Concurrent::Map
+  spec.add_dependency "prism", ">= 0.28", "< 2.0"           # Ruby parser - stdlib in 3.3+, gem for 3.1-3.2
+  spec.add_dependency "concurrent-ruby", ">= 1.2", "< 3.0"  # Thread-safe AST cache via Concurrent::Map
 
   # Dev dependencies
   spec.add_development_dependency "rspec", "~> 3.13"

--- a/spec/cli_smoke_spec.rb
+++ b/spec/cli_smoke_spec.rb
@@ -15,4 +15,11 @@ RSpec.describe "CLI smoke: every tool executes", type: :smoke do
       expect { runner.run }.not_to raise_error
     end
   end
+
+  it "documents the static-tier flags" do
+    help = `ruby #{File.expand_path('../exe/rails-ai-context', __dir__)} help serve 2>&1`
+    expect(help).to include("--no-boot")
+    expect(help).to include("--app-path")
+    expect(help).to include("--environment")
+  end
 end

--- a/spec/e2e/boot_resilience_spec.rb
+++ b/spec/e2e/boot_resilience_spec.rb
@@ -27,13 +27,15 @@ RSpec.describe "E2E: boot resilience", type: :e2e do
   end
 
   describe "app that raises during boot" do
-    it "tool command fails with a friendly diagnostic, not a Thor backtrace" do
+    it "tool command falls back to static analysis instead of dying" do
       with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING: REDIS_URL is not set"\n)) do
         result = @cli.cli_tool("schema")
-        expect(result.exit_status).to eq(1), result.to_s
-        expect(result.stderr).to include("failed to boot")
+        expect(result.exit_status).to eq(0), result.to_s
+        expect(result.stderr).to include("App boot failed")
         expect(result.stderr).to include("FATAL_ENV_MISSING")
+        expect(result.stderr).to include("static tier active")
         expect(result.stderr).not_to include("thor")
+        expect(result.stdout).not_to be_empty
       end
     end
 
@@ -45,12 +47,12 @@ RSpec.describe "E2E: boot resilience", type: :e2e do
       end
     end
 
-    it "handles a syntax error in an initializer" do
+    it "falls back to static analysis on a syntax error in an initializer" do
       with_initializer("zz_broken_syntax.rb", "def broken(\n") do
         result = @cli.cli_tool("schema")
-        expect(result.exit_status).to eq(1), result.to_s
-        expect(result.stderr).to include("failed to boot")
+        expect(result.exit_status).to eq(0), result.to_s
         expect(result.stderr).to match(/SyntaxError|broken_syntax/)
+        expect(result.stderr).to include("static tier active")
       end
     end
   end
@@ -129,10 +131,10 @@ RSpec.describe "E2E: boot resilience", type: :e2e do
   end
 
   describe "app that hangs during boot" do
-    it "fails with a friendly timeout message naming the configured limit, not the raw Timeout::Error" do
+    it "falls back to static analysis on boot timeout, naming the limit" do
       with_initializer("zz_slow.rb", "sleep 5\n") do
         result = @cli.cli_tool("schema", extra_env: { "RAILS_AI_CONTEXT_BOOT_TIMEOUT" => "2" })
-        expect(result.exit_status).to eq(1), result.to_s
+        expect(result.exit_status).to eq(0), result.to_s
         expect(result.stderr).to include("did not finish within 2s")
         expect(result.stderr).to include("RAILS_AI_CONTEXT_BOOT_TIMEOUT")
         expect(result.stderr).not_to include("Timeout::Error: execution expired")

--- a/spec/e2e/shapes_spec.rb
+++ b/spec/e2e/shapes_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require_relative "e2e_helper"
+require "open3"
+
+# Nonstandard app shapes: packwerk packs/, in-repo engines/, Rails 8
+# multi-database schema dumps, Mongoid apps, and auto_mount from a user
+# initializer. One shared app, mutated per example group and cleaned up,
+# plus a bare fake directory for the Mongoid case (static tier needs no
+# bootable app at all).
+RSpec.describe "E2E: app shapes", type: :e2e do
+  before(:all) do
+    @builder = E2E::TestAppBuilder.new(
+      parent_dir: E2E.root,
+      name: "shapes_app",
+      install_path: :in_gemfile
+    ).build!
+    @cli = E2E::CliRunner.new(@builder)
+  end
+
+  describe "packs and engines code discovery (static tier)" do
+    before(:all) do
+      pack_models = File.join(@builder.app_path, "packs", "billing", "app", "models")
+      engine_controllers = File.join(@builder.app_path, "engines", "store", "app", "controllers", "store")
+      FileUtils.mkdir_p(pack_models)
+      FileUtils.mkdir_p(engine_controllers)
+      File.write(File.join(pack_models, "invoice.rb"),
+                 "class Invoice < ApplicationRecord\n  belongs_to :customer\nend\n")
+      File.write(File.join(engine_controllers, "orders_controller.rb"),
+                 "class Store::OrdersController < ActionController::Base\n  def index; end\nend\n")
+    end
+
+    after(:all) do
+      FileUtils.rm_rf(File.join(@builder.app_path, "packs"))
+      FileUtils.rm_rf(File.join(@builder.app_path, "engines"))
+    end
+
+    it "finds a packs model" do
+      # model_details takes the model name via --model (see
+      # spec/e2e/tool_edge_cases_spec.rb), not a bare positional arg.
+      result = @cli.cli_tool("model_details", [ "--model", "Invoice", "--no-boot" ])
+      expect(result.exit_status).to eq(0), result.to_s
+      expect(result.stdout).to include("Invoice")
+      expect(result.stdout).to include("customer")
+    end
+
+    it "finds an in-repo engine controller" do
+      result = @cli.cli_tool("controllers", [ "--no-boot" ])
+      expect(result.exit_status).to eq(0), result.to_s
+      expect(result.stdout).to include("Store::OrdersController")
+    end
+  end
+
+  describe "multi-database schema dumps" do
+    before(:all) do
+      File.write(File.join(@builder.app_path, "db", "queue_schema.rb"), <<~RUBY)
+        ActiveRecord::Schema[7.2].define(version: 1) do
+          create_table "solid_queue_jobs" do |t|
+            t.string "queue_name", null: false
+          end
+        end
+      RUBY
+    end
+
+    after(:all) do
+      FileUtils.rm_f(File.join(@builder.app_path, "db", "queue_schema.rb"))
+    end
+
+    it "reports the queue database alongside the primary schema" do
+      result = @cli.cli_tool("schema", [ "--no-boot" ])
+      expect(result.exit_status).to eq(0), result.to_s
+      expect(result.stdout).to include("Secondary databases")
+      expect(result.stdout).to include("queue")
+      expect(result.stdout).to include("solid_queue_jobs")
+    end
+  end
+
+  describe "Mongoid app (bare directory, --app-path, no boot possible)" do
+    before(:all) do
+      @mongoid_dir = Dir.mktmpdir("mongoid_app")
+      FileUtils.mkdir_p(File.join(@mongoid_dir, "config"))
+      FileUtils.mkdir_p(File.join(@mongoid_dir, "app", "models"))
+      File.write(File.join(@mongoid_dir, "config", "mongoid.yml"), "development:\n  clients: {}\n")
+      File.write(File.join(@mongoid_dir, "app", "models", "customer.rb"), <<~RUBY)
+        class Customer
+          include Mongoid::Document
+          field :name, type: String
+          embeds_many :orders
+        end
+      RUBY
+    end
+
+    after(:all) { FileUtils.rm_rf(@mongoid_dir) }
+
+    # CliRunner#run always chdirs into the *primary* test app before running
+    # a command, so it can't target a second, unrelated directory. Build the
+    # same command line CliRunner would build and run it directly via Open3
+    # from outside both app directories - the only way to prove --app-path
+    # (not an ambient cwd match) resolves this bare Mongoid dir. cli_prefix
+    # is private (see spec/e2e/static_tier_spec.rb's "--app-path from
+    # outside the app directory" example for the same pattern). Flag order
+    # matters: --app-path/--no-boot must precede the tool name because
+    # `stop_on_unknown_option! :tool` only starts passing tokens straight
+    # through as tool args once it hits the first positional (the name).
+    def run_against_mongoid(*tool_args)
+      cmd = @cli.send(:cli_prefix) + [ "tool", "--app-path", @mongoid_dir, "--no-boot", *tool_args ]
+      stdout, stderr, status = Open3.capture3(@builder.env, *cmd, chdir: Dir.tmpdir)
+      [ stdout, stderr, status ]
+    end
+
+    it "schema reports the honest Mongoid signal" do
+      stdout, stderr, status = run_against_mongoid("schema")
+      expect(status.exitstatus).to eq(0), stderr
+      expect(stdout).to include("UNAVAILABLE")
+      expect(stdout).to include("Mongoid")
+    end
+
+    it "model details show fields and embeds" do
+      stdout, stderr, status = run_against_mongoid("model_details", "--model", "Customer")
+      expect(status.exitstatus).to eq(0), stderr
+      expect(stdout).to include("name")
+      expect(stdout).to match(/embeds_many|orders/)
+    end
+  end
+
+  describe "auto_mount from a user initializer" do
+    it "registers the middleware when config.auto_mount = true" do
+      initializer = File.join(@builder.app_path, "config", "initializers", "zz_auto_mount.rb")
+      File.write(initializer, <<~RUBY)
+        RailsAiContext.configure { |config| config.auto_mount = true }
+      RUBY
+      begin
+        stdout, stderr, status = Open3.capture3(
+          @builder.env, "bin/rails", "middleware", chdir: @builder.app_path
+        )
+        expect(status.exitstatus).to eq(0), stderr
+        expect(stdout).to include("RailsAiContext::Middleware")
+      ensure
+        File.delete(initializer) if File.exist?(initializer)
+      end
+    end
+  end
+end

--- a/spec/e2e/static_tier_spec.rb
+++ b/spec/e2e/static_tier_spec.rb
@@ -114,6 +114,21 @@ RSpec.describe "E2E: static tier", type: :e2e do
     end
   end
 
+  describe "syntax error in one model file" do
+    it "costs exactly that model, not the models section" do
+      broken = File.join(@builder.app_path, "app", "models", "zz_broken.rb")
+      File.write(broken, "class ZzBroken < ApplicationRecord\n  def oops(\nend\n")
+      begin
+        result = @cli.cli_tool("model_details", [ "--model", "Post", "--no-boot" ])
+        expect(result.exit_status).to eq(0), result.to_s
+        expect(result.stdout).to include("Post")
+        expect(result.stdout).not_to include("ZzBroken")
+      ensure
+        File.delete(broken) if File.exist?(broken)
+      end
+    end
+  end
+
   describe "--app-path from outside the app directory" do
     it "resolves the app root from a foreign cwd" do
       # CliRunner#run always chdirs into the app directory before running a

--- a/spec/e2e/static_tier_spec.rb
+++ b/spec/e2e/static_tier_spec.rb
@@ -64,6 +64,15 @@ RSpec.describe "E2E: static tier", type: :e2e do
         expect(result.stdout).to match(/UNAVAILABLE|not booted|static/i)
       end
     end
+
+    it "marks gems unavailable honestly instead of claiming none exist" do
+      with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING"\n)) do
+        result = @cli.cli_tool("gems")
+        expect(result.exit_status).to eq(0), result.to_s
+        expect(result.stdout).to include("UNAVAILABLE")
+        expect(result.stdout).not_to include("No notable gems")
+      end
+    end
   end
 
   describe "broken-boot app over MCP stdio" do

--- a/spec/e2e/static_tier_spec.rb
+++ b/spec/e2e/static_tier_spec.rb
@@ -48,10 +48,12 @@ RSpec.describe "E2E: static tier", type: :e2e do
         result = @cli.cli_tool("schema")
         expect(result.exit_status).to eq(0), result.to_s
         # Default detail level ("standard") headlines with "# Schema (N
-        # table(s), ...)" - it doesn't surface the "static_parse" adapter
-        # marker or a "schema.rb" filename (those only appear at other detail
-        # levels), so match what this response actually guarantees.
-        expect(result.stdout).to match(/schema|static_parse|tables?/i)
+        # table(s), ...)" - a shape only a successful parse produces. The
+        # tool's own failure strings ("Schema introspection not available...")
+        # never match this, so a regression that breaks static schema parsing
+        # fails this example instead of sliding through on a stray keyword.
+        expect(result.stdout).to match(/# Schema \(\d+ tables?/i)
+        expect(result.stdout).to include("posts")
       end
     end
 

--- a/spec/e2e/static_tier_spec.rb
+++ b/spec/e2e/static_tier_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require_relative "e2e_helper"
+
+# The static tier headline: an app that cannot boot still answers real
+# questions - routes from routes.rb, schema from schema.rb, controllers from
+# source - over both the CLI and MCP stdio, with an honest banner. A
+# dedicated app because these examples mutate config/initializers and
+# config/routes.rb.
+RSpec.describe "E2E: static tier", type: :e2e do
+  before(:all) do
+    @builder = E2E::TestAppBuilder.new(
+      parent_dir: E2E.root,
+      name: "static_tier_app",
+      install_path: :in_gemfile
+    ).build!
+    @cli = E2E::CliRunner.new(@builder)
+    @initializer_dir = File.join(@builder.app_path, "config", "initializers")
+
+    routes_path = File.join(@builder.app_path, "config", "routes.rb")
+    routes = File.read(routes_path)
+    File.write(routes_path, routes.sub(
+      "Rails.application.routes.draw do",
+      %(Rails.application.routes.draw do\n  get "static_probe", to: "probe#show"\n)
+    ))
+  end
+
+  def with_initializer(name, content)
+    path = File.join(@initializer_dir, name)
+    File.write(path, content)
+    yield
+  ensure
+    File.delete(path) if File.exist?(path)
+  end
+
+  describe "broken-boot app over the CLI" do
+    it "answers routes from config/routes.rb with the static banner" do
+      with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING"\n)) do
+        result = @cli.cli_tool("routes")
+        expect(result.exit_status).to eq(0), result.to_s
+        expect(result.stdout).to include("static_probe")
+        expect(result.stdout).to include("static analysis")
+      end
+    end
+
+    it "answers schema from db/schema.rb" do
+      with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING"\n)) do
+        result = @cli.cli_tool("schema")
+        expect(result.exit_status).to eq(0), result.to_s
+        # Default detail level ("standard") headlines with "# Schema (N
+        # table(s), ...)" - it doesn't surface the "static_parse" adapter
+        # marker or a "schema.rb" filename (those only appear at other detail
+        # levels), so match what this response actually guarantees.
+        expect(result.stdout).to match(/schema|static_parse|tables?/i)
+      end
+    end
+
+    it "marks runtime-only tools unavailable rather than crashing" do
+      with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING"\n)) do
+        result = @cli.cli_tool("runtime_info")
+        expect(result.exit_status).to eq(0), result.to_s
+        expect(result.stdout).to match(/UNAVAILABLE|not booted|static/i)
+      end
+    end
+  end
+
+  describe "broken-boot app over MCP stdio" do
+    it "serves the handshake, tool list, and static tool calls" do
+      with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING"\n)) do
+        client = E2E::McpStdioClient.new(@builder).start!
+        begin
+          response = client.request("initialize", {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "e2e-harness", version: "0.0.0" }
+          })
+          expect(response["result"]).to be_a(Hash), "handshake failed: #{response.inspect}"
+          client.notify("notifications/initialized")
+
+          tools = client.request("tools/list")
+          expect(tools.dig("result", "tools")).to be_an(Array)
+
+          call = client.request("tools/call", {
+            name: "rails_get_routes", arguments: {}
+          })
+          expect(call.dig("result", "isError")).not_to eq(true), call.inspect
+          text = call.dig("result", "content", 0, "text").to_s
+          expect(text).to include("static_probe")
+          expect(text).to include("static analysis")
+        ensure
+          client.stop!
+        end
+      end
+    end
+  end
+
+  describe "healthy app with --no-boot" do
+    it "serves static answers without booting" do
+      result = @cli.cli_tool("routes", [ "--no-boot" ])
+      expect(result.exit_status).to eq(0), result.to_s
+      expect(result.stderr).to include("static mode requested with --no-boot")
+      expect(result.stdout).to include("static_probe")
+    end
+  end
+
+  describe "--app-path from outside the app directory" do
+    it "resolves the app root from a foreign cwd" do
+      # CliRunner#run always chdirs into the app directory before running a
+      # command, so it cannot exercise --app-path resolving the app root from
+      # somewhere else. Build the same command line CliRunner would build and
+      # run it directly via Open3 with a cwd outside the app entirely - the
+      # only way to prove --app-path (not an ambient cwd match) is what finds
+      # the app. Flag order matters: `stop_on_unknown_option! :tool` passes
+      # anything after the positional tool name straight through as tool args,
+      # so --app-path must precede the "routes" tool name.
+      cmd = @cli.send(:cli_prefix) + [
+        "tool", "--app-path", @builder.app_path, "--no-boot", "routes"
+      ]
+      stdout, stderr, status = Open3.capture3(@builder.env, *cmd, chdir: Dir.tmpdir)
+      expect(status.exitstatus).to eq(0), "cmd=#{cmd.inspect}\nstdout:\n#{stdout}\nstderr:\n#{stderr}"
+      expect(stdout).to include("static_probe")
+    end
+  end
+end

--- a/spec/lib/rails_ai_context/app_kind_spec.rb
+++ b/spec/lib/rails_ai_context/app_kind_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+
+RSpec.describe RailsAiContext::AppKind do
+  it "detects Mongoid via config/mongoid.yml" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "config"))
+      File.write(File.join(dir, "config", "mongoid.yml"), "development:\n  clients: {}\n")
+      expect(described_class.mongoid?(dir)).to be(true)
+    end
+  end
+
+  it "detects Mongoid via Gemfile.lock" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "Gemfile.lock"), "GEM\n  specs:\n    mongoid (9.0.4)\n")
+      expect(described_class.mongoid?(dir)).to be(true)
+    end
+  end
+
+  it "is false for an ActiveRecord app" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "Gemfile.lock"), "GEM\n  specs:\n    pg (1.5.6)\n")
+      expect(described_class.mongoid?(dir)).to be(false)
+    end
+  end
+
+  it "does not match gems whose name merely contains mongoid" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "Gemfile.lock"), "GEM\n  specs:\n    mongoid_paranoia (1.0.0)\n")
+      expect(described_class.mongoid?(dir)).to be(false)
+    end
+  end
+end

--- a/spec/lib/rails_ai_context/confidence_spec.rb
+++ b/spec/lib/rails_ai_context/confidence_spec.rb
@@ -101,4 +101,23 @@ RSpec.describe RailsAiContext::Confidence do
       expect(described_class.static_node?(parse_expr("-> { x }"))).to be false
     end
   end
+
+  describe "tier vocabulary" do
+    it "exposes the STATIC tag" do
+      expect(described_class::STATIC).to eq("[STATIC]")
+    end
+
+    it "exposes the bare UNAVAILABLE tag" do
+      expect(described_class::UNAVAILABLE).to eq("[UNAVAILABLE]")
+    end
+
+    it "builds a reasoned UNAVAILABLE tag" do
+      expect(described_class.unavailable("requires a booted Rails app"))
+        .to eq("[UNAVAILABLE: requires a booted Rails app]")
+    end
+
+    it "collapses a multi-line reason to its first line" do
+      expect(described_class.unavailable("boom\nbacktrace")).to eq("[UNAVAILABLE: boom]")
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/configuration_yaml_spec.rb
+++ b/spec/lib/rails_ai_context/configuration_yaml_spec.rb
@@ -268,6 +268,23 @@ RSpec.describe RailsAiContext::Configuration, "YAML loading" do
         expect(config.introspectors).to eq(%i[schema models routes])
       end
     end
+
+    it "loads extra_app_paths as an array of strings" do
+      Dir.mktmpdir do |dir|
+        yaml_path = File.join(dir, ".rails-ai-context.yml")
+        File.write(yaml_path, YAML.dump({
+          "extra_app_paths" => %w[src vendor/internal]
+        }))
+
+        RailsAiContext::Configuration.load_from_yaml(yaml_path)
+
+        expect(config.extra_app_paths).to eq(%w[src vendor/internal])
+      end
+    end
+
+    it "defaults extra_app_paths to an empty array" do
+      expect(RailsAiContext::Configuration.new.extra_app_paths).to eq([])
+    end
   end
 
   describe ".auto_load!" do

--- a/spec/lib/rails_ai_context/engine_spec.rb
+++ b/spec/lib/rails_ai_context/engine_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe RailsAiContext::Engine do
     it "registers the middleware initializer" do
       expect(initializer_names).to include("rails_ai_context.middleware")
     end
+
+    it "mounts the middleware after user initializers have run" do
+      initializer = RailsAiContext::Engine.initializers.find { |i| i.name == "rails_ai_context.middleware" }
+      expect(initializer).not_to be_nil
+      expect(initializer.after).to eq(:load_config_initializers)
+    end
   end
 
   describe "configuration integration" do

--- a/spec/lib/rails_ai_context/introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspector_spec.rb
@@ -99,6 +99,60 @@ RSpec.describe RailsAiContext::Introspector do
     end
   end
 
+  describe "static tier dispatch" do
+    let(:static_app) { RailsAiContext::StaticApp.new(Dir.pwd) }
+
+    around do |example|
+      RailsAiContext.tier = :static
+      RailsAiContext.static_reason = "RuntimeError: FATAL_ENV_MISSING"
+      example.run
+    ensure
+      RailsAiContext.tier = :runtime
+      RailsAiContext.static_reason = nil
+    end
+
+    it "routes sections through static_call when the introspector provides one" do
+      static_capable = Class.new do
+        def initialize(app); end
+
+        def call
+          raise "runtime path must not run in static tier"
+        end
+
+        def static_call
+          { total: 7, confidence: RailsAiContext::Confidence::STATIC }
+        end
+      end
+      stub_const("RailsAiContext::Introspector::INTROSPECTOR_MAP",
+                 RailsAiContext::Introspector::INTROSPECTOR_MAP.merge(schema: static_capable))
+
+      result = RailsAiContext::Introspector.new(static_app).call
+      expect(result[:schema]).to eq(total: 7, confidence: "[STATIC]")
+    end
+
+    it "marks sections without a static path unavailable, with the boot reason" do
+      result = RailsAiContext::Introspector.new(static_app).call
+      expect(result[:jobs]).to eq(
+        unavailable: "requires a booted Rails app (RuntimeError: FATAL_ENV_MISSING)"
+      )
+    end
+
+    it "does not count unavailable sections as warnings" do
+      result = RailsAiContext::Introspector.new(static_app).call
+      Array(result[:_warnings]).each do |w|
+        expect(w[:error]).not_to include("requires a booted Rails app")
+      end
+    end
+
+    it "builds base fields without Rails" do
+      result = RailsAiContext::Introspector.new(static_app).call
+      expect(result[:app_name]).to eq(File.basename(Dir.pwd))
+      expect(result[:rails_version]).to include("UNAVAILABLE")
+      expect(result[:environment]).to be_a(String)
+      expect(result[:generated_at]).to match(/\d{4}-\d{2}-\d{2}T/)
+    end
+  end
+
   describe "INTROSPECTOR_MAP / PRESETS drift guard" do
     it "every PRESETS entry is registered in INTROSPECTOR_MAP" do
       RailsAiContext::Configuration::PRESETS.each do |preset_name, names|

--- a/spec/lib/rails_ai_context/introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspector_spec.rb
@@ -130,6 +130,21 @@ RSpec.describe RailsAiContext::Introspector do
       expect(result[:schema]).to eq(total: 7, confidence: "[STATIC]")
     end
 
+    it "isolates a raising static_call to its own section" do
+      exploding = Class.new do
+        def initialize(app); end
+
+        def static_call
+          raise "static boom"
+        end
+      end
+      stub_const("RailsAiContext::Introspector::INTROSPECTOR_MAP",
+                 RailsAiContext::Introspector::INTROSPECTOR_MAP.merge(schema: exploding))
+
+      result = RailsAiContext::Introspector.new(static_app).call
+      expect(result[:schema]).to eq(error: "static boom")
+    end
+
     it "marks sections without a static path unavailable, with the boot reason" do
       result = RailsAiContext::Introspector.new(static_app).call
       expect(result[:jobs]).to eq(

--- a/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
@@ -301,4 +301,45 @@ RSpec.describe RailsAiContext::Introspectors::ControllerIntrospector do
       expect(result[:nested]).to eq({ "address" => %w[line1 line2] })
     end
   end
+
+  describe "#static_call" do
+    it "extracts controllers purely from source files" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "controllers", "api"))
+        File.write(File.join(dir, "app", "controllers", "widgets_controller.rb"), <<~RUBY)
+          class WidgetsController < ApplicationController
+            before_action :set_widget, only: [:show]
+
+            def index; end
+
+            def show; end
+
+            private
+
+            def set_widget; end
+          end
+        RUBY
+        File.write(File.join(dir, "app", "controllers", "api", "pings_controller.rb"), <<~RUBY)
+          class Api::PingsController < ActionController::API
+            def show; end
+          end
+        RUBY
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        widgets = result[:controllers]["WidgetsController"]
+        expect(widgets[:actions]).to eq(%w[index show])
+        expect(widgets[:parent_class]).to eq("ApplicationController")
+        expect(widgets[:confidence]).to eq("[STATIC]")
+        expect(result[:controllers]["Api::PingsController"][:api_controller]).to be(true)
+      end
+    end
+
+    it "returns an empty controllers hash when the directory is missing" do
+      Dir.mktmpdir do |dir|
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+        expect(result[:controllers]).to eq({})
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
@@ -342,5 +342,20 @@ RSpec.describe RailsAiContext::Introspectors::ControllerIntrospector do
         expect(result[:controllers]).to eq({})
       end
     end
+
+    it "discovers controllers in packs and engines directories" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "controllers"))
+        FileUtils.mkdir_p(File.join(dir, "packs", "billing", "app", "controllers"))
+        File.write(File.join(dir, "app", "controllers", "users_controller.rb"),
+                   "class UsersController < ApplicationController\n  def index; end\nend\n")
+        File.write(File.join(dir, "packs", "billing", "app", "controllers", "invoices_controller.rb"),
+                   "class InvoicesController < ApplicationController\n  def show; end\nend\n")
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+        expect(result[:controllers].keys).to contain_exactly("UsersController", "InvoicesController")
+        expect(result[:controllers]["InvoicesController"][:actions]).to eq([ "show" ])
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "fileutils"
 
 RSpec.describe RailsAiContext::Introspectors::ControllerIntrospector do
   let(:introspector) { described_class.new(Rails.application) }

--- a/spec/lib/rails_ai_context/introspectors/gem_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/gem_introspector_spec.rb
@@ -159,5 +159,11 @@ RSpec.describe RailsAiContext::Introspectors::GemIntrospector do
       expect(entry).not_to be_nil
       expect(entry[:category]).to eq(:monitoring)
     end
+
+    it "ends every note with terminal punctuation" do
+      described_class::NOTABLE_GEMS.each do |gem_name, info|
+        expect(info[:note]).to match(/[.!?)]\z/), "Note for #{gem_name} is missing terminal punctuation: #{info[:note].inspect}"
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_context/introspectors/listeners/mongoid_fields_listener_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/listeners/mongoid_fields_listener_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiContext::Introspectors::Listeners::MongoidFieldsListener do
+  def results_for(source)
+    listener = described_class.new
+    dispatcher = Prism::Dispatcher.new
+    dispatcher.register(listener, :on_call_node_enter)
+    dispatcher.dispatch(Prism.parse(source).value)
+    listener.results
+  end
+
+  it "captures field declarations with types" do
+    results = results_for(<<~RUBY)
+      class User
+        include Mongoid::Document
+        field :name, type: String
+        field :age, type: Integer
+        field :tags
+      end
+    RUBY
+    fields = results.select { |r| r[:macro] == :field }
+    expect(fields.map { |f| f[:args].first }).to eq([ :name, :age, :tags ])
+    expect(fields.first[:options][:type]).to eq("String")
+  end
+
+  it "captures embeds and store_in" do
+    results = results_for(<<~RUBY)
+      class Order
+        embeds_many :line_items
+        embedded_in :customer
+        store_in collection: "legacy_orders"
+      end
+    RUBY
+    expect(results.map { |r| r[:macro] }).to contain_exactly(:embeds_many, :embedded_in, :store_in)
+    store = results.find { |r| r[:macro] == :store_in }
+    expect(store[:options][:collection]).to eq("legacy_orders")
+  end
+
+  it "ignores receivered calls" do
+    expect(results_for("config.field :nope")).to be_empty
+  end
+end

--- a/spec/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener_spec.rb
@@ -144,6 +144,26 @@ RSpec.describe RailsAiContext::Introspectors::Listeners::RoutesDslListener do
     expect(records.map { |r| r[:controller] }.uniq).to eq([ "posts" ])
   end
 
+  it "suppresses routes inside a namespace whose name isn't a literal, when it has a block" do
+    results = routes_for('namespace Api::VERSION do
+      resources :posts
+    end')
+    expect(results.none? { |r| r[:type] == :route }).to be(true)
+    dynamic = results.select { |r| r[:type] == :dynamic }
+    expect(dynamic.size).to eq(1)
+    expect(dynamic.first[:macro]).to eq(:namespace)
+  end
+
+  it "suppresses routes inside resources whose name isn't a literal, when it has a block" do
+    results = routes_for('resources Api::NAMES do
+      member { get :extra }
+    end')
+    expect(results.none? { |r| r[:type] == :route }).to be(true)
+    dynamic = results.select { |r| r[:type] == :dynamic }
+    expect(dynamic.size).to eq(1)
+    expect(dynamic.first[:macro]).to eq(:resources)
+  end
+
   it "records dynamic constructs instead of guessing" do
     results = routes_for('devise_for :users
     resources Api::NAMES')

--- a/spec/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiContext::Introspectors::Listeners::RoutesDslListener do
+  def routes_for(source)
+    listener = described_class.new
+    dispatcher = Prism::Dispatcher.new
+    dispatcher.register(listener, :on_call_node_enter, :on_call_node_leave)
+    dispatcher.dispatch(Prism.parse(source).value)
+    listener.results
+  end
+
+  def route_records(source)
+    routes_for(source).select { |r| r[:type] == :route }
+  end
+
+  it "expands plural resources into the seven RESTful actions plus PUT" do
+    records = route_records('Rails.application.routes.draw do
+      resources :posts
+    end')
+    expect(records.map { |r| [ r[:verb], r[:path], r[:action] ] }).to contain_exactly(
+      [ "GET", "/posts", "index" ],
+      [ "POST", "/posts", "create" ],
+      [ "GET", "/posts/new", "new" ],
+      [ "GET", "/posts/:id/edit", "edit" ],
+      [ "GET", "/posts/:id", "show" ],
+      [ "PATCH", "/posts/:id", "update" ],
+      [ "PUT", "/posts/:id", "update" ],
+      [ "DELETE", "/posts/:id", "destroy" ]
+    )
+    expect(records).to all(include(controller: "posts", restful: true))
+  end
+
+  it "honors only: and except:" do
+    records = route_records('resources :posts, only: [:index, :show]')
+    expect(records.map { |r| r[:action] }).to contain_exactly("index", "show")
+
+    records = route_records('resources :posts, except: [:destroy]')
+    expect(records.map { |r| r[:action] }).not_to include("destroy")
+  end
+
+  it "expands a singular resource without :id segments" do
+    records = route_records('resource :profile, only: [:show, :update]')
+    expect(records.map { |r| [ r[:verb], r[:path] ] }).to contain_exactly(
+      [ "GET", "/profile" ], [ "PATCH", "/profile" ], [ "PUT", "/profile" ]
+    )
+    expect(records.first[:controller]).to eq("profiles")
+  end
+
+  it "applies namespace path, module, and name prefixes" do
+    records = route_records('namespace :admin do
+      resources :posts, only: [:index]
+    end')
+    expect(records.first).to include(
+      path: "/admin/posts", controller: "admin/posts", action: "index", name: "admin_posts"
+    )
+  end
+
+  it "nests resources under the parent param" do
+    records = route_records('resources :posts do
+      resources :comments, only: [:index, :create]
+    end')
+    nested = records.select { |r| r[:controller] == "comments" }
+    expect(nested.map { |r| r[:path] }.uniq).to eq([ "/posts/:post_id/comments" ])
+    expect(nested.first[:params]).to eq([ "post_id" ])
+  end
+
+  it "handles member and collection blocks" do
+    records = route_records('resources :posts do
+      member { get :preview }
+      collection { get :archived }
+    end')
+    preview = records.find { |r| r[:action] == "preview" }
+    archived = records.find { |r| r[:action] == "archived" }
+    expect(preview).to include(verb: "GET", path: "/posts/:id/preview", controller: "posts")
+    expect(archived).to include(verb: "GET", path: "/posts/archived", controller: "posts")
+  end
+
+  it "handles on: :member and on: :collection keywords" do
+    records = route_records('resources :posts do
+      get :preview, on: :member
+      get :archived, on: :collection
+    end')
+    expect(records.find { |r| r[:action] == "preview" }[:path]).to eq("/posts/:id/preview")
+    expect(records.find { |r| r[:action] == "archived" }[:path]).to eq("/posts/archived")
+  end
+
+  it "parses bare verb routes with to:" do
+    records = route_records('get "login", to: "sessions#new", as: :login')
+    expect(records.first).to include(
+      verb: "GET", path: "/login", controller: "sessions", action: "new", name: "login"
+    )
+  end
+
+  it "parses hash-rocket verb routes (the Rails default health check)" do
+    records = route_records('get "up" => "rails/health#show", as: :rails_health_check')
+    expect(records.first).to include(
+      verb: "GET", path: "/up", controller: "rails/health", action: "show", name: "rails_health_check"
+    )
+  end
+
+  it "prefixes to: targets with the enclosing module" do
+    records = route_records('namespace :api do
+      get "status", to: "health#show"
+    end')
+    expect(records.first).to include(path: "/api/status", controller: "api/health")
+  end
+
+  it "parses root" do
+    records = route_records('root "welcome#index"')
+    expect(records.first).to include(verb: "GET", path: "/", controller: "welcome", action: "index", name: "root")
+
+    records = route_records('root to: "welcome#index"')
+    expect(records.first).to include(path: "/", controller: "welcome")
+  end
+
+  it "applies scope path and module independently" do
+    records = route_records('scope "/v2", module: :v2 do
+      resources :posts, only: [:index]
+    end')
+    expect(records.first).to include(path: "/v2/posts", controller: "v2/posts")
+  end
+
+  it "suppresses routes inside concern definitions" do
+    records = route_records('concern :commentable do
+      resources :comments
+    end
+    resources :posts, only: [:index]')
+    expect(records.map { |r| r[:controller] }.uniq).to eq([ "posts" ])
+  end
+
+  it "records dynamic constructs instead of guessing" do
+    results = routes_for('devise_for :users
+    resources Api::NAMES')
+    dynamic = results.select { |r| r[:type] == :dynamic }
+    expect(dynamic.map { |r| r[:macro] }).to include(:devise_for)
+    expect(results.none? { |r| r[:type] == :route }).to be(true)
+  end
+
+  it "honors path: and controller: overrides on resources" do
+    records = route_records('resources :posts, path: "articles", controller: "articles", only: [:index]')
+    expect(records.first).to include(path: "/articles", controller: "articles")
+  end
+
+  it "ignores calls with an explicit receiver" do
+    expect(routes_for('router.resources :posts')).to be_empty
+  end
+end

--- a/spec/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/listeners/routes_dsl_listener_spec.rb
@@ -115,6 +115,20 @@ RSpec.describe RailsAiContext::Introspectors::Listeners::RoutesDslListener do
     expect(records.first).to include(path: "/", controller: "welcome")
   end
 
+  it "records a non-literal to: target as dynamic instead of guessing" do
+    results = routes_for('resources :posts do
+      get "legacy", to: redirect("/elsewhere")
+    end')
+    expect(results.none? { |r| r[:type] == :route && r[:action] == "legacy" }).to be(true)
+    expect(results.select { |r| r[:type] == :dynamic }.map { |r| r[:macro] }).to include(:get)
+  end
+
+  it "records a slashed segment with non-literal to: as dynamic" do
+    results = routes_for('get "admin/up", to: redirect("/status")')
+    expect(results.none? { |r| r[:type] == :route }).to be(true)
+    expect(results.first).to include(type: :dynamic, macro: :get)
+  end
+
   it "applies scope path and module independently" do
     records = route_records('scope "/v2", module: :v2 do
       resources :posts, only: [:index]

--- a/spec/lib/rails_ai_context/introspectors/migration_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/migration_introspector_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tmpdir"
+require "fileutils"
 
 RSpec.describe RailsAiContext::Introspectors::MigrationIntrospector do
   let(:app) { Rails.application }
@@ -79,6 +81,25 @@ RSpec.describe RailsAiContext::Introspectors::MigrationIntrospector do
 
     it "does not return an error" do
       expect(result[:error]).to be_nil
+    end
+  end
+
+  describe "#static_call" do
+    it "reports migrations from a bare directory with no booted app" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "db", "migrate"))
+        File.write(File.join(dir, "db", "migrate", "20240101000000_create_widgets.rb"), <<~RUBY)
+          class CreateWidgets < ActiveRecord::Migration[7.1]
+            def change
+              create_table :widgets
+            end
+          end
+        RUBY
+        app = RailsAiContext::StaticApp.new(dir)
+        result = described_class.new(app).static_call
+        expect(result[:total]).to eq(1)
+        expect(result[:recent].first[:name]).to eq("Create widgets")
+      end
     end
   end
 end

--- a/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tmpdir"
+require "fileutils"
 
 # Ensure test app models are loaded
 require_relative "../../../internal/app/models/application_record"
@@ -344,6 +346,59 @@ RSpec.describe RailsAiContext::Introspectors::ModelIntrospector do
 
       it "returns empty hash" do
         expect(result).to eq({})
+      end
+    end
+  end
+
+  describe "#static_call" do
+    it "discovers and parses models from source without constantizing" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "models", "concerns"))
+        FileUtils.mkdir_p(File.join(dir, "app", "models", "admin"))
+        File.write(File.join(dir, "app", "models", "widget.rb"), <<~RUBY)
+          class Widget < ApplicationRecord
+            belongs_to :factory
+            has_many :parts
+            validates :name, presence: true
+            scope :active, -> { where(active: true) }
+          end
+        RUBY
+        File.write(File.join(dir, "app", "models", "admin", "report.rb"), <<~RUBY)
+          class Admin::Report < ApplicationRecord
+          end
+        RUBY
+        File.write(File.join(dir, "app", "models", "application_record.rb"), <<~RUBY)
+          class ApplicationRecord < ActiveRecord::Base
+            primary_abstract_class
+          end
+        RUBY
+        File.write(File.join(dir, "app", "models", "concerns", "searchable.rb"), <<~RUBY)
+          module Searchable
+          end
+        RUBY
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result.keys).to contain_exactly("Widget", "Admin::Report")
+        widget = result["Widget"]
+        expect(widget[:confidence]).to eq("[STATIC]")
+        expect(widget[:table_name]).to eq("widgets")
+        expect(widget[:associations].map { |a| a[:name] }).to contain_exactly(:factory, :parts)
+        expect(widget[:validations]).not_to be_empty
+        expect(result["Admin::Report"][:table_name]).to eq("reports")
+      end
+    end
+
+    it "isolates a single unreadable model to its own entry" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "models"))
+        File.write(File.join(dir, "app", "models", "good.rb"), "class Good < ApplicationRecord\nend\n")
+        File.write(File.join(dir, "app", "models", "huge.rb"), "class Huge < ApplicationRecord\nend\n")
+        allow(File).to receive(:size).and_call_original
+        allow(File).to receive(:size).with(a_string_ending_with("huge.rb")).and_return(10_000_000)
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+        expect(result.keys).to contain_exactly("Good")
       end
     end
   end

--- a/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
@@ -415,5 +415,39 @@ RSpec.describe RailsAiContext::Introspectors::ModelIntrospector do
         expect(result["Good"]).to have_key(:associations)
       end
     end
+
+    it "discovers models in packs and engines directories" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "models"))
+        FileUtils.mkdir_p(File.join(dir, "packs", "billing", "app", "models"))
+        FileUtils.mkdir_p(File.join(dir, "engines", "store", "app", "models", "store"))
+        File.write(File.join(dir, "app", "models", "user.rb"),
+                   "class User < ApplicationRecord\nend\n")
+        File.write(File.join(dir, "packs", "billing", "app", "models", "invoice.rb"),
+                   "class Invoice < ApplicationRecord\n  belongs_to :user\nend\n")
+        File.write(File.join(dir, "engines", "store", "app", "models", "store", "order.rb"),
+                   "class Store::Order < ApplicationRecord\nend\n")
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result.keys).to contain_exactly("User", "Invoice", "Store::Order")
+        expect(result["Invoice"][:associations].map { |a| a[:name] }).to eq([ :user ])
+        expect(result["Store::Order"][:table_name]).to eq("orders")
+      end
+    end
+
+    it "keeps the first definition when the same class name appears in two dirs" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "models"))
+        FileUtils.mkdir_p(File.join(dir, "packs", "billing", "app", "models"))
+        File.write(File.join(dir, "app", "models", "user.rb"),
+                   "class User < ApplicationRecord\n  has_many :posts\nend\n")
+        File.write(File.join(dir, "packs", "billing", "app", "models", "user.rb"),
+                   "class User < ApplicationRecord\nend\n")
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+        expect(result["User"][:associations]).not_to be_empty
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
@@ -450,4 +450,32 @@ RSpec.describe RailsAiContext::Introspectors::ModelIntrospector do
       end
     end
   end
+
+  describe "Mongoid apps" do
+    it "extracts fields and embeds statically in both tiers" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "config"))
+        FileUtils.mkdir_p(File.join(dir, "app", "models"))
+        File.write(File.join(dir, "config", "mongoid.yml"), "development:\n  clients: {}\n")
+        File.write(File.join(dir, "app", "models", "customer.rb"), <<~RUBY)
+          class Customer
+            include Mongoid::Document
+            field :name, type: String
+            embeds_many :orders
+            has_many :tickets
+          end
+        RUBY
+
+        introspector = described_class.new(RailsAiContext::StaticApp.new(dir))
+        [ introspector.static_call, introspector.call ].each do |result|
+          customer = result["Customer"]
+          expect(customer[:mongoid]).to be(true)
+          expect(customer[:fields]).to include(name: :name, type: "String")
+          expect(customer[:embeds]).to include(type: :embeds_many, name: :orders)
+          expect(customer[:associations].map { |a| a[:name] }).to include(:tickets)
+          expect(customer).not_to have_key(:table_name)
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
@@ -401,5 +401,19 @@ RSpec.describe RailsAiContext::Introspectors::ModelIntrospector do
         expect(result.keys).to contain_exactly("Good")
       end
     end
+
+    it "records a stat failure as that model's error entry without aborting the pass" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "models"))
+        File.write(File.join(dir, "app", "models", "good.rb"), "class Good < ApplicationRecord\nend\n")
+        File.write(File.join(dir, "app", "models", "bad.rb"), "class Bad < ApplicationRecord\nend\n")
+        allow(File).to receive(:size).and_call_original
+        allow(File).to receive(:size).with(a_string_ending_with("bad.rb")).and_raise(Errno::EACCES)
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+        expect(result["Bad"]).to include(error: a_string_including("Permission denied"))
+        expect(result["Good"]).to have_key(:associations)
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
@@ -478,4 +478,46 @@ RSpec.describe RailsAiContext::Introspectors::ModelIntrospector do
       end
     end
   end
+
+  describe "hybrid AR + Mongoid apps" do
+    it "static_call gives AR-style table details for AR models and Mongoid details for Mongoid documents" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "config"))
+        FileUtils.mkdir_p(File.join(dir, "app", "models"))
+        File.write(File.join(dir, "config", "mongoid.yml"), "development:\n  clients: {}\n")
+        File.write(File.join(dir, "app", "models", "widget.rb"), <<~RUBY)
+          class Widget < ApplicationRecord
+            belongs_to :factory
+          end
+        RUBY
+        File.write(File.join(dir, "app", "models", "customer.rb"), <<~RUBY)
+          class Customer
+            include Mongoid::Document
+            field :name, type: String
+          end
+        RUBY
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        widget = result["Widget"]
+        expect(widget[:table_name]).to eq("widgets")
+        expect(widget[:associations].map { |a| a[:name] }).to contain_exactly(:factory)
+        expect(widget).not_to have_key(:mongoid)
+
+        customer = result["Customer"]
+        expect(customer[:mongoid]).to be(true)
+        expect(customer[:fields]).to include(name: :name, type: "String")
+        expect(customer).not_to have_key(:table_name)
+      end
+    end
+
+    it "#call keeps AR-reflected entries (with real table_name) instead of discarding them when AppKind.mongoid? is true" do
+      allow(RailsAiContext::AppKind).to receive(:mongoid?).and_return(true)
+
+      result = introspector.call
+
+      expect(result["User"][:table_name]).to eq("users")
+      expect(result["User"][:associations]).not_to be_empty
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/introspectors/route_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/route_introspector_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tmpdir"
+require "fileutils"
 
 RSpec.describe RailsAiContext::Introspectors::RouteIntrospector do
   let(:introspector) { described_class.new(Rails.application) }
@@ -28,6 +30,48 @@ RSpec.describe RailsAiContext::Introspectors::RouteIntrospector do
 
     it "returns mounted_engines as an array" do
       expect(result[:mounted_engines]).to be_an(Array)
+    end
+  end
+
+  describe "#static_call" do
+    it "builds the runtime output shape from config/routes.rb without booting" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "config"))
+        File.write(File.join(dir, "config", "routes.rb"), <<~RUBY)
+          Rails.application.routes.draw do
+            root "welcome#index"
+            resources :posts, only: [:index, :show]
+            namespace :api do
+              namespace :v1 do
+                resources :widgets, only: [:index]
+              end
+            end
+            mount Sidekiq::Web, at: "/sidekiq"
+            devise_for :users
+          end
+        RUBY
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result[:total_routes]).to eq(4)
+        expect(result[:by_controller].keys).to contain_exactly("welcome", "posts", "api/v1/widgets")
+        post_routes = result[:by_controller]["posts"]
+        expect(post_routes).to include(
+          a_hash_including(verb: "GET", path: "/posts", action: "index", restful: true)
+        )
+        expect(result[:api_namespaces]).to eq([ "/api/v1" ])
+        expect(result[:mounted_engines]).to eq([ { engine: "Sidekiq::Web", path: "/sidekiq" } ])
+        expect(result[:root_route]).to eq("welcome#index")
+        expect(result[:confidence]).to eq("[STATIC]")
+        expect(result[:dynamic_routes]).to eq(1)
+      end
+    end
+
+    it "reports a missing routes.rb honestly" do
+      Dir.mktmpdir do |dir|
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+        expect(result[:error]).to include("config/routes.rb")
+      end
     end
   end
 end

--- a/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tmpdir"
+require "fileutils"
 
 RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
   let(:app) { double("app", root: Pathname.new(fixture_path)) }
@@ -499,6 +501,26 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
         expect(result[:schema_version]).to eq("20240115123456")
       ensure
         FileUtils.rm_rf(db_dir)
+      end
+    end
+  end
+
+  describe "#static_call" do
+    it "answers from files even when a live connection exists" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "db"))
+        File.write(File.join(dir, "db", "schema.rb"), <<~RUBY)
+          ActiveRecord::Schema[7.1].define(version: 2024_01_01_000000) do
+            create_table "widgets" do |t|
+              t.string "name"
+            end
+          end
+        RUBY
+        app = RailsAiContext::StaticApp.new(dir)
+        result = described_class.new(app).static_call
+        expect(result[:total_tables]).to eq(1)
+        expect(result[:tables]).to have_key("widgets")
+        expect(result[:adapter]).to eq("static_parse")
       end
     end
   end

--- a/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
@@ -112,6 +112,16 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
       end
     end
 
+    def parse_structure_fixture(sql)
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "db"))
+        path = File.join(dir, "db", "structure.sql")
+        File.write(path, sql)
+        fixture_introspector = described_class.new(RailsAiContext::StaticApp.new(dir))
+        return fixture_introspector.send(:parse_structure_sql, path)
+      end
+    end
+
     context "with a valid structure.sql fixture" do
       before do
         allow(introspector).to receive(:active_record_connected?).and_return(false)
@@ -193,6 +203,91 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
           to_table: "users",
           column: "user_id"
         ))
+      end
+
+      it "reports the postgresql dialect" do
+        result = introspector.call
+        expect(result[:dialect]).to eq("postgresql")
+      end
+    end
+
+    context "with a MySQL (mysqldump) structure.sql" do
+      let(:mysql_sql) do
+        <<~SQL
+          CREATE TABLE `products` (
+            `id` bigint NOT NULL AUTO_INCREMENT,
+            `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+            `price_cents` int NOT NULL DEFAULT '0',
+            `active` tinyint(1) DEFAULT '1',
+            `store_id` bigint DEFAULT NULL,
+            `metadata` json DEFAULT NULL,
+            `created_at` datetime(6) NOT NULL,
+            PRIMARY KEY (`id`),
+            UNIQUE KEY `index_products_on_name` (`name`),
+            KEY `index_products_on_store_id` (`store_id`),
+            CONSTRAINT `fk_rails_123abc` FOREIGN KEY (`store_id`) REFERENCES `stores` (`id`)
+          ) ENGINE=InnoDB AUTO_INCREMENT=42 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+          CREATE TABLE `stores` (
+            `id` bigint NOT NULL AUTO_INCREMENT,
+            `name` varchar(255) DEFAULT NULL,
+            PRIMARY KEY (`id`)
+          ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+          INSERT INTO `schema_migrations` (version) VALUES ('20240101000000');
+        SQL
+      end
+
+      it "extracts tables, columns, indexes, and foreign keys" do
+        result = parse_structure_fixture(mysql_sql)
+
+        expect(result[:dialect]).to eq("mysql")
+        expect(result[:total_tables]).to eq(2)
+
+        products = result[:tables]["products"]
+        expect(products[:columns].map { |c| c[:name] })
+          .to contain_exactly("id", "name", "price_cents", "active", "store_id", "metadata", "created_at")
+        types = products[:columns].to_h { |c| [ c[:name], c[:type] ] }
+        expect(types["name"]).to eq("string")
+        expect(types["active"]).to eq("boolean")
+        expect(types["price_cents"]).to eq("integer")
+        expect(types["created_at"]).to eq("datetime")
+
+        expect(products[:indexes]).to include(
+          { name: "index_products_on_name", columns: [ "name" ], unique: true },
+          { name: "index_products_on_store_id", columns: [ "store_id" ], unique: false }
+        )
+        expect(products[:foreign_keys]).to eq(
+          [ { from_table: "products", to_table: "stores", column: "store_id", primary_key: "id" } ]
+        )
+      end
+    end
+
+    context "with a SQLite structure.sql" do
+      let(:sqlite_sql) do
+        <<~SQL
+          CREATE TABLE IF NOT EXISTS "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
+          CREATE TABLE IF NOT EXISTS "widgets" (
+            "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+            "name" varchar DEFAULT NULL,
+            "weight" decimal(8,2),
+            "created_at" datetime(6) NOT NULL
+          );
+          CREATE UNIQUE INDEX "index_widgets_on_name" ON "widgets" ("name");
+          INSERT INTO "schema_migrations" (version) VALUES ('20240101000000');
+        SQL
+      end
+
+      it "extracts quoted tables, columns, and indexes" do
+        result = parse_structure_fixture(sqlite_sql)
+
+        expect(result[:dialect]).to eq("sqlite")
+        expect(result[:tables].keys).to eq([ "widgets" ])
+        widgets = result[:tables]["widgets"]
+        expect(widgets[:columns].map { |c| c[:name] }).to include("name", "weight", "created_at")
+        expect(widgets[:indexes]).to eq(
+          [ { name: "index_widgets_on_name", columns: [ "name" ], unique: true } ]
+        )
       end
     end
 

--- a/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
@@ -639,4 +639,74 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
       end
     end
   end
+
+  describe "secondary database dumps" do
+    it "reports db/*_schema.rb dumps under secondary_databases" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "db"))
+        File.write(File.join(dir, "db", "schema.rb"), <<~RUBY)
+          ActiveRecord::Schema[8.0].define(version: 2024_01_01_000000) do
+            create_table "users" do |t|
+              t.string "name"
+            end
+          end
+        RUBY
+        File.write(File.join(dir, "db", "queue_schema.rb"), <<~RUBY)
+          ActiveRecord::Schema[8.0].define(version: 1) do
+            create_table "solid_queue_jobs" do |t|
+              t.string "queue_name", null: false
+            end
+          end
+        RUBY
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result[:tables].keys).to eq([ "users" ])
+        expect(result[:secondary_databases].keys).to eq([ "queue" ])
+        expect(result[:secondary_databases]["queue"][:tables]).to have_key("solid_queue_jobs")
+        expect(result[:secondary_databases]["queue"][:note]).to include("queue_schema.rb")
+      end
+    end
+
+    it "omits the key entirely when no secondary dumps exist" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "db"))
+        File.write(File.join(dir, "db", "schema.rb"), <<~RUBY)
+          ActiveRecord::Schema[8.0].define(version: 1) do
+            create_table "users" do |t|
+              t.string "name"
+            end
+          end
+        RUBY
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+        expect(result).not_to have_key(:secondary_databases)
+      end
+    end
+
+    it "attaches secondary_databases from the LIVE path in #call too" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "db"))
+        File.write(File.join(dir, "db", "queue_schema.rb"), <<~RUBY)
+          ActiveRecord::Schema[8.0].define(version: 1) do
+            create_table "solid_queue_jobs" do |t|
+              t.string "queue_name", null: false
+            end
+          end
+        RUBY
+
+        app = double("app", root: Pathname.new(dir))
+        live_introspector = described_class.new(app)
+        allow(live_introspector).to receive(:active_record_connected?).and_return(true)
+        allow(live_introspector).to receive(:adapter_name).and_return("postgresql")
+        allow(live_introspector).to receive(:table_names).and_return([ "users" ])
+        allow(live_introspector).to receive(:extract_tables).and_return({ "users" => { columns: [], indexes: [], foreign_keys: [] } })
+
+        result = live_introspector.call
+
+        expect(result[:tables].keys).to eq([ "users" ])
+        expect(result[:secondary_databases].keys).to eq([ "queue" ])
+        expect(result[:secondary_databases]["queue"][:tables]).to have_key("solid_queue_jobs")
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
@@ -618,6 +618,65 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
         FileUtils.rm_rf(db_dir)
       end
     end
+
+    context "with a secondary database dump and ActiveRecord not connected" do
+      it "still attaches secondary_databases through the static fallback" do
+        Dir.mktmpdir do |dir|
+          FileUtils.mkdir_p(File.join(dir, "db"))
+          File.write(File.join(dir, "db", "schema.rb"), <<~RUBY)
+            ActiveRecord::Schema[8.0].define(version: 2024_01_01_000000) do
+              create_table "users" do |t|
+                t.string "name"
+              end
+            end
+          RUBY
+          File.write(File.join(dir, "db", "queue_schema.rb"), <<~RUBY)
+            ActiveRecord::Schema[8.0].define(version: 1) do
+              create_table "solid_queue_jobs" do |t|
+                t.string "queue_name", null: false
+              end
+            end
+          RUBY
+
+          fixture_introspector = described_class.new(RailsAiContext::StaticApp.new(dir))
+          allow(fixture_introspector).to receive(:active_record_connected?).and_return(false)
+
+          result = fixture_introspector.call
+
+          expect(result[:secondary_databases].keys).to eq([ "queue" ])
+        end
+      end
+    end
+
+    context "with a secondary database dump and no live tables" do
+      it "still attaches secondary_databases when table_names is empty" do
+        Dir.mktmpdir do |dir|
+          FileUtils.mkdir_p(File.join(dir, "db"))
+          File.write(File.join(dir, "db", "schema.rb"), <<~RUBY)
+            ActiveRecord::Schema[8.0].define(version: 2024_01_01_000000) do
+              create_table "users" do |t|
+                t.string "name"
+              end
+            end
+          RUBY
+          File.write(File.join(dir, "db", "queue_schema.rb"), <<~RUBY)
+            ActiveRecord::Schema[8.0].define(version: 1) do
+              create_table "solid_queue_jobs" do |t|
+                t.string "queue_name", null: false
+              end
+            end
+          RUBY
+
+          fixture_introspector = described_class.new(RailsAiContext::StaticApp.new(dir))
+          allow(fixture_introspector).to receive(:active_record_connected?).and_return(true)
+          allow(fixture_introspector).to receive(:table_names).and_return([])
+
+          result = fixture_introspector.call
+
+          expect(result[:secondary_databases].keys).to eq([ "queue" ])
+        end
+      end
+    end
   end
 
   describe "#static_call" do
@@ -652,7 +711,7 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
           end
         RUBY
         File.write(File.join(dir, "db", "queue_schema.rb"), <<~RUBY)
-          ActiveRecord::Schema[8.0].define(version: 1) do
+          ActiveRecord::Schema[8.0].define(version: 2019_09_20_000000) do
             create_table "solid_queue_jobs" do |t|
               t.string "queue_name", null: false
             end
@@ -662,9 +721,11 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
         result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
 
         expect(result[:tables].keys).to eq([ "users" ])
+        expect(result[:schema_version]).to eq("20240101000000")
         expect(result[:secondary_databases].keys).to eq([ "queue" ])
         expect(result[:secondary_databases]["queue"][:tables]).to have_key("solid_queue_jobs")
         expect(result[:secondary_databases]["queue"][:note]).to include("queue_schema.rb")
+        expect(result[:secondary_databases]["queue"][:schema_version]).to eq("20190920000000")
       end
     end
 

--- a/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
@@ -697,6 +697,16 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
         expect(result[:adapter]).to eq("static_parse")
       end
     end
+
+    it "reports Mongoid apps as unavailable instead of a misleading missing-schema error" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "config"))
+        File.write(File.join(dir, "config", "mongoid.yml"), "development:\n  clients: {}\n")
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+        expect(result[:unavailable]).to include("Mongoid")
+        expect(result).not_to have_key(:error)
+      end
+    end
   end
 
   describe "secondary database dumps" do

--- a/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/schema_introspector_spec.rb
@@ -263,6 +263,26 @@ RSpec.describe RailsAiContext::Introspectors::SchemaIntrospector do
       end
     end
 
+    context "with unquoted key/index column names (PostgreSQL non-reserved words)" do
+      let(:pg_key_sql) do
+        <<~SQL
+          CREATE TABLE public.settings (
+              id bigint NOT NULL,
+              key character varying NOT NULL,
+              index integer DEFAULT 0,
+              value text
+          );
+        SQL
+      end
+
+      it "parses key and index as columns, not index definitions" do
+        result = parse_structure_fixture(pg_key_sql)
+        settings = result[:tables]["settings"]
+        expect(settings[:columns].map { |c| c[:name] }).to contain_exactly("id", "key", "index", "value")
+        expect(settings[:indexes]).to be_empty
+      end
+    end
+
     context "with a SQLite structure.sql" do
       let(:sqlite_sql) do
         <<~SQL

--- a/spec/lib/rails_ai_context/path_resolver_spec.rb
+++ b/spec/lib/rails_ai_context/path_resolver_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+
+RSpec.describe RailsAiContext::PathResolver do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @root = dir
+      example.run
+    end
+  ensure
+    RailsAiContext.configuration.extra_app_paths = []
+  end
+
+  def mkdirs(*paths)
+    paths.each { |p| FileUtils.mkdir_p(File.join(@root, p)) }
+  end
+
+  it "returns only the conventional dir for a stock app" do
+    mkdirs("app/models")
+    expect(described_class.model_dirs(@root)).to eq([ File.join(@root, "app/models") ])
+  end
+
+  it "includes packs and engines dirs, conventional first, packs before engines, each sorted" do
+    mkdirs("app/models",
+           "packs/billing/app/models", "packs/admin/app/models",
+           "engines/store/app/models")
+    expect(described_class.model_dirs(@root)).to eq([
+      File.join(@root, "app/models"),
+      File.join(@root, "packs/admin/app/models"),
+      File.join(@root, "packs/billing/app/models"),
+      File.join(@root, "engines/store/app/models")
+    ])
+  end
+
+  it "includes configured extra_app_paths" do
+    mkdirs("app/models", "src/app/models")
+    RailsAiContext.configuration.extra_app_paths = [ "src" ]
+    expect(described_class.model_dirs(@root)).to include(File.join(@root, "src/app/models"))
+  end
+
+  it "omits directories that do not exist" do
+    mkdirs("packs/billing/app/models")
+    RailsAiContext.configuration.extra_app_paths = [ "nope" ]
+    expect(described_class.model_dirs(@root)).to eq([ File.join(@root, "packs/billing/app/models") ])
+  end
+
+  it "resolves controllers and views the same way" do
+    mkdirs("app/controllers", "packs/billing/app/views")
+    expect(described_class.controller_dirs(@root)).to eq([ File.join(@root, "app/controllers") ])
+    expect(described_class.view_dirs(@root)).to eq([ File.join(@root, "packs/billing/app/views") ])
+  end
+
+  it "accepts a Pathname root" do
+    mkdirs("app/models")
+    expect(described_class.model_dirs(Pathname.new(@root))).to eq([ File.join(@root, "app/models") ])
+  end
+end

--- a/spec/lib/rails_ai_context/static_app_spec.rb
+++ b/spec/lib/rails_ai_context/static_app_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiContext::StaticApp do
+  it "exposes root as a Pathname" do
+    app = described_class.new("/tmp/some_app")
+    expect(app.root).to be_a(Pathname)
+    expect(app.root.to_s).to eq("/tmp/some_app")
+  end
+
+  it "accepts a Pathname root" do
+    app = described_class.new(Pathname.new("/tmp/some_app"))
+    expect(File.join(app.root, "app", "models")).to eq("/tmp/some_app/app/models")
+  end
+end

--- a/spec/lib/rails_ai_context/tier_state_spec.rb
+++ b/spec/lib/rails_ai_context/tier_state_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiContext do
+  describe "tier state" do
+    after do
+      RailsAiContext.tier = :runtime
+      RailsAiContext.static_reason = nil
+    end
+
+    it "defaults to :runtime" do
+      expect(RailsAiContext.tier).to eq(:runtime)
+      expect(RailsAiContext.static_tier?).to be(false)
+    end
+
+    it "records the static tier and reason" do
+      RailsAiContext.tier = :static
+      RailsAiContext.static_reason = "RuntimeError: FATAL_ENV_MISSING"
+      expect(RailsAiContext.static_tier?).to be(true)
+      expect(RailsAiContext.static_reason).to eq("RuntimeError: FATAL_ENV_MISSING")
+    end
+
+    it "builds a StaticApp from configuration.app_root in static tier" do
+      RailsAiContext.tier = :static
+      RailsAiContext.configuration.app_root = "/tmp/static_root"
+      app = RailsAiContext.send(:default_app)
+      expect(app).to be_a(RailsAiContext::StaticApp)
+      expect(app.root.to_s).to eq("/tmp/static_root")
+    ensure
+      RailsAiContext.configuration.app_root = nil
+    end
+
+    it "returns Rails.application in runtime tier" do
+      expect(RailsAiContext.send(:default_app)).to eq(Rails.application)
+    end
+  end
+end

--- a/spec/lib/rails_ai_context/tier_state_spec.rb
+++ b/spec/lib/rails_ai_context/tier_state_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RailsAiContext do
     it "builds a StaticApp from configuration.app_root in static tier" do
       RailsAiContext.tier = :static
       RailsAiContext.configuration.app_root = "/tmp/static_root"
-      app = RailsAiContext.send(:default_app)
+      app = RailsAiContext.default_app
       expect(app).to be_a(RailsAiContext::StaticApp)
       expect(app.root.to_s).to eq("/tmp/static_root")
     ensure
@@ -32,7 +32,7 @@ RSpec.describe RailsAiContext do
     end
 
     it "returns Rails.application in runtime tier" do
-      expect(RailsAiContext.send(:default_app)).to eq(Rails.application)
+      expect(RailsAiContext.default_app).to eq(Rails.application)
     end
   end
 end

--- a/spec/lib/rails_ai_context/tools/base_tool_truncation_spec.rb
+++ b/spec/lib/rails_ai_context/tools/base_tool_truncation_spec.rb
@@ -156,4 +156,72 @@ RSpec.describe RailsAiContext::Tools::BaseTool do
       expect(cache[:fingerprint]).to be_nil
     end
   end
+
+  describe "static tier banner" do
+    around do |example|
+      RailsAiContext.tier = :static
+      RailsAiContext.static_reason = "RuntimeError: FATAL_ENV_MISSING"
+      example.run
+    ensure
+      RailsAiContext.tier = :runtime
+      RailsAiContext.static_reason = nil
+    end
+
+    it "appends the banner to every response" do
+      response = RailsAiContext::Tools::GetSchema.text_response("## Schema\n\ntables: 3")
+      text = response.content.first[:text]
+      expect(text).to start_with("## Schema")
+      expect(text).to include("App boot failed (RuntimeError: FATAL_ENV_MISSING)")
+      expect(text).to include("static analysis")
+      expect(text).to include("rails-ai-context doctor")
+    end
+
+    it "composes with a caller-provided suffix" do
+      response = RailsAiContext::Tools::GetSchema.text_response("body", suffix: "\n\n_custom note_")
+      text = response.content.first[:text]
+      expect(text).to include("_custom note_")
+      expect(text.index("_custom note_")).to be < text.index("App boot failed")
+    end
+
+    it "survives truncation" do
+      allow(RailsAiContext.configuration).to receive(:max_tool_response_chars).and_return(50)
+      response = RailsAiContext::Tools::GetSchema.text_response("x" * 500)
+      text = response.content.first[:text]
+      expect(text).to include("Response truncated")
+      expect(text).to include("App boot failed")
+    end
+
+    it "describes --no-boot mode when there is no boot failure" do
+      RailsAiContext.static_reason = "static mode requested with --no-boot"
+      response = RailsAiContext::Tools::GetSchema.text_response("body")
+      expect(response.content.first[:text]).to include("static mode requested with --no-boot")
+    end
+  end
+
+  describe "runtime tier" do
+    it "adds no banner to text_response" do
+      response = RailsAiContext::Tools::GetSchema.text_response("body")
+      expect(response.content.first[:text]).to eq("body")
+    end
+  end
+
+  describe ".rails_app tier routing" do
+    after do
+      RailsAiContext.tier = :runtime
+      RailsAiContext.configuration.app_root = nil
+    end
+
+    it "returns a StaticApp in static tier" do
+      RailsAiContext.tier = :static
+      RailsAiContext.configuration.app_root = "/tmp/static_root"
+
+      app = described_class.rails_app
+      expect(app).to be_a(RailsAiContext::StaticApp)
+      expect(app.root.to_s).to eq("/tmp/static_root")
+    end
+
+    it "returns Rails.application in runtime tier" do
+      expect(described_class.rails_app).to eq(Rails.application)
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/tools/base_tool_truncation_spec.rb
+++ b/spec/lib/rails_ai_context/tools/base_tool_truncation_spec.rb
@@ -205,6 +205,51 @@ RSpec.describe RailsAiContext::Tools::BaseTool do
     end
   end
 
+  describe ".unavailable_note" do
+    it "returns nil for a Hash without :unavailable" do
+      expect(described_class.unavailable_note({ notable_gems: [] })).to be_nil
+    end
+
+    it "returns nil for a Hash carrying a real :error" do
+      expect(described_class.unavailable_note({ error: "boom" })).to be_nil
+    end
+
+    it "returns nil for non-Hash input" do
+      expect(described_class.unavailable_note(nil)).to be_nil
+      expect(described_class.unavailable_note([])).to be_nil
+    end
+
+    it "returns a bracketed note carrying the reason for an unavailable section" do
+      note = described_class.unavailable_note({ unavailable: "requires a booted Rails app (RuntimeError: boom)" })
+      expect(note).to eq("[UNAVAILABLE: requires a booted Rails app (RuntimeError: boom)]")
+    end
+  end
+
+  describe ".error_response" do
+    it "does not append a banner in runtime tier" do
+      response = RailsAiContext::Tools::GetSchema.error_response("something failed")
+      expect(response.content.first[:text]).to eq("something failed")
+    end
+
+    context "in static tier" do
+      around do |example|
+        RailsAiContext.tier = :static
+        RailsAiContext.static_reason = "RuntimeError: FATAL_ENV_MISSING"
+        example.run
+      ensure
+        RailsAiContext.tier = :runtime
+        RailsAiContext.static_reason = nil
+      end
+
+      it "appends the tier banner so a failing tool keeps degradation context" do
+        response = RailsAiContext::Tools::GetSchema.error_response("something failed")
+        text = response.content.first[:text]
+        expect(text).to start_with("something failed")
+        expect(text).to include("App boot failed (RuntimeError: FATAL_ENV_MISSING)")
+      end
+    end
+  end
+
   describe ".rails_app tier routing" do
     after do
       RailsAiContext.tier = :runtime

--- a/spec/lib/rails_ai_context/tools/base_tool_truncation_spec.rb
+++ b/spec/lib/rails_ai_context/tools/base_tool_truncation_spec.rb
@@ -205,6 +205,34 @@ RSpec.describe RailsAiContext::Tools::BaseTool do
     end
   end
 
+  describe ".rails_env_name" do
+    it "returns Rails.env when Rails is loaded" do
+      expect(described_class.rails_env_name).to eq(Rails.env)
+    end
+
+    it "falls back to RAILS_ENV when Rails does not respond to :env" do
+      allow(Rails).to receive(:respond_to?).with(:env).and_return(false)
+      begin
+        original = ENV["RAILS_ENV"]
+        ENV["RAILS_ENV"] = "staging"
+        expect(described_class.rails_env_name).to eq("staging")
+      ensure
+        ENV["RAILS_ENV"] = original
+      end
+    end
+
+    it "falls back to development when neither Rails.env nor RAILS_ENV is available" do
+      allow(Rails).to receive(:respond_to?).with(:env).and_return(false)
+      begin
+        original = ENV["RAILS_ENV"]
+        ENV.delete("RAILS_ENV")
+        expect(described_class.rails_env_name).to eq("development")
+      ensure
+        ENV["RAILS_ENV"] = original
+      end
+    end
+  end
+
   describe ".unavailable_note" do
     it "returns nil for a Hash without :unavailable" do
       expect(described_class.unavailable_note({ notable_gems: [] })).to be_nil

--- a/spec/lib/rails_ai_context/tools/get_callbacks_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_callbacks_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe RailsAiContext::Tools::GetCallbacks do
         end
       RUBY
 
-      allow(Rails).to receive(:root).and_return(Pathname.new(tmpdir))
+      allow(Rails.application).to receive(:root).and_return(Pathname.new(tmpdir))
       allow(RailsAiContext.configuration).to receive(:concern_paths).and_return(%w[app/models/concerns])
       allow(RailsAiContext.configuration).to receive(:max_file_size).and_return(1_000_000)
     end
@@ -172,7 +172,7 @@ RSpec.describe RailsAiContext::Tools::GetCallbacks do
         end
       RUBY
 
-      allow(Rails).to receive(:root).and_return(Pathname.new(tmpdir))
+      allow(Rails.application).to receive(:root).and_return(Pathname.new(tmpdir))
       allow(RailsAiContext.configuration).to receive(:concern_paths).and_return(%w[app/models/concerns])
       allow(RailsAiContext.configuration).to receive(:max_file_size).and_return(1_000_000)
     end

--- a/spec/lib/rails_ai_context/tools/get_component_catalog_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_component_catalog_spec.rb
@@ -149,5 +149,21 @@ RSpec.describe RailsAiContext::Tools::GetComponentCatalog do
         expect(text).to include("do %>")
       end
     end
+
+    context "when the app is API-only" do
+      before do
+        allow(described_class).to receive(:cached_context).and_return(
+          api: { api_only: true },
+          components: { components: [] }
+        )
+      end
+
+      it "reports API-only apps as not applicable instead of an empty listing" do
+        response = described_class.call
+        text = response.content.first[:text]
+        expect(text).to include("Not applicable")
+        expect(text).to include("API-only")
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_context/tools/get_conventions_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_conventions_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe RailsAiContext::Tools::GetConventions do
 
     before do
       FileUtils.mkdir_p(controllers_dir)
-      allow(Rails).to receive(:root).and_return(Pathname.new(tmpdir))
+      allow(Rails.application).to receive(:root).and_return(Pathname.new(tmpdir))
       allow(described_class).to receive(:cached_context).and_return({ conventions: {} })
     end
 

--- a/spec/lib/rails_ai_context/tools/get_frontend_stack_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_frontend_stack_spec.rb
@@ -268,6 +268,20 @@ RSpec.describe RailsAiContext::Tools::GetFrontendStack do
       end
     end
 
+    context "when frontend_frameworks is unavailable (static tier)" do
+      it "reports [UNAVAILABLE] instead of a fabricated empty answer" do
+        allow(described_class).to receive(:cached_context).and_return({
+          frontend_frameworks: { unavailable: "requires a booted Rails app (RuntimeError: boom)" }
+        })
+        result = described_class.call
+        text = result.content.first[:text]
+
+        expect(text).to include("UNAVAILABLE")
+        expect(text).to include("requires a booted Rails app (RuntimeError: boom)")
+        expect(text).not_to include("No frontend framework data available")
+      end
+    end
+
     context "with unknown detail level" do
       it "returns an error message" do
         result = described_class.call(detail: "verbose")

--- a/spec/lib/rails_ai_context/tools/get_gems_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_gems_spec.rb
@@ -129,6 +129,17 @@ RSpec.describe RailsAiContext::Tools::GetGems do
       expect(text).to include("Gemfile.lock not found")
     end
 
+    it "reports [UNAVAILABLE] instead of a fabricated empty answer in static tier" do
+      allow(described_class).to receive(:cached_context).and_return({
+        gems: { unavailable: "requires a booted Rails app (RuntimeError: boom)" }
+      })
+      result = described_class.call
+      text = result.content.first[:text]
+      expect(text).to include("UNAVAILABLE")
+      expect(text).to include("requires a booted Rails app (RuntimeError: boom)")
+      expect(text).not_to include("No notable gems")
+    end
+
     it "handles empty notable_gems list" do
       gems_data[:notable_gems] = []
       result = described_class.call

--- a/spec/lib/rails_ai_context/tools/get_job_pattern_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_job_pattern_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RailsAiContext::Tools::GetJobPattern do
           end
         RUBY
 
-        allow(Rails).to receive(:root).and_return(Pathname.new(tmpdir))
+        allow(Rails.application).to receive(:root).and_return(Pathname.new(tmpdir))
         allow(RailsAiContext.configuration).to receive(:max_file_size).and_return(1_000_000)
       end
 
@@ -210,7 +210,7 @@ RSpec.describe RailsAiContext::Tools::GetJobPattern do
           end
         RUBY
 
-        allow(Rails).to receive(:root).and_return(Pathname.new(tmpdir))
+        allow(Rails.application).to receive(:root).and_return(Pathname.new(tmpdir))
         allow(described_class).to receive(:cached_context).and_return(jobs: { jobs: [], mailers: [], channels: [] })
       end
 

--- a/spec/lib/rails_ai_context/tools/get_model_details_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_model_details_spec.rb
@@ -141,6 +141,40 @@ RSpec.describe RailsAiContext::Tools::GetModelDetails do
     end
   end
 
+  describe ".call with a Mongoid model" do
+    let(:mongoid_models) do
+      {
+        "Customer" => {
+          mongoid: true,
+          fields: [ { name: :name, type: "String" }, { name: :active, type: "Boolean" } ],
+          embeds: [ { type: :embeds_many, name: :orders } ],
+          associations: [],
+          validations: []
+        }
+      }
+    end
+
+    before do
+      allow(described_class).to receive(:cached_context).and_return({ models: mongoid_models })
+    end
+
+    it "renders declared fields since there is no AR table/columns" do
+      result = described_class.call(model: "Customer")
+      text = result.content.first[:text]
+      expect(text).to include("## Fields")
+      expect(text).to include("name")
+      expect(text).to include("String")
+    end
+
+    it "renders embedded relations" do
+      result = described_class.call(model: "Customer")
+      text = result.content.first[:text]
+      expect(text).to include("## Embedded relations")
+      expect(text).to include("embeds_many")
+      expect(text).to include("orders")
+    end
+  end
+
   describe ".call with pagination" do
     it "respects limit parameter" do
       result = described_class.call(limit: 1)

--- a/spec/lib/rails_ai_context/tools/get_partial_interface_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_partial_interface_spec.rb
@@ -128,6 +128,20 @@ RSpec.describe RailsAiContext::Tools::GetPartialInterface do
       end
     end
 
+    context "when the app is API-only" do
+      it "reports API-only apps as not applicable instead of an empty listing" do
+        Dir.mktmpdir("rac_gpi_api_only") do |tmp|
+          allow(described_class).to receive(:cached_context).and_return(api: { api_only: true })
+          allow(described_class).to receive(:rails_app).and_return(double(root: Pathname.new(tmp)))
+
+          result = described_class.call(partial: "shared/status_badge")
+          text = result.content.first[:text]
+          expect(text).to include("Not applicable")
+          expect(text).to include("API-only")
+        end
+      end
+    end
+
     context "C1 symlink hardening (v5.8.1 round 2)" do
       let(:views_dir) { Rails.root.join("app", "views") }
 

--- a/spec/lib/rails_ai_context/tools/get_schema_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_schema_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe RailsAiContext::Tools::GetSchema do
             "queue" => {
               tables: { "solid_queue_jobs" => { columns: [], indexes: [], foreign_keys: [] } },
               total_tables: 1,
-              note: "Parsed from db/queue_schema.rb (no DB connection)"
+              note: "Parsed from db/queue_schema.rb (from committed dump, not a live connection)"
             }
           }
         },

--- a/spec/lib/rails_ai_context/tools/get_schema_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_schema_spec.rb
@@ -222,6 +222,34 @@ RSpec.describe RailsAiContext::Tools::GetSchema do
     end
   end
 
+  describe "secondary databases" do
+    before do
+      allow(described_class).to receive(:cached_context).and_return({
+        schema: {
+          adapter: "sqlite3",
+          tables: tables,
+          total_tables: 3,
+          secondary_databases: {
+            "queue" => {
+              tables: { "solid_queue_jobs" => { columns: [], indexes: [], foreign_keys: [] } },
+              total_tables: 1,
+              note: "Parsed from db/queue_schema.rb (no DB connection)"
+            }
+          }
+        },
+        models: {}
+      })
+    end
+
+    it "renders a secondary databases section when present" do
+      response = described_class.call
+      text = response.content.first[:text]
+      expect(text).to include("Secondary databases")
+      expect(text).to include("queue")
+      expect(text).to include("solid_queue_jobs")
+    end
+  end
+
   describe "singular pluralization with exactly one table" do
     before do
       allow(described_class).to receive(:cached_context).and_return({

--- a/spec/lib/rails_ai_context/tools/get_service_pattern_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_service_pattern_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe RailsAiContext::Tools::GetServicePattern do
           end
         RUBY
 
-        allow(Rails).to receive(:root).and_return(Pathname.new(tmpdir))
+        allow(Rails.application).to receive(:root).and_return(Pathname.new(tmpdir))
         allow(RailsAiContext.configuration).to receive(:max_file_size).and_return(1_000_000)
       end
 
@@ -170,7 +170,7 @@ RSpec.describe RailsAiContext::Tools::GetServicePattern do
 
       before do
         FileUtils.mkdir_p(File.join(tmpdir, "app", "services"))
-        allow(Rails).to receive(:root).and_return(Pathname.new(tmpdir))
+        allow(Rails.application).to receive(:root).and_return(Pathname.new(tmpdir))
       end
 
       after { FileUtils.remove_entry(tmpdir) }

--- a/spec/lib/rails_ai_context/tools/get_stimulus_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_stimulus_spec.rb
@@ -93,5 +93,21 @@ RSpec.describe RailsAiContext::Tools::GetStimulus do
       text = result.content.first[:text]
       expect(text).to include("No Stimulus controllers")
     end
+
+    context "when the app is API-only" do
+      before do
+        allow(described_class).to receive(:cached_context).and_return(
+          api: { api_only: true },
+          stimulus: { controllers: [] }
+        )
+      end
+
+      it "reports API-only apps as not applicable instead of an empty listing" do
+        result = described_class.call
+        text = result.content.first[:text]
+        expect(text).to include("Not applicable")
+        expect(text).to include("API-only")
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_context/tools/get_turbo_map_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_turbo_map_spec.rb
@@ -114,6 +114,17 @@ RSpec.describe RailsAiContext::Tools::GetTurboMap do
     end
   end
 
+  describe ".call for an API-only app" do
+    it "reports API-only apps as not applicable instead of an empty listing" do
+      allow(described_class).to receive(:cached_context).and_return(api: { api_only: true })
+
+      result = described_class.call(controller: "nonexistent_controller_xyz", detail: "standard")
+      text = result.content.first[:text]
+      expect(text).to include("Not applicable")
+      expect(text).to include("API-only")
+    end
+  end
+
   describe "when turbo-rails IS installed (per Gemfile.lock)" do
     let(:lock_path) { File.join(Rails.root.to_s, "Gemfile.lock") }
 

--- a/spec/lib/rails_ai_context/tools/get_view_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_view_spec.rb
@@ -188,6 +188,49 @@ RSpec.describe RailsAiContext::Tools::GetView do
       end
     end
 
+    context "when the app is API-only but has real views (e.g. mailer templates)" do
+      before do
+        allow(described_class).to receive(:cached_context).and_return(
+          api: { api_only: true },
+          view_templates: {
+            templates: { "user_mailer/welcome.html.erb" => { lines: 10 } },
+            partials: {}
+          }
+        )
+      end
+
+      it "keeps the original recovery copy for a controller filter miss instead of the API-only note" do
+        response = described_class.call(controller: "posts")
+        text = response.content.first[:text]
+        expect(text).to include("No views for 'posts'")
+        expect(text).to include("Directories with views: user_mailer")
+        expect(text).not_to include("Not applicable")
+      end
+
+      it "lists the real views for the unfiltered default call" do
+        response = described_class.call
+        text = response.content.first[:text]
+        expect(text).to include("user_mailer/welcome.html.erb")
+        expect(text).not_to include("Not applicable")
+      end
+    end
+
+    context "when the app is API-only with zero views anywhere and no controller filter" do
+      before do
+        allow(described_class).to receive(:cached_context).and_return(
+          api: { api_only: true },
+          view_templates: { templates: {}, partials: {} }
+        )
+      end
+
+      it "reports API-only apps as not applicable for the default unfiltered listing" do
+        response = described_class.call
+        text = response.content.first[:text]
+        expect(text).to include("Not applicable")
+        expect(text).to include("API-only")
+      end
+    end
+
     context "list_layouts hardening" do
       let(:views_dir) { Rails.root.join("app", "views") }
       let(:layouts_dir) { views_dir.join("layouts") }

--- a/spec/lib/rails_ai_context/tools/get_view_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_view_spec.rb
@@ -172,6 +172,22 @@ RSpec.describe RailsAiContext::Tools::GetView do
       end
     end
 
+    context "when the app is API-only" do
+      before do
+        allow(described_class).to receive(:cached_context).and_return(
+          api: { api_only: true },
+          view_templates: { templates: {}, partials: {} }
+        )
+      end
+
+      it "reports API-only apps as not applicable instead of an empty listing" do
+        response = described_class.call(controller: "users")
+        text = response.content.first[:text]
+        expect(text).to include("Not applicable")
+        expect(text).to include("API-only")
+      end
+    end
+
     context "list_layouts hardening" do
       let(:views_dir) { Rails.root.join("app", "views") }
       let(:layouts_dir) { views_dir.join("layouts") }


### PR DESCRIPTION
Makes the gem work on any Rails app: any supported version, any shape, bootable or not. An app that cannot boot now gets real answers instead of a dead process, and every degraded answer says so in-band.

## Static tier (universal-compat phase 2)

`serve` and `tool` no longer exit 1 when the app fails to boot. They fall back to source-file analysis:

- Routes parsed from `config/routes.rb` by a new Prism walker (namespace/scope/resources/member/collection nesting resolved; dynamic constructs like `devise_for` become explicit markers, never guessed routes)
- Schema from `db/schema.rb` / `db/structure.sql` / migrations; structure.sql parsing is now dialect-aware (PostgreSQL, MySQL, SQLite)
- Models and controllers from source via the existing listener stack
- Sections that genuinely need a booted app report `[UNAVAILABLE: <reason>]` through one shared spine instead of fabricating empty answers
- Every response carries a tier banner that survives truncation; `[STATIC]` and `[UNAVAILABLE:]` join the confidence vocabulary
- New CLI flags: `--no-boot` (serve/tool), `--app-path` and `--environment` (all app-reading commands)
- `doctor` keeps requiring a bootable app; that is its job

## Shapes (phase 3)

- `PathResolver`: models/controllers discovered in packwerk `packs/*/app/*`, in-repo `engines/*/app/*`, and configured `extra_app_paths`, both tiers
- Rails 8 multi-database dumps (`db/queue_schema.rb` etc.) reported under an additive `secondary_databases` key with per-file schema versions
- Mongoid: honest `[UNAVAILABLE]` schema signal plus static field/embeds/store_in extraction; hybrid AR+Mongoid apps keep full ActiveRecord reflection
- API-only apps get "Not applicable" from view/frontend tools instead of empty listings indistinguishable from missing views
- `config.auto_mount = true` set in a user initializer now takes effect (the middleware initializer ran before user initializers loaded)

## Hygiene + proof (phases 4-5)

- `prism < 2.0` and `concurrent-ruby < 3.0` caps
- CI matrix corrected: Ruby 3.2 x Rails 8.x now runs (upstream supports 3.2+; the old exclusion premise was wrong)
- Loud stderr warning when the standalone CLI meets Rails 9
- `docs/COMPATIBILITY.md`: tool-by-shape matrix where every cell cites the spec that proves it

## Verification

- Unit: 2608 examples, 0 failures; RuboCop clean
- Full e2e suite: 150 examples, 0 failures (all 39 tools x in-Gemfile/standalone/zero-config installs x stdio/HTTP transports x empty/massive/API-only/structure.sql/multi-DB/packs/engines/Mongoid/broken-boot shapes, on real generated apps)
- All 17 supported Ruby x Rails cells run locally at this HEAD, each 2608/0: Ruby 3.1.7 (Rails 7.0.10/7.1.6/7.2.3.1), 3.2.11 and 3.3.11 and 3.4.9 (7.1/7.2/8.0/8.1), 4.0.5 (8.0.5/8.1.3)

Boot-failure contract change: `tool`/`serve` on a broken app now exit 0 with static answers plus a stderr notice (previously exit 1). The e2e contract tests were updated deliberately; `doctor` behavior is unchanged.
