### PR TITLE
The remaining deepenings from the architecture review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`AstCache.parse_string` caches, as its name always said.** Keyed by
+  content digest, sharing the store and its eviction; oversize sources
+  bypass instead of raising. A controller was parsed up to ten times per
+  static run because every extractor received the text and re-parsed it.
+- **`rails_validate` says which checks it skipped.** When the AST parse
+  fails, the three rules with no regex twin used to vanish silently and a
+  partially-checked file read as clean; the response now names them. The
+  tool also gains its first spec file.
+- **A downstream app exception is the app's again.** The middleware's
+  rescue used to convert any error from the app behind it - non-MCP
+  requests included - into an MCP error frame. `McpEdge.rack_call` now owns
+  the whole Rack-shaped request (path match, session scope, dispatch,
+  containment) for the middleware and the standalone server, and the
+  pass-through branch runs outside the rescue.
+
+### Changed
+
+- **The cache fingerprint watches what the resolvers read.** Packs,
+  engines, `extra_app_paths`, every concern home, the `Gemfile`,
+  `config/locales` and `config/environments` now feed the fingerprint, so
+  an edit there cannot serve a stale answer that looks fresh.
+- **One change-detection loop.** `ChangeWatch` owns the watch list, the
+  Listen wiring, the fingerprint gate and the code reload; `Watcher` and
+  `LiveReload` keep only their reactions (regenerate files; refresh caches
+  and notify clients) and their own missing-`listen` policy.
+- **The initializer guard and the `tool_mode` line each have one home.**
+  `Install::InitializerFile` holds the guard patterns the generator writes
+  and the doctor diagnoses; `SelectionRecord.write_tool_mode` replaces the
+  rake task's hand-rolled three-branch rewriter, and only rewrites an
+  uncommented line, so the generated commented-out default stays a comment.
+- **Split-rule targets derive from the `Install::AiTool` table.** The
+  rules serializers read `rules_dir` (and the AGENTS.md pair) from the
+  table doctor and cleanup already read, so a moved path changes every
+  surface at once.
+- **The stack helper writes through `SafeFile.atomic_write`** instead of a
+  private copy of it, and its app-tree scans take a root, so they are
+  covered by specs for the first time.
+- **Every serializer is proven against a context real introspectors
+  produced** (`IntrospectedFixture`), so no serializer can read a shape
+  production does not make - the class of defect that kept the engines and
+  turbo sections dead while hand-built fixtures stayed green.
+
 ## [5.22.0] - 2026-08-16
 
 ### Fixed

--- a/lib/generators/rails_ai_context/install/install_generator.rb
+++ b/lib/generators/rails_ai_context/install/install_generator.rb
@@ -38,12 +38,7 @@ module RailsAiContext
       class_option :defaults, type: :boolean, default: false,
         desc: "Skip all interactive prompts and use each prompt's documented default (for CI/non-interactive use)"
 
-      # The initializer guard written before this gem checked respond_to?(:configure).
-      # A path:/git: gemspec is evaluated in-process by Bundler in every environment,
-      # defining a VERSION-only stub `RailsAiContext` module even when the gem itself
-      # isn't in the current Bundler group - so `defined?(RailsAiContext)` alone
-      # doesn't prove `.configure` exists.
-      BARE_GUARD_PATTERN = /^([ \t]*)if defined\?\(RailsAiContext\)$/
+      BARE_GUARD_PATTERN = RailsAiContext::Install::InitializerFile::BARE_GUARD
 
       def select_ai_tools
         @selected_formats = RailsAiContext::Install::Program.select_ai_tools(program_surface)
@@ -373,7 +368,7 @@ module RailsAiContext
         body = header_match ? content.delete_prefix(header_match[0]) : content
         body = "#{body}\n" unless body.end_with?("\n")
 
-        wrapped = "#{header}if defined?(RailsAiContext) && RailsAiContext.respond_to?(:configure)\n#{indent_content(body)}end\n"
+        wrapped = "#{header}#{RailsAiContext::Install::InitializerFile::GUARD_LINE}\n#{indent_content(body)}end\n"
         [ wrapped, wrapped != content ]
       end
 
@@ -382,7 +377,7 @@ module RailsAiContext
       # No-op if the guard is already the current form.
       def upgrade_bare_guard(content)
         upgraded = content.sub(BARE_GUARD_PATTERN) do
-          "#{Regexp.last_match(1)}if defined?(RailsAiContext) && RailsAiContext.respond_to?(:configure)"
+          "#{Regexp.last_match(1)}#{RailsAiContext::Install::InitializerFile::GUARD_LINE}"
         end
         [ upgraded, upgraded != content ]
       end
@@ -404,11 +399,7 @@ module RailsAiContext
       end
 
       def guarded_initializer?(content)
-        # Matches the current guard (which also checks respond_to?(:configure)) as
-        # well as the older bare guard, so re-running the generator neither
-        # double-wraps an initializer nor treats an unguarded one as guarded.
-        content.match?(BARE_GUARD_PATTERN) ||
-          content.match?(/^[ \t]*if defined\?\(RailsAiContext\)\s*&&\s*RailsAiContext\.respond_to\?\(:configure\)$/)
+        RailsAiContext::Install::InitializerFile.guarded?(content)
       end
 
       def indent_content(content)

--- a/lib/rails_ai_context/ast_cache.rb
+++ b/lib/rails_ai_context/ast_cache.rb
@@ -41,10 +41,21 @@ module RailsAiContext
       STORE.compute_if_absent(key) { Prism.parse(content) }
     end
 
-    # Parse a Ruby source string (no caching).
-    # Returns a Prism::ParseResult.
+    # Parse a Ruby source string, cached by content digest. The name always
+    # promised a cache; the implementation was a bypass, so a controller was
+    # parsed up to ten times per static run because every extractor received
+    # the text and re-parsed it.
     def self.parse_string(source)
-      Prism.parse(source)
+      return Prism.parse(source) if source.bytesize > MAX_PARSE_SIZE
+
+      key = "string:#{Digest::SHA256.hexdigest(source)}"
+
+      cached = STORE[key]
+      return cached if cached
+
+      evict_if_full
+
+      STORE.compute_if_absent(key) { Prism.parse(source) }
     end
 
     # Invalidate all cached entries for a given path.

--- a/lib/rails_ai_context/change_watch.rb
+++ b/lib/rails_ai_context/change_watch.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module RailsAiContext
+  # Notices that the app actually changed: the watch list, the Listen
+  # wiring, the fingerprint gate and the code reload, stated once. Watcher
+  # and LiveReload were two implementations of this loop that differed only
+  # in their reaction, and the copies had grown apart where nobody chose -
+  # different watch lists, and a fingerprint gate maintained twice.
+  #
+  # The caller supplies the reaction (regenerate files, or refresh caches
+  # and notify clients) and its own policy for a missing `listen` gem -
+  # start raises LoadError so a CLI can exit and a server can downgrade.
+  class ChangeWatch
+    # The union the two watchers had converged on, one home. config and db
+    # cover their subdirectories; the app/ entries mirror what the
+    # fingerprint reads.
+    WATCH_DIRS = %w[
+      app/models app/controllers app/views app/jobs app/mailers
+      app/channels app/components app/helpers app/services
+      app/javascript/controllers app/middleware
+      config db lib/tasks
+    ].freeze
+
+    def initialize(app)
+      @app = app
+      @last_fingerprint = Fingerprinter.compute(app)
+    end
+
+    def watched_dirs
+      root = @app.root.to_s
+      WATCH_DIRS.map { |p| File.join(root, p) }.select { |d| Dir.exist?(d) }
+    end
+
+    # Wires Listen to the watched directories and runs every change batch
+    # through the gate. Returns the listener, or nil when nothing is
+    # watchable.
+    def start(debounce: nil, &reaction)
+      require "listen"
+
+      dirs = watched_dirs
+      return nil if dirs.empty?
+
+      options = debounce ? { wait_for_delay: debounce } : {}
+      @listener = Listen.to(*dirs, **options) do |modified, added, removed|
+        changed = modified + added + removed
+        next if changed.empty?
+
+        gate(changed, &reaction)
+      end
+      @listener.start
+      @listener
+    end
+
+    def stop
+      @listener&.stop
+    end
+
+    # The part both reactions share: nothing happened unless the fingerprint
+    # moved, and the reaction sees fresh code - without the reload, a
+    # reaction describes the app as it was when the watch started.
+    def gate(paths, &reaction)
+      return unless Fingerprinter.changed?(@app, @last_fingerprint)
+
+      @last_fingerprint = Fingerprinter.compute(@app)
+      reloaded = CodeReloader.reload!
+      reaction.call(paths, reloaded)
+    rescue => e
+      $stderr.puts "[rails-ai-context] Change watch error: #{e.message}"
+    end
+  end
+end

--- a/lib/rails_ai_context/doctor.rb
+++ b/lib/rails_ai_context/doctor.rb
@@ -241,7 +241,7 @@ module RailsAiContext
       return nil unless File.exist?(path)
 
       content = File.read(path)
-      return nil unless content.match?(/^[ \t]*if defined\?\(RailsAiContext\)$/)
+      return nil unless Install::InitializerFile.bare_guard?(content)
 
       Check.new(name: "Initializer guard", status: :warn,
         message: "config/initializers/rails_ai_context.rb guards on `defined?(RailsAiContext)` alone",

--- a/lib/rails_ai_context/fingerprinter.rb
+++ b/lib/rails_ai_context/fingerprinter.rb
@@ -11,6 +11,7 @@ module RailsAiContext
       db/structure.sql
       config/routes.rb
       config/database.yml
+      Gemfile
       Gemfile.lock
       package.json
       tsconfig.json
@@ -24,11 +25,26 @@ module RailsAiContext
       app/mailers
       app/channels
       app/components
+      app/helpers
+      app/services
       app/javascript/controllers
       app/middleware
       config/initializers
+      config/locales
+      config/environments
       db/migrate
       lib/tasks
+    ].freeze
+
+    # The kinds whose homes PathResolver resolves beyond the conventional
+    # tree - packs/*, engines/* and configured extras. Derived at compute
+    # time so an edit in a pack invalidates the cache the way one in app/
+    # does; a stale answer that looks fresh is the failure this exists to
+    # prevent. WATCHED_DIRS stays a plain list because live_reload and the
+    # watcher consume it as relative patterns.
+    RESOLVED_KINDS = %w[
+      app/models app/controllers app/views app/jobs app/mailers
+      app/channels app/components app/helpers app/services
     ].freeze
 
     class << self
@@ -54,10 +70,7 @@ module RailsAiContext
           # File deleted between exist? check and mtime read - skip
         end
 
-        WATCHED_DIRS.each do |dir|
-          full_dir = File.join(root, dir)
-          next unless Dir.exist?(full_dir)
-
+        watched_dirs(root).each do |full_dir|
           Dir.glob(File.join(full_dir, "**/*.{rb,rake,js,ts,erb,haml,slim,yml}")).sort.each do |path|
             digest.update(File.mtime(path).to_f.to_s)
           rescue Errno::ENOENT
@@ -66,6 +79,16 @@ module RailsAiContext
         end
 
         digest.hexdigest
+      end
+
+      # Everything a change could hide in: the conventional dirs plus what
+      # the resolvers add for this app (packs, engines, extra_app_paths,
+      # concern homes such as app/serializers/concerns).
+      def watched_dirs(root)
+        conventional = WATCHED_DIRS.map { |dir| File.join(root, dir) }
+        resolved = RESOLVED_KINDS.flat_map { |kind| PathResolver.dirs_for(root, kind) }
+
+        (conventional + resolved + ConcernPaths.resolve(root)).uniq.select { |dir| Dir.exist?(dir) }
       end
 
       # Clear the memoized gem-lib fingerprint. Called by BaseTool.reset_cache!

--- a/lib/rails_ai_context/install/ai_tool.rb
+++ b/lib/rails_ai_context/install/ai_tool.rb
@@ -10,7 +10,13 @@ module RailsAiContext
     #
     # Vocabulary per CONTEXT.md: "AI tool" for the assistant, "context files"
     # for what the gem generates for it.
-    AiTool = Struct.new(:number, :key, :name, :files, :context_paths, :mcp_config, :legacy_paths,
+    #
+    # context_paths lists the root file first; what follows are the
+    # split-rule targets. rules_dir is the gem-owned directory of split rule
+    # files, nil for tools whose split targets are files (the AGENTS.md
+    # pair). The writers derive from these, the same as doctor and cleanup -
+    # a moved path must change every surface at once.
+    AiTool = Struct.new(:number, :key, :name, :files, :context_paths, :rules_dir, :mcp_config, :legacy_paths,
                         keyword_init: true)
 
     class AiTool
@@ -19,6 +25,7 @@ module RailsAiContext
           number: "1", key: :claude, name: "Claude Code",
           files: "CLAUDE.md + .claude/rules/",
           context_paths: %w[CLAUDE.md .claude/rules],
+          rules_dir: ".claude/rules",
           mcp_config: { path: ".mcp.json", root_key: "mcpServers", format: :mcp_json },
           legacy_paths: [ ".claude/rules/rails-ui-patterns.md", ".claude/rules/rails-accessibility.md" ]
         ),
@@ -26,6 +33,7 @@ module RailsAiContext
           number: "2", key: :cursor, name: "Cursor",
           files: ".cursor/rules/ + .cursorrules (legacy fallback)",
           context_paths: %w[.cursor/rules .cursorrules],
+          rules_dir: ".cursor/rules",
           mcp_config: { path: ".cursor/mcp.json", root_key: "mcpServers", format: :mcp_json },
           legacy_paths: [ ".cursor/rules/rails-ui-patterns.mdc" ]
         ),
@@ -33,6 +41,7 @@ module RailsAiContext
           number: "3", key: :copilot, name: "GitHub Copilot",
           files: ".github/copilot-instructions.md + .github/instructions/",
           context_paths: %w[.github/copilot-instructions.md .github/instructions],
+          rules_dir: ".github/instructions",
           mcp_config: { path: ".vscode/mcp.json", root_key: "servers", format: :vscode_json },
           legacy_paths: [ ".github/instructions/rails-ui-patterns.instructions.md" ]
         ),

--- a/lib/rails_ai_context/install/initializer_file.rb
+++ b/lib/rails_ai_context/install/initializer_file.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module RailsAiContext
+  module Install
+    # The initializer guard's vocabulary, in one place. The generator wraps
+    # and upgrades the guard and the doctor diagnoses it; each carried its own
+    # copy of the pattern, and the copies had already been restated once.
+    #
+    # The bare form predates the respond_to? check: a path:/git: gemspec is
+    # evaluated in-process by Bundler in every environment, defining a
+    # VERSION-only stub `RailsAiContext` module even when the gem is not in
+    # the current group - so `defined?(RailsAiContext)` alone does not prove
+    # `.configure` exists.
+    module InitializerFile
+      BARE_GUARD = /^([ \t]*)if defined\?\(RailsAiContext\)$/
+      CURRENT_GUARD = /^[ \t]*if defined\?\(RailsAiContext\)\s*&&\s*RailsAiContext\.respond_to\?\(:configure\)$/
+      GUARD_LINE = "if defined?(RailsAiContext) && RailsAiContext.respond_to?(:configure)"
+
+      module_function
+
+      def bare_guard?(content)
+        content.match?(BARE_GUARD)
+      end
+
+      # Either form counts as guarded, so a re-run neither double-wraps an
+      # initializer nor treats an unguarded one as guarded.
+      def guarded?(content)
+        content.match?(BARE_GUARD) || content.match?(CURRENT_GUARD)
+      end
+    end
+  end
+end

--- a/lib/rails_ai_context/install/selection_record.rb
+++ b/lib/rails_ai_context/install/selection_record.rb
@@ -55,6 +55,40 @@ module RailsAiContext
         mode_from_initializer(root) || mode_from_yaml(root)
       end
 
+      # Rewrites (or inserts) the tool_mode line, the way `write` handles the
+      # tools line. The rake task carried its own three-branch rewriter with a
+      # duplicate of CONFIGURE_BLOCK; the file's shape belongs here. Only an
+      # uncommented line is rewritten - the generated initializer ships a
+      # commented-out default that must stay a comment.
+      #
+      # @return [Symbol] :updated, :inserted, :unchanged or :absent
+      def write_tool_mode(mode, root:)
+        path = File.join(root.to_s, INITIALIZER)
+        return :absent unless File.exist?(path)
+
+        content = File.read(path)
+        line = "  config.tool_mode = :#{mode}"
+
+        if content.match?(MODE_LINE)
+          updated = content.sub(/^[ \t]*config\.tool_mode\s*=.*$/, line)
+          return :unchanged if updated == content
+
+          File.write(path, updated)
+          :updated
+        elsif content.match?(SELECTION_LINE)
+          File.write(path, content.sub(/^([ \t]*config\.ai_tools\s*=[^\n]*)$/) { "#{Regexp.last_match(1)}\n#{line}" })
+          :inserted
+        elsif content.match?(CONFIGURE_BLOCK)
+          File.write(path, content.sub(CONFIGURE_BLOCK) { "#{Regexp.last_match(0)}#{line}\n" })
+          :inserted
+        else
+          :absent
+        end
+      rescue StandardError => e
+        RailsAiContext.log_warn "[rails-ai-context] could not write #{INITIALIZER}: #{e.message}"
+        :unchanged
+      end
+
       # Records the selection in both places and says what it did, because
       # every entry prints its own "Created / Updated / unchanged" line and
       # would otherwise keep its own copy of the writing just to know which.

--- a/lib/rails_ai_context/live_reload.rb
+++ b/lib/rails_ai_context/live_reload.rb
@@ -1,82 +1,47 @@
 # frozen_string_literal: true
 
 module RailsAiContext
-  # Watches for file changes and automatically invalidates MCP tool caches,
-  # sending notifications to connected AI clients so they re-query fresh data.
-  # Runs a background thread alongside the MCP server (stdio or HTTP).
+  # Keeps a long-lived MCP server truthful: when the app changes, drop the
+  # tool caches and tell connected clients to re-query. The loop - watch
+  # list, fingerprint gate, code reload - is ChangeWatch's; this supplies
+  # the non-blocking background behavior, the debounce, and the
+  # cache-and-notify reaction. A missing `listen` gem raises out of start;
+  # Server#maybe_start_live_reload owns that policy.
   class LiveReload
     include CountPhrase
-
-    WATCH_DIRS = (Watcher::WATCH_PATTERNS | Fingerprinter::WATCHED_DIRS).freeze
 
     attr_reader :app, :mcp_server
 
     def initialize(app, mcp_server)
       @app = app
       @mcp_server = mcp_server
-      @last_fingerprint = Fingerprinter.compute(app)
+      @watch = ChangeWatch.new(app)
     end
 
     # Start the file watcher in a background thread. Non-blocking.
     def start
-      require "listen"
-
-      root = app.root.to_s
-      debounce = RailsAiContext.configuration.live_reload_debounce
-      dirs = WATCH_DIRS.map { |p| File.join(root, p) }.select { |d| Dir.exist?(d) }
-
+      dirs = @watch.watched_dirs
       if dirs.empty?
         $stderr.puts "[rails-ai-context] Live reload: no watchable directories found"
         return
       end
 
+      debounce = RailsAiContext.configuration.live_reload_debounce
       $stderr.puts "[rails-ai-context] Live reload enabled (debounce: #{debounce}s)"
-      $stderr.puts "[rails-ai-context] Watching: #{dirs.map { |d| d.sub("#{root}/", "") }.join(", ")}"
+      $stderr.puts "[rails-ai-context] Watching: #{dirs.map { |d| d.sub("#{app.root}/", "") }.join(", ")}"
 
-      listener = Listen.to(*dirs, wait_for_delay: debounce) do |modified, added, removed|
-        all_changes = modified + added + removed
-        next if all_changes.empty?
-
-        handle_change(all_changes)
-      end
-
-      listener.start
-      @listener = listener
+      @watch.start(debounce: debounce) { |paths, reloaded| react(paths, reloaded) }
     end
 
     # Stop the background listener thread.
     def stop
-      @listener&.stop
+      @watch.stop
     end
 
-    # Process a batch of file changes. Public for testability.
+    # Run a batch of changed paths through the shared gate. Public for
+    # testability - specs drive this instead of a real Listen thread.
     def handle_change(changed_paths = [])
-      return unless Fingerprinter.changed?(app, @last_fingerprint)
-
-      @last_fingerprint = Fingerprinter.compute(app)
-
-      # Order matters: reload the app's code first, then drop the caches built
-      # from the old constants. Clearing caches alone left the server answering
-      # from whatever Rails autoloaded at boot.
-      reloaded = CodeReloader.reload!
-
-      # Invalidate all tool caches (includes AstCache.clear)
-      Tools::BaseTool.reset_all_caches!
-
-      # Build a human-readable change summary
-      message = format_change_message(categorize_changes(changed_paths))
-
-      # Notify connected MCP clients
-      mcp_server.notify_resources_list_changed
-      mcp_server.notify_log_message(
-        data: "#{message} Tool caches invalidated#{reloaded ? " and app code reloaded" : ""}.",
-        level: "info",
-        logger: "rails-ai-context"
-      )
-
-      $stderr.puts "[rails-ai-context] #{message} Tool caches invalidated#{reloaded ? " and app code reloaded" : ""}."
-    rescue => e
-      $stderr.puts "[rails-ai-context] Live reload error: #{e.message}"
+      @watch.gate(changed_paths) { |paths, reloaded| react(paths, reloaded) }
     end
 
     # Group changed file paths by category (model, controller, etc.)
@@ -109,6 +74,28 @@ module RailsAiContext
     def format_change_message(categories)
       parts = categories.map { |cat, count| count_phrase(count, cat) }
       "Files changed: #{parts.join(", ")}."
+    end
+
+    private
+
+    # The gate already reloaded the app's code; dropping the caches after
+    # that order is what keeps the server from answering with constants
+    # Rails autoloaded at boot.
+    def react(paths, reloaded)
+      Tools::BaseTool.reset_all_caches!
+
+      message = format_change_message(categorize_changes(paths))
+
+      mcp_server.notify_resources_list_changed
+      mcp_server.notify_log_message(
+        data: "#{message} Tool caches invalidated#{reloaded ? " and app code reloaded" : ""}.",
+        level: "info",
+        logger: "rails-ai-context"
+      )
+
+      $stderr.puts "[rails-ai-context] #{message} Tool caches invalidated#{reloaded ? " and app code reloaded" : ""}."
+    rescue => e
+      $stderr.puts "[rails-ai-context] Live reload error: #{e.message}"
     end
   end
 end

--- a/lib/rails_ai_context/mcp_edge.rb
+++ b/lib/rails_ai_context/mcp_edge.rb
@@ -31,9 +31,31 @@ module RailsAiContext
         [ 500, { "Content-Type" => "application/json" }, [ internal_error_frame(error) ] ]
       end
 
-      # Memoization is the caller's: the middleware holds one per instance,
-      # the controller one per class, and the standalone server one per
-      # process.
+      # The whole Rack-shaped request: the path match (trailing slash
+      # included), session scoping, dispatch and error containment. The
+      # middleware and the standalone server used to state these ten lines
+      # separately, and only the non-match branch differs, so the caller
+      # supplies it as the block. The block runs outside the rescue: an
+      # exception from the app behind the middleware is the app's to handle,
+      # not an MCP error frame.
+      def rack_call(env, transport:)
+        path = RailsAiContext.configuration.http_path
+        return yield unless env["PATH_INFO"] == path || env["PATH_INFO"] == "#{path}/"
+
+        begin
+          request = Rack::Request.new(env)
+          Tools::BaseTool.with_session_for(env) do
+            transport.handle_request(request)
+          end
+        rescue => e
+          internal_error_response(e)
+        end
+      end
+
+      # Memoization is the caller's: the middleware holds one per instance
+      # and the controller one per class. The standalone server builds its
+      # own transport because start_http also needs the underlying server
+      # for the banner and live reload.
       def build_transport(app = nil)
         app ||= Rails.application
         MCP::Server::Transports::StreamableHTTPTransport.new(Server.new(app, transport: :http).build)

--- a/lib/rails_ai_context/middleware.rb
+++ b/lib/rails_ai_context/middleware.rb
@@ -15,19 +15,7 @@ module RailsAiContext
     end
 
     def call(env)
-      config = RailsAiContext.configuration
-      path = config.http_path
-
-      if env["PATH_INFO"] == path || env["PATH_INFO"] == "#{path}/"
-        request = Rack::Request.new(env)
-        Tools::BaseTool.with_session_for(env) do
-          transport.handle_request(request)
-        end
-      else
-        @app.call(env)
-      end
-    rescue => e
-      McpEdge.internal_error_response(e)
+      McpEdge.rack_call(env, transport: transport) { @app.call(env) }
     end
 
     private

--- a/lib/rails_ai_context/serializers/claude_rules_serializer.rb
+++ b/lib/rails_ai_context/serializers/claude_rules_serializer.rb
@@ -17,7 +17,7 @@ module RailsAiContext
       # @param output_dir [String] Rails root path
       # @return [Hash] { written: [paths], skipped: [paths] }
       def call(output_dir)
-        rules_dir = File.join(output_dir, ".claude", "rules")
+        rules_dir = File.join(output_dir, Install::AiTool.find(:claude).rules_dir)
 
         files = {
           File.join(rules_dir, "rails-context.md") => render_context_overview,

--- a/lib/rails_ai_context/serializers/copilot_instructions_serializer.rb
+++ b/lib/rails_ai_context/serializers/copilot_instructions_serializer.rb
@@ -15,7 +15,7 @@ module RailsAiContext
       end
 
       def call(output_dir)
-        dir = File.join(output_dir, ".github", "instructions")
+        dir = File.join(output_dir, Install::AiTool.find(:copilot).rules_dir)
 
         files = {
           File.join(dir, "rails-context.instructions.md") => render_context_instructions,

--- a/lib/rails_ai_context/serializers/cursor_rules_serializer.rb
+++ b/lib/rails_ai_context/serializers/cursor_rules_serializer.rb
@@ -28,7 +28,7 @@ module RailsAiContext
       # @param output_dir [String] Rails root path
       # @return [Hash] { written: [paths], skipped: [paths] }
       def call(output_dir)
-        rules_dir = File.join(output_dir, ".cursor", "rules")
+        rules_dir = File.join(output_dir, Install::AiTool.find(:cursor).rules_dir)
 
         # Split rule files (.cursor/rules/*.mdc) are fully gem-owned.
         # written as-is with no markers (the gem manages every file in

--- a/lib/rails_ai_context/serializers/opencode_rules_serializer.rb
+++ b/lib/rails_ai_context/serializers/opencode_rules_serializer.rb
@@ -20,14 +20,19 @@ module RailsAiContext
 
       # @param output_dir [String] Rails root path
       # @return [Hash] { written: [paths], skipped: [paths] }
+      RENDERERS = {
+        "app/models/AGENTS.md" => :render_models_reference,
+        "app/controllers/AGENTS.md" => :render_controllers_reference
+      }.freeze
+
       def call(output_dir)
         files = {}
 
-        [ [ "app", "models", "AGENTS.md", :render_models_reference ],
-          [ "app", "controllers", "AGENTS.md", :render_controllers_reference ] ].each do |*parts, method|
-          filepath = File.join(output_dir, *parts)
+        # The split targets after the root file, per the table's convention.
+        Install::AiTool.find(:opencode).context_paths.drop(1).each do |relative|
+          filepath = File.join(output_dir, relative)
           next unless Dir.exist?(File.dirname(filepath))
-          files[filepath] = send(method)
+          files[filepath] = send(RENDERERS.fetch(relative))
         end
 
         write_rule_files(files)

--- a/lib/rails_ai_context/serializers/stack_overview_helper.rb
+++ b/lib/rails_ai_context/serializers/stack_overview_helper.rb
@@ -159,11 +159,7 @@ module RailsAiContext
           if File.exist?(filepath) && File.read(filepath) == content
             skipped << filepath
           else
-            dir = File.dirname(filepath)
-            FileUtils.mkdir_p(dir)
-            tmp = File.join(dir, ".#{File.basename(filepath)}.#{SecureRandom.hex(4)}.tmp")
-            File.write(tmp, content)
-            File.rename(tmp, filepath)
+            SafeFile.atomic_write(filepath, content)
             written << filepath
           end
         end
@@ -177,9 +173,10 @@ module RailsAiContext
         defined?(Rails) && Rails.respond_to?(:root) && Rails.root ? Rails.root.to_s : Dir.pwd
       end
 
-      # Scan app/services/ for service object class names.
-      def detect_service_files
-        dir = File.join(project_root, "app", "services")
+      # Scan app/services/ for service object class names. The root
+      # parameter is the test seam - specs point it at a fixture tree.
+      def detect_service_files(root = project_root)
+        dir = File.join(root, "app", "services")
         return [] unless Dir.exist?(dir)
         Dir.glob(File.join(dir, "*.rb"))
           .map { |f| File.basename(f, ".rb").camelize }
@@ -190,8 +187,8 @@ module RailsAiContext
       end
 
       # Scan app/jobs/ for job class names.
-      def detect_job_files
-        dir = File.join(project_root, "app", "jobs")
+      def detect_job_files(root = project_root)
+        dir = File.join(root, "app", "jobs")
         return [] unless Dir.exist?(dir)
         Dir.glob(File.join(dir, "*.rb"))
           .map { |f| File.basename(f, ".rb").camelize }
@@ -202,8 +199,8 @@ module RailsAiContext
       end
 
       # Extract before_action names from ApplicationController source.
-      def detect_before_actions
-        app_ctrl_file = File.join(project_root, "app", "controllers", "application_controller.rb")
+      def detect_before_actions(root = project_root)
+        app_ctrl_file = File.join(root, "app", "controllers", "application_controller.rb")
         return [] unless File.exist?(app_ctrl_file)
         File.read(app_ctrl_file).scan(/before_action\s+:([\w!?]+)/).flatten
       rescue => e

--- a/lib/rails_ai_context/server.rb
+++ b/lib/rails_ai_context/server.rb
@@ -202,7 +202,7 @@ module RailsAiContext
       transport = MCP::Server::Transports::StreamableHTTPTransport.new(server)
 
       # Build a minimal Rack app that delegates to the MCP transport
-      rack_app = build_rack_app(transport, config.http_path)
+      rack_app = build_rack_app(transport)
 
       loopback = %w[127.0.0.1 ::1 localhost].freeze
       unless loopback.include?(config.http_bind)
@@ -274,19 +274,11 @@ module RailsAiContext
       end
     end
 
-    def build_rack_app(transport, path)
+    def build_rack_app(transport)
       lambda do |env|
-        # Only handle requests at the configured MCP path
-        unless env["PATH_INFO"] == path || env["PATH_INFO"] == "#{path}/"
-          return [ 404, { "Content-Type" => "application/json" }, [ '{"error":"Not found"}' ] ]
+        McpEdge.rack_call(env, transport: transport) do
+          [ 404, { "Content-Type" => "application/json" }, [ '{"error":"Not found"}' ] ]
         end
-
-        request = Rack::Request.new(env)
-        Tools::BaseTool.with_session_for(env) do
-          transport.handle_request(request)
-        end
-      rescue => e
-        McpEdge.internal_error_response(e)
       end
     end
   end

--- a/lib/rails_ai_context/tasks/rails_ai_context.rake
+++ b/lib/rails_ai_context/tasks/rails_ai_context.rake
@@ -66,24 +66,7 @@ def prompt_tool_mode
 end unless defined?(prompt_tool_mode)
 
 def save_tool_mode_to_initializer(mode)
-  init_path = Rails.root.join("config/initializers/rails_ai_context.rb")
-  return unless File.exist?(init_path)
-
-  content = File.read(init_path)
-  mode_line = "  config.tool_mode = :#{mode}"
-
-  if content.include?("config.tool_mode")
-    content.sub!(/^.*config\.tool_mode.*$/, mode_line)
-  elsif content.include?("config.ai_tools")
-    # Insert after ai_tools line
-    content.sub!(/^(.*config\.ai_tools.*)$/, "\\1\n#{mode_line}")
-  elsif content.include?("RailsAiContext.configure")
-    content.sub!(/RailsAiContext\.configure do \|config\|\n/, "RailsAiContext.configure do |config|\n#{mode_line}\n")
-  else
-    return
-  end
-
-  File.write(init_path, content)
+  RailsAiContext::Install::SelectionRecord.write_tool_mode(mode, root: Rails.root)
 rescue => e
   $stderr.puts "[rails-ai-context] save_tool_mode_to_initializer failed: #{e.message}" if ENV["DEBUG"]
   nil

--- a/lib/rails_ai_context/tools/validate_semantics.rb
+++ b/lib/rails_ai_context/tools/validate_semantics.rb
@@ -221,6 +221,9 @@ module RailsAiContext
           else
             warnings.concat(check_route_helpers_regex(file, content, context))
             warnings.concat(check_column_references_regex(file, content, context))
+            # Three AST checks have no regex twin. Saying so keeps a partial
+            # answer from reading as "checked and clean".
+            warnings << "AST parse failed - strong_params, callback and partial checks skipped for this file"
           end
           # Cache-only checks (no AST needed)
           warnings.concat(check_has_many_dependent(file, context))

--- a/lib/rails_ai_context/watcher.rb
+++ b/lib/rails_ai_context/watcher.rb
@@ -1,32 +1,22 @@
 # frozen_string_literal: true
 
 module RailsAiContext
-  # File system watcher that regenerates context files when key files change.
-  # Requires the `listen` gem (optional dependency).
+  # Regenerates context files when the app changes. The loop - watch list,
+  # fingerprint gate, code reload - is ChangeWatch's; this supplies the
+  # blocking foreground behavior and the regeneration reaction. Interactive
+  # by nature, so it also gets the one-time legacy-files prompt the
+  # server-side reload deliberately skips.
   class Watcher
-    DEBOUNCE_SECONDS = 2
-    WATCH_PATTERNS = %w[
-      app/models
-      app/controllers
-      app/jobs
-      app/mailers
-      app/javascript/controllers
-      config
-      db
-    ].freeze
-
     attr_reader :app
 
     def initialize(app = nil)
       @app = app || Rails.application
-      @last_fingerprint = Fingerprinter.compute(@app)
+      @watch = ChangeWatch.new(@app)
     end
 
     def start
-      require "listen"
-
       root = app.root.to_s
-      dirs = WATCH_PATTERNS.map { |p| File.join(root, p) }.select { |d| Dir.exist?(d) }
+      dirs = @watch.watched_dirs
 
       if dirs.empty?
         $stderr.puts "[rails-ai-context] No watchable directories found"
@@ -43,19 +33,15 @@ module RailsAiContext
       $stderr.puts "[rails-ai-context] Watching for changes..."
       $stderr.puts "[rails-ai-context] Directories: #{dirs.map { |d| d.sub("#{root}/", '') }.join(', ')}"
 
-      listener = Listen.to(*dirs) do |modified, added, removed|
-        next if (modified + added + removed).empty?
-        handle_change
-      end
-
-      listener.start
+      listener = @watch.start { |_paths, _reloaded| regenerate }
+      return unless listener
 
       # Keep the process alive
       loop do
         sleep 1
       rescue Interrupt
         $stderr.puts "\n[rails-ai-context] Stopping watcher..."
-        listener.stop
+        @watch.stop
         break
       end
     rescue LoadError
@@ -64,17 +50,16 @@ module RailsAiContext
       exit 1
     end
 
+    # Run one change batch through the shared gate. Public for testability -
+    # specs drive this instead of a real Listen thread.
+    def handle_change(paths = [])
+      @watch.gate(paths) { |_paths, _reloaded| regenerate }
+    end
+
     private
 
-    def handle_change
-      return unless Fingerprinter.changed?(app, @last_fingerprint)
-
-      @last_fingerprint = Fingerprinter.compute(app)
-
+    def regenerate
       $stderr.puts "[rails-ai-context] Changes detected, regenerating context files..."
-      # Without this the regenerated files describe the app as it was when the
-      # watcher started, not as it is now.
-      CodeReloader.reload!
       result = RailsAiContext.generate_context(format: :all)
       result[:written].each { |f| $stderr.puts "  Updated: #{f}" }
       result[:skipped].each { |f| $stderr.puts "  Unchanged: #{f}" }

--- a/spec/lib/rails_ai_context/ast_cache_spec.rb
+++ b/spec/lib/rails_ai_context/ast_cache_spec.rb
@@ -75,4 +75,35 @@ RSpec.describe RailsAiContext::AstCache do
       large.close!
     end
   end
+
+  describe ".parse_string" do
+    before { described_class.clear }
+
+    it "parses a source string once and serves the rest from the cache" do
+      source = "class CachedProbe\n  def index; end\nend\n"
+
+      expect(Prism).to receive(:parse).once.and_call_original
+      first = described_class.parse_string(source)
+      second = described_class.parse_string(source)
+
+      expect(second).to equal(first)
+      expect(described_class.size).to eq(1)
+    end
+
+    it "keeps distinct sources distinct" do
+      a = described_class.parse_string("class A; end\n")
+      b = described_class.parse_string("class B; end\n")
+
+      expect(a).not_to equal(b)
+      expect(described_class.size).to eq(2)
+    end
+
+    it "bypasses the cache for oversize sources instead of raising" do
+      stub_const("RailsAiContext::AstCache::MAX_PARSE_SIZE", 10)
+
+      result = described_class.parse_string("class TooBigForTheCache; end\n")
+      expect(result).to be_a(Prism::ParseResult)
+      expect(described_class.size).to eq(0)
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/fingerprinter_spec.rb
+++ b/spec/lib/rails_ai_context/fingerprinter_spec.rb
@@ -69,6 +69,28 @@ RSpec.describe RailsAiContext::Fingerprinter do
       expect(described_class::WATCHED_FILES).to include("tsconfig.json")
     end
 
+    it "includes the Gemfile in WATCHED_FILES" do
+      expect(described_class::WATCHED_FILES).to include("Gemfile")
+    end
+
+    it "watches a packwerk pack's models, so a pack edit invalidates the cache" do
+      require "tmpdir"
+      Dir.mktmpdir do |root|
+        FileUtils.mkdir_p(File.join(root, "packs", "billing", "app", "models"))
+        dirs = described_class.send(:watched_dirs, root)
+        expect(dirs).to include(File.join(root, "packs", "billing", "app", "models"))
+      end
+    end
+
+    it "watches every concern home the resolver names" do
+      require "tmpdir"
+      Dir.mktmpdir do |root|
+        FileUtils.mkdir_p(File.join(root, "app", "serializers", "concerns"))
+        dirs = described_class.send(:watched_dirs, root)
+        expect(dirs).to include(File.join(root, "app", "serializers", "concerns"))
+      end
+    end
+
     it "detects changes to package.json" do
       package_json = File.join(Rails.root, "package.json")
       next unless File.exist?(package_json)

--- a/spec/lib/rails_ai_context/install/ai_tool_ownership_spec.rb
+++ b/spec/lib/rails_ai_context/install/ai_tool_ownership_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe "AI tool identity ownership" do
     expect(paths).to eq(RailsAiContext::Install::AiTool.all.to_h { |t| [ t.key, t.mcp_config[:path] ] })
   end
 
+  it "keeps every rules_dir inside the tool's own context paths" do
+    RailsAiContext::Install::AiTool.all.each do |tool|
+      next unless tool.rules_dir
+
+      expect(tool.context_paths).to include(tool.rules_dir),
+        "#{tool.key}: rules_dir #{tool.rules_dir} is not one of its context_paths"
+    end
+  end
+
   it "derives doctor's tool list from the table" do
     expect(RailsAiContext::Doctor::ALL_AI_TOOLS)
       .to eq(RailsAiContext::Install::AiTool.all.map(&:key))

--- a/spec/lib/rails_ai_context/install/selection_record_spec.rb
+++ b/spec/lib/rails_ai_context/install/selection_record_spec.rb
@@ -455,4 +455,41 @@ RSpec.describe RailsAiContext::Install::SelectionRecord do
       expect(described_class.tool_mode(root: root)).to be_nil
     end
   end
+
+  describe ".write_tool_mode" do
+    it "rewrites an existing uncommented line" do
+      write_initializer("RailsAiContext.configure do |config|\n  config.tool_mode = :mcp\nend\n")
+
+      expect(described_class.write_tool_mode(:cli, root: root)).to eq(:updated)
+      expect(described_class.tool_mode(root: root)).to eq(:cli)
+    end
+
+    it "inserts beside the recorded tools line, leaving a commented default a comment" do
+      write_initializer(<<~RUBY)
+        RailsAiContext.configure do |config|
+          config.ai_tools = %i[claude]
+          # config.tool_mode = :cli
+        end
+      RUBY
+
+      expect(described_class.write_tool_mode(:mcp, root: root)).to eq(:inserted)
+      content = File.read(File.join(root, "config", "initializers", "rails_ai_context.rb"))
+      expect(content).to include("config.ai_tools = %i[claude]\n  config.tool_mode = :mcp")
+      expect(content).to include("# config.tool_mode = :cli")
+    end
+
+    it "inserts into a bare configure block" do
+      write_initializer("RailsAiContext.configure do |config|\nend\n")
+
+      expect(described_class.write_tool_mode(:cli, root: root)).to eq(:inserted)
+      expect(described_class.tool_mode(root: root)).to eq(:cli)
+    end
+
+    it "reports an unchanged line and an absent file honestly" do
+      expect(described_class.write_tool_mode(:cli, root: root)).to eq(:absent)
+
+      write_initializer("RailsAiContext.configure do |config|\n  config.tool_mode = :cli\nend\n")
+      expect(described_class.write_tool_mode(:cli, root: root)).to eq(:unchanged)
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/live_reload_spec.rb
+++ b/spec/lib/rails_ai_context/live_reload_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe RailsAiContext::LiveReload do
       end
 
       it "rescues and logs the error without crashing" do
-        expect($stderr).to receive(:puts).with("[rails-ai-context] Live reload error: disk error")
+        expect($stderr).to receive(:puts).with("[rails-ai-context] Change watch error: disk error")
         expect { live_reload.handle_change(changed_paths) }.not_to raise_error
       end
     end
@@ -174,7 +174,7 @@ RSpec.describe RailsAiContext::LiveReload do
 
     before do
       # Stub `require "listen"` so it doesn't raise LoadError in the test env
-      allow(live_reload).to receive(:require).with("listen").and_return(true)
+      allow(live_reload.instance_variable_get(:@watch)).to receive(:require).with("listen").and_return(true)
       stub_const("Listen", listen_mod)
       allow(listen_mod).to receive(:to).and_return(listener)
       allow(listener).to receive(:start)
@@ -212,7 +212,7 @@ RSpec.describe RailsAiContext::LiveReload do
     it "stops the listener when one is running" do
       listener = instance_double("Listen::Listener")
       allow(listener).to receive(:stop)
-      live_reload.instance_variable_set(:@listener, listener)
+      live_reload.instance_variable_get(:@watch).instance_variable_set(:@listener, listener)
 
       live_reload.stop
 
@@ -224,10 +224,14 @@ RSpec.describe RailsAiContext::LiveReload do
     end
   end
 
-  describe "WATCH_DIRS" do
-    it "is the union of Watcher::WATCH_PATTERNS and Fingerprinter::WATCHED_DIRS" do
-      expected = (RailsAiContext::Watcher::WATCH_PATTERNS | RailsAiContext::Fingerprinter::WATCHED_DIRS)
-      expect(described_class::WATCH_DIRS).to match_array(expected)
+  describe "the shared watch list" do
+    it "covers everything the fingerprint reads, so a change cannot be fingerprinted but unwatched" do
+      RailsAiContext::Fingerprinter::WATCHED_DIRS.each do |dir|
+        covered = RailsAiContext::ChangeWatch::WATCH_DIRS.any? do |watched|
+          dir == watched || dir.start_with?("#{watched}/")
+        end
+        expect(covered).to be(true), "#{dir} is fingerprinted but not watched"
+      end
     end
   end
 end

--- a/spec/lib/rails_ai_context/middleware_spec.rb
+++ b/spec/lib/rails_ai_context/middleware_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe RailsAiContext::Middleware do
       expect(status).not_to eq(200)
     end
 
+    it "lets a downstream app exception propagate instead of answering an MCP error frame" do
+      raising = described_class.new(->(_env) { raise "app boom" })
+      env = Rack::MockRequest.env_for("/users")
+
+      expect { raising.call(env) }.to raise_error("app boom")
+    end
+
     # What the frame contains is McpEdge's, pinned once in mcp_edge_spec.
     # What this transport owes is routing a raise into it rather than letting
     # the exception reach the rackup.

--- a/spec/lib/rails_ai_context/serializers/real_shape_smoke_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/real_shape_smoke_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+# Every serializer, driven over a context real introspectors produced. The
+# per-file specs pin wording against hand-built hashes; this pins the one
+# thing those cannot: that no serializer reads a shape production does not
+# make.
+RSpec.describe "Serializers against a real introspected context" do
+  let(:context) { IntrospectedFixture.context }
+
+  [
+    RailsAiContext::Serializers::ClaudeSerializer,
+    RailsAiContext::Serializers::CopilotSerializer,
+    RailsAiContext::Serializers::OpencodeSerializer,
+    RailsAiContext::Serializers::MarkdownSerializer,
+    RailsAiContext::Serializers::JsonSerializer
+  ].each do |klass|
+    it "#{klass.name.split('::').last} renders it" do
+      output = klass.new(context).call
+      expect(output).to be_a(String)
+      expect(output).not_to be_empty
+    end
+  end
+
+  [
+    RailsAiContext::Serializers::ClaudeRulesSerializer,
+    RailsAiContext::Serializers::CursorRulesSerializer,
+    RailsAiContext::Serializers::CopilotInstructionsSerializer
+  ].each do |klass|
+    it "#{klass.name.split('::').last} writes its rule files from it" do
+      Dir.mktmpdir do |dir|
+        result = klass.new(context).call(dir)
+        expect(result[:written]).not_to be_empty
+        result[:written].each do |path|
+          expect(File.read(path)).not_to be_empty
+        end
+      end
+    end
+  end
+
+  it "OpencodeRulesSerializer writes the split AGENTS.md pair when the app dirs exist" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "app", "models"))
+      FileUtils.mkdir_p(File.join(dir, "app", "controllers"))
+
+      result = RailsAiContext::Serializers::OpencodeRulesSerializer.new(context).call(dir)
+      expect(result[:written].map { |p| p.sub("#{dir}/", "") })
+        .to match_array(%w[app/models/AGENTS.md app/controllers/AGENTS.md])
+    end
+  end
+end

--- a/spec/lib/rails_ai_context/serializers/stack_overview_helper_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/stack_overview_helper_spec.rb
@@ -164,4 +164,58 @@ RSpec.describe RailsAiContext::Serializers::StackOverviewHelper do
       expect(host.new(context).database_adapter_label).not_to include("static_parse")
     end
   end
+
+  describe "the app-tree scans" do
+    require "tmpdir"
+
+    def app_tree
+      Dir.mktmpdir do |root|
+        FileUtils.mkdir_p(File.join(root, "app", "services"))
+        FileUtils.mkdir_p(File.join(root, "app", "jobs"))
+        FileUtils.mkdir_p(File.join(root, "app", "controllers"))
+        File.write(File.join(root, "app", "services", "application_service.rb"), "class ApplicationService; end\n")
+        File.write(File.join(root, "app", "services", "payment_service.rb"), "class PaymentService; end\n")
+        File.write(File.join(root, "app", "jobs", "cleanup_job.rb"), "class CleanupJob; end\n")
+        File.write(File.join(root, "app", "controllers", "application_controller.rb"),
+                   "class ApplicationController < ActionController::Base\n  before_action :set_locale\n  before_action :authenticate_user!\nend\n")
+        yield root
+      end
+    end
+
+    it "names the app's services, jobs and global before_actions from the given root" do
+      app_tree do |root|
+        helper = test_class.new({})
+        expect(helper.detect_service_files(root)).to eq(%w[PaymentService])
+        expect(helper.detect_job_files(root)).to eq(%w[CleanupJob])
+        expect(helper.detect_before_actions(root)).to eq(%w[set_locale authenticate_user!])
+      end
+    end
+
+    it "answers empty for a tree without those directories" do
+      Dir.mktmpdir do |root|
+        helper = test_class.new({})
+        expect(helper.detect_service_files(root)).to eq([])
+        expect(helper.detect_job_files(root)).to eq([])
+        expect(helper.detect_before_actions(root)).to eq([])
+      end
+    end
+  end
+
+  describe "#write_rule_files" do
+    require "tmpdir"
+
+    it "writes through SafeFile.atomic_write and skips unchanged files" do
+      Dir.mktmpdir do |root|
+        helper = test_class.new({})
+        path = File.join(root, ".claude", "rules", "rails-context.md")
+
+        first = helper.write_rule_files({ path => "content" })
+        expect(first).to eq(written: [ path ], skipped: [])
+        expect(File.read(path)).to eq("content")
+
+        second = helper.write_rule_files({ path => "content" })
+        expect(second).to eq(written: [], skipped: [ path ])
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/server_spec.rb
+++ b/spec/lib/rails_ai_context/server_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe RailsAiContext::Server do
     let(:mcp_path) { RailsAiContext.configuration.http_path }
 
     def call_rack_app(transport, path_info)
-      rack_app = s.send(:build_rack_app, transport, mcp_path)
+      rack_app = s.send(:build_rack_app, transport)
       rack_app.call(
         "PATH_INFO" => path_info,
         "REQUEST_METHOD" => "POST",

--- a/spec/lib/rails_ai_context/tools/shared_cache_concurrency_spec.rb
+++ b/spec/lib/rails_ai_context/tools/shared_cache_concurrency_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe "BaseTool shared caches under concurrency" do
         [ 200, {}, [ "{}" ] ]
       end
 
-      app = RailsAiContext::Server.new(RailsAiContext.default_app).send(:build_rack_app, transport, "/mcp")
+      app = RailsAiContext::Server.new(RailsAiContext.default_app).send(:build_rack_app, transport)
       app.call(rack_request("standalone-7").env.merge("PATH_INFO" => "/mcp"))
 
       expect(seen).to eq("standalone-7")

--- a/spec/lib/rails_ai_context/tools/validate_semantics_spec.rb
+++ b/spec/lib/rails_ai_context/tools/validate_semantics_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+# The one tool file that had no spec of its own. These drive the dispatcher
+# through its public seam; the rules gain coverage as they change.
+RSpec.describe RailsAiContext::Tools::ValidateSemantics do
+  def with_app_file(relative, content)
+    Dir.mktmpdir do |root|
+      full = File.join(root, relative)
+      FileUtils.mkdir_p(File.dirname(full))
+      File.write(full, content)
+      yield relative, full
+    end
+  end
+
+  before do
+    allow(described_class).to receive(:cached_context).and_return({
+      routes: { by_controller: {} },
+      schema: { tables: {} },
+      models: {}
+    })
+  end
+
+  describe ".check_rails_semantics" do
+    it "answers cleanly for a plain file" do
+      with_app_file("app/models/widget.rb", "class Widget < ApplicationRecord\nend\n") do |file, path|
+        warnings = described_class.check_rails_semantics(file, path)
+        expect(warnings).to eq([])
+      end
+    end
+
+    it "says which checks were skipped when the AST parse fails, instead of reading as clean" do
+      allow(RailsAiContext::AstCache).to receive(:parse_string).and_raise(RuntimeError, "prism exploded")
+
+      with_app_file("app/models/widget.rb", "class Widget < ApplicationRecord\nend\n") do |file, path|
+        warnings = described_class.check_rails_semantics(file, path)
+        expect(warnings.join).to include("AST parse failed")
+        expect(warnings.join).to include("skipped")
+      end
+    end
+
+    it "flags a scope chain that loads every record into memory" do
+      source = <<~RUBY
+        class WidgetsController < ApplicationController
+          def index
+            @names = Widget.active.map { |w| w.name }
+          end
+        end
+      RUBY
+
+      with_app_file("app/controllers/widgets_controller.rb", source) do |file, path|
+        warnings = described_class.check_rails_semantics(file, path)
+        expect(warnings.join).to include("may load all records into memory")
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_context/watcher_spec.rb
+++ b/spec/lib/rails_ai_context/watcher_spec.rb
@@ -6,20 +6,10 @@ RSpec.describe RailsAiContext::Watcher do
   let(:app) { Rails.application }
   let(:watcher) { described_class.new(app) }
 
-  describe "DEBOUNCE_SECONDS" do
-    it "is set to 2" do
-      expect(described_class::DEBOUNCE_SECONDS).to eq(2)
-    end
-  end
-
-  describe "WATCH_PATTERNS" do
-    it "is a frozen array" do
-      expect(described_class::WATCH_PATTERNS).to be_frozen
-      expect(described_class::WATCH_PATTERNS).to be_an(Array)
-    end
-
+  describe "the shared watch list" do
     it "includes key Rails directories" do
-      patterns = described_class::WATCH_PATTERNS
+      patterns = RailsAiContext::ChangeWatch::WATCH_DIRS
+      expect(patterns).to be_frozen
       expect(patterns).to include("app/models")
       expect(patterns).to include("app/controllers")
       expect(patterns).to include("config")
@@ -45,7 +35,7 @@ RSpec.describe RailsAiContext::Watcher do
   describe "#start" do
     context "when listen gem is not available" do
       before do
-        allow(watcher).to receive(:require).with("listen").and_raise(LoadError)
+        allow(watcher.instance_variable_get(:@watch)).to receive(:require).with("listen").and_raise(LoadError)
         allow($stderr).to receive(:puts)
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ end
 
 require "rails_ai_context"
 
+Dir[File.join(__dir__, "support", "**", "*.rb")].sort.each { |f| require f }
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/introspected_fixture.rb
+++ b/spec/support/introspected_fixture.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# One introspected context for the whole suite, built from the static
+# fixture app instead of hand-typed hashes - a spec reading it cannot
+# encode a payload shape production never produces, which is how the dead
+# engines and turbo keys stayed green for months.
+module IntrospectedFixture
+  ROOT = File.expand_path("../fixtures/static_app", __dir__)
+
+  def self.context
+    @context ||= begin
+      app = RailsAiContext::StaticApp.new(ROOT)
+      RailsAiContext::Introspector::INTROSPECTOR_MAP.each_with_object({
+        app_name: "StaticApp", rails_version: "8.0", ruby_version: RUBY_VERSION
+      }) do |(key, klass), ctx|
+        next unless klass.answers_statically?
+
+        instance = klass.new(app)
+        ctx[key] = if klass.static_tier == RailsAiContext::Introspectors::StaticTier::ALTERNATE_SOURCE
+          instance.send(:static_call)
+        else
+          instance.call
+        end
+      rescue StandardError => e
+        ctx[key] = { error: e.message }
+      end.freeze
+    end
+  end
+end


### PR DESCRIPTION
v5.22.0 shipped the review's eight Strong candidates straight to main. This branch carries everything the review left open - the two remaining full cards and the seven smaller candidates - so the last of it lands reviewed.

## What changed

- **AstCache.parse_string caches** by content digest. The name promised a cache and the implementation was a bypass; a controller was parsed up to ten times per static run.
- **McpEdge owns the Rack request** for the middleware and the standalone server: one path match, one session scope, one rescue. A downstream app exception now propagates to the app instead of coming back as an MCP error frame - that one is a live bug fix, with a regression example.
- **One home for the initializer guard and the tool_mode line.** Install::InitializerFile carries the guard patterns the generator writes and the doctor diagnoses; SelectionRecord.write_tool_mode replaces the rake task's hand-rolled three-branch rewriter and leaves the generated commented-out default a comment.
- **Split-rule targets derive from Install::AiTool.** New rules_dir field for the three dir-based tools; the AGENTS.md pair comes off the table's split-target convention, guarded by an ownership example.
- **The stack helper** writes through SafeFile.atomic_write instead of a private copy of it, and its app-tree scans take a root - covered by specs for the first time.
- **The fingerprint watches what the resolvers read**: packs, engines, extra_app_paths, every concern home, the Gemfile, config/locales and config/environments. An edit there used to serve a stale answer that looked fresh.
- **rails_validate says which checks it skipped** when the AST parse fails, instead of reading as clean - and gains its first spec file.
- **ChangeWatch is the one change-detection loop**; Watcher and LiveReload keep only their reactions (regenerate files; refresh caches and notify clients) and their own missing-listen policy.
- **IntrospectedFixture drives every serializer over a context real introspectors produced**, so no serializer can read a shape production does not make - the defect class that kept the engines and turbo sections dead while hand-built fixtures stayed green.

## Verification

- Unit: 3589 examples, 0 failures (25 new)
- RuboCop: clean, 488 files
- E2E: 163 examples, 0 failures (full run on this branch)