### PR TITLE
QA round 8: a name never rebuilds a path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-Six defects found by a QA round against GitLab, OpenProject, Canvas LMS,
+Defects found by a QA round against GitLab, OpenProject, Canvas LMS,
 Discourse and Mastodon. Every one of them exits 0.
+
+- **The commands that read the app degrade the way `tool` does.** `context`,
+  `inspect`, `facts`, `preset`, `watch` and `init` called a bare boot guard,
+  so on a repo you have just cloned - the case an agent most needs a
+  `CLAUDE.md` for, and the case least likely to boot - every tool answered
+  and the command that writes the files exited 1 having written nothing.
+  `init` was worse: it writes its config files first, so a boot failure left
+  the app half set up and called that a failure. They allow the static tier
+  now and each takes `--no-boot`; `doctor` still fails, because diagnosing
+  the boot is its job. Writing under `--no-boot` then exposed its own bug -
+  the context writer asked `Rails.application` for the output directory,
+  which raises `NameError` on the path where Rails is never loaded at all.
+- **`tool --list` reads the app's config when the app cannot boot.** Boot is
+  what normally loads `.rails-ai-context.yml`, so the listing fell back to
+  the gem's defaults: on Mastodon it advertised 45 tools while the MCP server
+  offered 43 and the CLI itself answered `Unknown tool 'query'` for one it
+  had just listed.
+- **`search_extensions` reaches the ripgrep path too.** It was read only by
+  the Ruby fallback, so the same configuration gave two different answers
+  depending on whether ripgrep happened to be installed - and on the machines
+  where it is, narrowing the list did nothing at all.
+- **A mixin in a nested concerns directory is not a model.** The skip only saw
+  the top-level `concerns/` that Rails autoloads, so OpenProject's
+  `app/models/queries/operators/concerns` contributed four mixins to a model
+  count of 978 where the app has 974.
+- **`docs/COMPATIBILITY.md` describes the static tier the gem actually has.**
+  It said 6 introspectors answer without a booted app and "the other 34 have
+  no static path", naming eight examples - all of which answer. The real
+  split is 23 files-only, 9 alternate-source and 8 runtime-only: 32 of 40.
+  A guard spec derives all three lists from `INTROSPECTOR_MAP`.
 
 - **A controller is named by the constant its source declares.** Zeitwerk
   resolves a path through the app's own inflector, which the static tier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,17 @@ Discourse and Mastodon. Every one of them exits 0.
   - the shape this gem has shipped as a defect before. Entries and size are
   now facts, and a store that answers `#stats` gets its hash rendered as pairs
   rather than a Ruby literal.
+- **A model's table comes from its file, not from its name.** Naming a model by
+  the constant its source declares made `underscore` stop being the way back:
+  `OAuthClientConfig` underscores to `o_auth_client_config`, and the file is
+  `oauth_client_config.rb`. `rails_model_details` reported the table as
+  `o_auth_client_configs`, which no app has, so the columns section vanished
+  and the schema hint pointed at nothing - on Canvas that hit
+  `OAuthClientConfig`, `OAuthRequest`, `AuthenticationProvider::OAuth` and
+  `OAuth2`, on OpenProject `OAuthClient` and `OAuthClientToken`. The file's own
+  name already carries the inflection, because Zeitwerk resolved the constant
+  from it. `rails_generate_test`, `rails_get_callbacks`, `rails_test_info` and
+  the five `rails_validate` checks that key models by path read it too.
 - **An abstract base class is not a model in the static tier either.** A
   booted Rails rejects `abstract_class?`, and a namespaced base class is one:
   GitLab's `Ci::ApplicationRecord`, `PackageMetadata::ApplicationRecord` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,11 @@ Discourse and Mastodon. Every one of them exits 0.
   for a controller with a route. `rails_analyze_feature` listed them as
   untested. `Payload.controller_route_key` is the one derivation now, and a
   spec drives all five tools with an inflected name.
+- **The install path's files require their own stdlib.** `init` loads six
+  files before Rails and before the entry file, on purpose - so the entry
+  file's `require "set"` never runs for them. `legacy_cleanup`'s `[...].to_set`
+  raised `NoMethodError` on Ruby 3.1, where `Set` is not autoloaded, and 3.2+
+  hid it: only the CI matrix ever saw it.
 - **`rails_runtime_info` reports cache numbers, not the cache object.** The
   MemoryStore branch passed `cache.inspect` straight through, so the answer
   carried `#<ActiveSupport::Cache::MemoryStore entries=0, size=0, options={...}>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.23.1] - 2026-08-16
+## [5.24.0] - 2026-08-17
 
 ### Fixed
 
@@ -30,8 +30,8 @@ Discourse and Mastodon. Every one of them exits 0.
   had just listed.
 - **`search_extensions` is documented as the fallback's list, which is what
   it is.** Making ripgrep honour it did make the two backends agree, and it
-  cost the reach that makes the tool useful: on Mastodon `gem "devise"` went
-  from 9 results to none, because a Gemfile carries no listed extension - and
+  cost the reach that makes the tool useful: on Mastodon `gem 'devise'` went
+  from 5 results to none, because a Gemfile carries no listed extension - and
   the same for a Rakefile, a `.md`, a `.sql`. The docs, the attr comment and
   the line the install generator writes now say plainly that the list is the
   Ruby fallback's and that ripgrep searches every file.
@@ -46,7 +46,9 @@ Discourse and Mastodon. Every one of them exits 0.
 - **A mixin in a nested concerns directory is not a model.** The skip only saw
   the top-level `concerns/` that Rails autoloads, so OpenProject's
   `app/models/queries/operators/concerns` contributed four mixins to a model
-  count of 978 where the app has 974.
+  count of 978 where the app has 974. A nested `concerns/` is an ordinary
+  namespace, though, so the directory name alone does not decide it: a file
+  there that declares a class is a model like any other.
 - **`docs/COMPATIBILITY.md` describes the static tier the gem actually has.**
   It said 6 introspectors answer without a booted app and "the other 34 have
   no static path", naming eight examples - all of which answer. The real
@@ -79,15 +81,17 @@ Discourse and Mastodon. Every one of them exits 0.
   and `revert`, and for the `t.timestamps` inside them - those were found by
   a separate walk over the whole file, so a down body's timestamps landed on
   the last table created on the way up.
-- **i18n coverage leaves out the locales below its own rounding floor, and
-  says which.** A language-name lookup table under `config/locales`
+- **i18n coverage groups the locales below its own rounding floor instead of
+  listing them.** A language-name lookup table under `config/locales`
   contributes a top-level key per language, and Rails does load each as an
   available locale. Scoring them produced a row each saying every key was
   missing: on Discourse, 138 of 186 coverage rows described a translation
-  effort nobody had started. Those 138 are now named in one line instead. The
-  available list still matches a booted Rails, and a locale's keys are read
-  from its own file and any shared file together, so one that lives outside
-  the naming convention is scored rather than written off.
+  effort nobody had started. Those 138 are now summarised in one line, with a
+  shared key count stated once. The rows still exist - asking for one by name
+  answers with its numbers, so a translation genuinely started below the floor
+  is not written off as untranslated. The available list still matches a
+  booted Rails, and a locale's keys are read from its own file and any shared
+  file together, so one that lives outside the naming convention is scored.
 - **A recorded tool selection no longer switches off `.ai-context.json`.**
   The install generator always records one, and every later `rails
   ai:context` passed that list to the serializer. The machine artifact is
@@ -112,6 +116,46 @@ Discourse and Mastodon. Every one of them exits 0.
   it took the i18n answer from 4.6 seconds to four and a half minutes. Each
   entry also records the locales it serves, so asking for one by name finds
   its files even when the filename spells the gem rather than the locale.
+
+- **Every consumer that turns a controller name back into a path reads the
+  file it was read from.** Carrying `file:` fixed six of them and left five
+  answering a confident negative, which is the answer an agent acts on
+  without checking. On Mastodon's 18 inflected controllers: `rails_test_info`
+  reported 16 specs that exist as missing, `rails_get_routes` reported 4
+  routes that exist as absent, `rails_get_view` 2 views, and
+  `rails_generate_test` wrote a spec whose body was `skip "no routes found"`
+  for a controller with a route. `rails_analyze_feature` listed them as
+  untested. `Payload.controller_route_key` is the one derivation now, and a
+  spec drives all five tools with an inflected name.
+- **A model carries its file too, and is named by the constant its source
+  declares.** `rails_model_details` rebuilt `app/models/<underscored>.rb` from
+  the name in four places, so for a model in a pack or an engine the custom
+  validations, the source-defined methods, the method signatures and the class
+  structure all went quietly missing from an answer that otherwise looked
+  complete. The static tier also camelized the path into the name, so an app
+  registering an inflection got a constant it does not have - and one the
+  booted tier, which reads the real class, would never agree with.
+- **`rails_validate_semantics` checks the views under an inflected directory.**
+  A view directory names the route key, so camelizing `app/views/oauth/` back
+  gave a constant the app never declares and the undefined-ivar check stopped
+  running for that whole tree without saying so.
+- **A test-gap claim is not made from a scan that stopped early.**
+  `rails_analyze_feature` scans the first 500 files per glob; Discourse has
+  1,672 specs, so the scan never reached the ones covering the feature and
+  every controller in it was reported as having no test. The Tests section
+  disclosed the cap, the gaps section asserted through it.
+- **"Global before_actions" in the generated files means global.** The scan
+  matched `skip_before_action` too, and ignored `only:` / `except:` / `if:`.
+  Mastodon's `CLAUDE.md` listed five, of which three were false - including
+  `verify_authenticity_token`, which that controller skips.
+
+### Added
+
+- **`--no-boot` on `context`, `inspect`, `facts`, `preset`, `watch` and
+  `init`.** The static tier was reachable from `tool` and `serve` only.
+- **`--no-boot` reads a repo that has source but no `config/`.** An engine
+  keeps its dummy app under `spec/dummy`, so the guard against describing an
+  empty directory has to measure source, not boot files.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,11 @@ Discourse and Mastodon. Every one of them exits 0.
   for a controller with a route. `rails_analyze_feature` listed them as
   untested. `Payload.controller_route_key` is the one derivation now, and a
   spec drives all five tools with an inflected name.
+- **An abstract base class is not a model in the static tier either.** A
+  booted Rails rejects `abstract_class?`, and a namespaced base class is one:
+  GitLab's `Ci::ApplicationRecord`, `PackageMetadata::ApplicationRecord` and
+  `SecApplicationRecord` were counted, so the same app answered 895 models
+  without a boot and 888 with one. OpenProject: 974 against 971.
 - **A model carries its file too, and is named by the constant its source
   declares.** `rails_model_details` rebuilt `app/models/<underscored>.rb` from
   the name in four places, so for a model in a pack or an engine the custom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,15 @@ Discourse and Mastodon. Every one of them exits 0.
   and `revert`, and for the `t.timestamps` inside them - those were found by
   a separate walk over the whole file, so a down body's timestamps landed on
   the last table created on the way up.
-- **i18n coverage skips locales that carry no translations, and says so.** A
-  language-name lookup table under `config/locales` contributes a top-level
-  key per language, and Rails does load each as an available locale. Scoring
-  them produced a row each saying every key was missing: on Discourse, 138
-  of 186 coverage rows described a translation effort nobody had started.
-  The available list still matches a booted Rails.
+- **i18n coverage leaves out the locales below its own rounding floor, and
+  says which.** A language-name lookup table under `config/locales`
+  contributes a top-level key per language, and Rails does load each as an
+  available locale. Scoring them produced a row each saying every key was
+  missing: on Discourse, 138 of 186 coverage rows described a translation
+  effort nobody had started. Those 138 are now named in one line instead. The
+  available list still matches a booted Rails, and a locale's keys are read
+  from its own file and any shared file together, so one that lives outside
+  the naming convention is scored rather than written off.
 - **A recorded tool selection no longer switches off `.ai-context.json`.**
   The install generator always records one, and every later `rails
   ai:context` passed that list to the serializer. The machine artifact is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,13 @@ Discourse and Mastodon. Every one of them exits 0.
   the gem's defaults: on Mastodon it advertised 45 tools while the MCP server
   offered 43 and the CLI itself answered `Unknown tool 'query'` for one it
   had just listed.
-- **`search_extensions` reaches the ripgrep path too.** It was read only by
-  the Ruby fallback, so the same configuration gave two different answers
-  depending on whether ripgrep happened to be installed - and on the machines
-  where it is, narrowing the list did nothing at all.
+- **`search_extensions` is documented as the fallback's list, which is what
+  it is.** Making ripgrep honour it did make the two backends agree, and it
+  cost the reach that makes the tool useful: on Mastodon `gem "devise"` went
+  from 9 results to none, because a Gemfile carries no listed extension - and
+  the same for a Rakefile, a `.md`, a `.sql`. The docs, the attr comment and
+  the line the install generator writes now say plainly that the list is the
+  Ruby fallback's and that ripgrep searches every file.
 - **A table the replay cannot name is not reported.** Canvas has a migration
   that calls `create_table table_name do |t|` with a local computed at run
   time; the replay kept the entry under a nil key, and the first serializer
@@ -59,11 +62,14 @@ Discourse and Mastodon. Every one of them exits 0.
   path stays the answer where the source does not carry the whole name
   (`application_cable/channel.rb`) and where the declared name does not name
   that file, since Prism recovers a syntax error into a partial tree.
-- **Only a class names a mailer or a channel.** `app/mailers` is also where
-  ActionMailer interceptors live, and every `.rb` under it counted:
-  OpenProject's `Interceptors::DefaultHeaders` arrived as a mailer with
-  `delivering_email` - a hook the framework calls - listed as an email an
-  agent could send, 2 of its 11 entries.
+- **An interceptor is told from a mailer by its framework hook.**
+  `app/mailers` is also where ActionMailer interceptors live, and every `.rb`
+  under it counted: OpenProject's `Interceptors::DefaultHeaders` arrived as a
+  mailer with `delivering_email` - a hook the framework calls - listed as an
+  email an agent could send, 2 of its 11 entries. What an interceptor has and
+  a mailer does not is one of `delivering_email`, `previewing_email` or
+  `delivered_email`; requiring a class instead would have dropped GitLab's 20
+  `Emails::*` modules, which hold every notification it sends.
 - **Migration replay reads what a migration does, not what it undoes.** A
   `def down` says how to reverse the change, so replaying it alongside `up`
   cancelled the migration out. On a migrations-only app the ordinary
@@ -92,6 +98,20 @@ Discourse and Mastodon. Every one of them exits 0.
   other key in the generated initializer takes symbols, and `%i[]` here
   skipped nothing at all: both readers compare against a tool name, which is
   a String.
+
+- **A controller carries the file it was read from.** Reading the name from
+  the source fixed the name and broke every path derived from it:
+  `ActivityPub::CollectionsController`.underscore is `activity_pub/...` and
+  the file is under `activitypub/`, so `rails_get_context` answered "Could
+  not extract source code" for a file that exists and asked the routes for a
+  controller key Rails does not use. Both tiers emit `file:` - the booted one
+  asks Ruby where the class was defined - and the consumers read it through
+  `Payload`.
+- **The locale files are indexed once, not once per locale.** Asking every
+  file about every locale is O(locales x files): on Discourse, 187 over 108,
+  it took the i18n answer from 4.6 seconds to four and a half minutes. Each
+  entry also records the locales it serves, so asking for one by name finds
+  its files even when the filename spells the gem rather than the locale.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ Discourse and Mastodon. Every one of them exits 0.
   the Ruby fallback, so the same configuration gave two different answers
   depending on whether ripgrep happened to be installed - and on the machines
   where it is, narrowing the list did nothing at all.
+- **A table the replay cannot name is not reported.** Canvas has a migration
+  that calls `create_table table_name do |t|` with a local computed at run
+  time; the replay kept the entry under a nil key, and the first serializer
+  to sort the table names took the whole context run down. Reachable only
+  once `context` could enter the static tier at all.
+- **Coverage says nothing when there is nothing to measure against.** With a
+  `default_locale` the app configures but ships no file for, every locale
+  scored zero and all of them were named as untranslated.
 - **A mixin in a nested concerns directory is not a model.** The skip only saw
   the top-level `concerns/` that Rails autoloads, so OpenProject's
   `app/models/queries/operators/concerns` contributed four mixins to a model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,11 @@ Discourse and Mastodon. Every one of them exits 0.
   `def down` says how to reverse the change, so replaying it alongside `up`
   cancelled the migration out. On a migrations-only app the ordinary
   up-creates/down-drops pair erased two tables OpenProject really has (35
-  to 37), and the reverse pair would have invented one it dropped.
+  to 37), and the reverse pair would have invented one it dropped. The same
+  now holds for the block spellings, `reversible { |dir| dir.down { ... } }`
+  and `revert`, and for the `t.timestamps` inside them - those were found by
+  a separate walk over the whole file, so a down body's timestamps landed on
+  the last table created on the way up.
 - **i18n coverage skips locales that carry no translations, and says so.** A
   language-name lookup table under `config/locales` contributes a top-level
   key per language, and Rails does load each as an available locale. Scoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.23.1] - 2026-08-16
+
+### Fixed
+
+Six defects found by a QA round against GitLab, OpenProject, Canvas LMS,
+Discourse and Mastodon. Every one of them exits 0.
+
+- **A controller is named by the constant its source declares.** Zeitwerk
+  resolves a path through the app's own inflector, which the static tier
+  never loads, so camelizing the path invented `Activitypub::` for the 12
+  controllers Mastodon declares as `ActivityPub::` and `Oauth::` for the 4
+  it declares as `OAuth::` - names that appear nowhere in an app that
+  registers those acronyms, and a `NameError` for anyone who uses one. The
+  path stays the answer where the source does not carry the whole name
+  (`application_cable/channel.rb`) and where the declared name does not name
+  that file, since Prism recovers a syntax error into a partial tree.
+- **Only a class names a mailer or a channel.** `app/mailers` is also where
+  ActionMailer interceptors live, and every `.rb` under it counted:
+  OpenProject's `Interceptors::DefaultHeaders` arrived as a mailer with
+  `delivering_email` - a hook the framework calls - listed as an email an
+  agent could send, 2 of its 11 entries.
+- **Migration replay reads what a migration does, not what it undoes.** A
+  `def down` says how to reverse the change, so replaying it alongside `up`
+  cancelled the migration out. On a migrations-only app the ordinary
+  up-creates/down-drops pair erased two tables OpenProject really has (35
+  to 37), and the reverse pair would have invented one it dropped.
+- **i18n coverage skips locales that carry no translations, and says so.** A
+  language-name lookup table under `config/locales` contributes a top-level
+  key per language, and Rails does load each as an available locale. Scoring
+  them produced a row each saying every key was missing: on Discourse, 138
+  of 186 coverage rows described a translation effort nobody had started.
+  The available list still matches a booted Rails.
+- **A recorded tool selection no longer switches off `.ai-context.json`.**
+  The install generator always records one, and every later `rails
+  ai:context` passed that list to the serializer. The machine artifact is
+  not an AI tool and no install menu offers it, so it silently stopped being
+  written on the one install path the docs describe - while the generator
+  went on adding it to `.gitignore`.
+- **`skip_tools` accepts the symbol spelling its neighbours use.** Every
+  other key in the generated initializer takes symbols, and `%i[]` here
+  skipped nothing at all: both readers compare against a tool name, which is
+  a String.
+
+### Changed
+
+- **The generated initializer has one indent from top to bottom.** The AI
+  Tools section was written at the configure body's indent and every section
+  after it flush, so the file an app commits changed indent two lines in and
+  stayed there.
+
 ## [5.23.0] - 2026-08-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,12 @@ Discourse and Mastodon. Every one of them exits 0.
   for a controller with a route. `rails_analyze_feature` listed them as
   untested. `Payload.controller_route_key` is the one derivation now, and a
   spec drives all five tools with an inflected name.
+- **`rails_runtime_info` reports cache numbers, not the cache object.** The
+  MemoryStore branch passed `cache.inspect` straight through, so the answer
+  carried `#<ActiveSupport::Cache::MemoryStore entries=0, size=0, options={...}>`
+  - the shape this gem has shipped as a defect before. Entries and size are
+  now facts, and a store that answers `#stats` gets its hash rendered as pairs
+  rather than a Ruby literal.
 - **An abstract base class is not a model in the static tier either.** A
   booted Rails rejects `abstract_class?`, and a namespaced base class is one:
   GitLab's `Ci::ApplicationRecord`, `PackageMetadata::ApplicationRecord` and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,8 @@ What a source file calls its own class, as opposed to the **path name** - the co
 
 Distinct from the **Static tier** sense of "declared": that one is about declaring a tier's capability up front rather than detecting it at runtime. This one is about a constant's spelling.
 
+The other half of the same problem is the reverse trip. Once a name is the declared one, no consumer can rebuild the path from it - and a pack or an in-repo engine breaks that derivation too, inflection or not. So controllers and models carry `file:` from whichever tier found them, and consumers read it through `Payload` (`controller_file`, `controller_route_key`, `controller_for_route_key`, `model_file`). The rule: a tool that needs a path for a name reads it, never underscores it.
+
 ## Static tier
 
 The mode where the app did not boot, or `--no-boot` was passed. What an introspector answers here is what it declared, never what a runtime check happened to detect. Every introspector in `INTROSPECTOR_MAP` extends `StaticTier` and names one of three kinds:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,12 @@ Two senses, one per module, and neither is bare "path" in a name.
 
 **How a path is written down** - `PortablePath` rewrites one so it means the same thing on another machine, because what it touches ends up in `.ai-context.json` and the app commits that file. App paths go app-relative, gem paths keep the gem and version and drop the install prefix. "Relativize" always means this.
 
+## Declared constant
+
+What a source file calls its own class, as opposed to the **path name** - the constant its path camelizes to. The two differ wherever the app registers an inflection, because Zeitwerk resolves a path through the app's own inflector and the static tier has never loaded it: `app/controllers/activitypub/` is `ActivityPub` in Mastodon, and `Oauth` is a constant nothing defines. `DeclaredConstant` reads the class the source declares, and since an inflection only ever changes case, the declaration that names a file is the one equal to the path name ignoring case. Anything else - a second class in the file, a nested error class, a tree Prism recovered from a syntax error - is not this file's class, and there the path name stays the answer: it is the only thing carrying the namespace when the source does not.
+
+Distinct from the **Static tier** sense of "declared": that one is about declaring a tier's capability up front rather than detecting it at runtime. This one is about a constant's spelling.
+
 ## Static tier
 
 The mode where the app did not boot, or `--no-boot` was passed. What an introspector answers here is what it declared, never what a runtime check happened to detect. Every introspector in `INTROSPECTOR_MAP` extends `StaticTier` and names one of three kinds:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -37,6 +37,7 @@ rails-ai-context serve --transport http --port 6029   # HTTP transport
 |:-------|:--------|:------------|
 | `--transport` | `stdio` | `stdio` or `http` |
 | `--port` | `6029` | HTTP listen port |
+| `--no-boot` | off | Skip booting the app; answer from source alone |
 
 ### `tool`
 
@@ -58,6 +59,28 @@ rails-ai-context tool model_details --model User
 |:-------|:------------|
 | `--list` | List all available tools |
 | `--json` | Output as JSON |
+| `--no-boot` | Skip booting the app; answer from source alone |
+
+### The static tier and `--no-boot`
+
+Every command that reads the app takes `--no-boot`: `tool`, `serve`, `context`,
+`inspect`, `facts`, `preset`, `watch` and `init`. It skips the boot and answers
+from source alone, which is what you want on a repo you have just cloned, on an
+app whose boot is broken, and in CI where booting costs more than the answer.
+
+The same tier is entered automatically when a boot fails, so you get an answer
+either way. Answers that need a running app are marked `[UNAVAILABLE: ...]`
+rather than guessed, and everything else is tagged `[STATIC]` instead of
+`[VERIFIED]`. `docs/COMPATIBILITY.md` lists which of the 40 introspectors answer
+in which tier.
+
+`doctor` is the exception: diagnosing the boot is its job, so it refuses
+`--no-boot` and still exits 1 when the app cannot start.
+
+```bash
+rails-ai-context tool models --no-boot        # no boot, no database, no Gemfile
+rails-ai-context context --no-boot            # writes CLAUDE.md from source
+```
 
 ### Tool name resolution
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -70,23 +70,37 @@ Two tiers, both reachable over the CLI and MCP (stdio and HTTP):
 (ActiveRecord connections, `Rails.application.routes`, loaded classes) plus the
 Prism AST layer for source-level facts (scopes, callbacks, strong params).
 
-**STATIC** - the app didn't boot, or `--no-boot` was passed. Only introspectors
-that define a `static_call` path can answer without a booted app:
+**STATIC** - the app didn't boot, or `--no-boot` was passed. 32 of the 40
+introspectors answer here; each declares which of three kinds it is
+(ADR-0002), so what a tier can say is a declaration rather than a guess.
+
+**files-only** (23) run unchanged against the static app handle, because they
+only ever read files: `gems`, `views`, `view_templates`, `turbo`, `stimulus`,
+`active_storage`, `action_text`, `auth`, `tests`, `rake_tasks`, `assets`,
+`devops`, `action_mailbox`, `migrations`, `seeds`, `middleware`, `env_config`,
+`multi_database`, `components`, `performance`, `frontend_frameworks`,
+`credentials` and `env`.
+
+**alternate-source** (9) have a `static_call` that reads a different source
+from the booted path:
 
 | Introspector | Static source |
 |:---|:---|
-| `schema` | `db/schema.rb` / `db/structure.sql` / migration files |
-| `migrations` | migration file list + `db/structure.sql`'s trailing `schema_migrations` insert |
-| `routes` | `config/routes.rb` parsed with a dedicated Prism listener |
+| `schema` | `db/schema.rb` / `db/structure.sql` / migration replay |
 | `models` | `app/models/**/*.rb` (plus packs/engines/extra paths) parsed, not constantized |
+| `routes` | `config/routes.rb` parsed with a dedicated Prism listener |
 | `controllers` | `app/controllers/**/*.rb` (plus packs/engines/extra paths) parsed, not constantized |
-| `env_config` | `config/environments/*.rb` read from disk - file-based, so the static tier serves the same data as a booted app |
+| `jobs` | `app/jobs`, `app/mailers` and `app/channels` parsed for classes and their public methods |
+| `i18n` | every top-level key across `config/locales`, and the default locale read from `config/` |
+| `api` | serializers, API controllers and route constraints read from source |
+| `engines` | `config/routes.rb` mounts, plus the Gemfile |
+| `active_support` | concern and core-extension use read from source |
 
-The other 34 introspectors (views, jobs, gems, turbo, i18n, active_storage,
-auth, api, and the rest) have no static path and report `{ unavailable: reason
-}` in this tier - by construction, not by shape: `Introspector#run_introspector`
-(`lib/rails_ai_context/introspector.rb`) falls back to the same message
-regardless of what triggered the static tier.
+**runtime-only** (8) report `{ unavailable: reason }` here, and only these:
+`conventions`, `database_stats`, `config`, `initializers`, `autoload`,
+`connection_pool`, `security` and `observability`. The fallback message comes
+from `Introspector#run_introspector` (`lib/rails_ai_context/introspector.rb`)
+and is the same whatever put the gem in the static tier.
 
 `doctor` never enters the static tier - its job is diagnosing why boot failed,
 so it always requires a bootable app.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -113,7 +113,7 @@ preset: full
 |:-------|:-----|:--------|:------------|
 | `max_search_results` | Integer | `200` | Maximum search results |
 | `max_validate_files` | Integer | `50` | Maximum files for validation |
-| `search_extensions` | Array | `["rb", "js", "erb", "yml", "yaml", "json", "ts", "tsx", "vue", "svelte", "haml", "slim"]` | File extensions searched, on both the ripgrep and fallback paths |
+| `search_extensions` | Array | `["rb", "js", "erb", "yml", "yaml", "json", "ts", "tsx", "vue", "svelte", "haml", "slim"]` | File extensions the Ruby fallback searches (ripgrep, when installed, searches every file) |
 | `concern_paths` | Array | `nil` (discovers `app/*/concerns`) | Paths to scan for concerns. Setting it replaces discovery, so it can narrow as well as widen |
 | `frontend_paths` | Array | `nil` (auto-detect) | Override frontend file paths |
 | `extra_app_paths` | Array | `[]` | Extra directories under the app root to treat as application code |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -113,7 +113,7 @@ preset: full
 |:-------|:-----|:--------|:------------|
 | `max_search_results` | Integer | `200` | Maximum search results |
 | `max_validate_files` | Integer | `50` | Maximum files for validation |
-| `search_extensions` | Array | `["rb", "js", "erb", "yml", "yaml", "json", "ts", "tsx", "vue", "svelte", "haml", "slim"]` | File extensions to search |
+| `search_extensions` | Array | `["rb", "js", "erb", "yml", "yaml", "json", "ts", "tsx", "vue", "svelte", "haml", "slim"]` | File extensions searched, on both the ripgrep and fallback paths |
 | `concern_paths` | Array | `nil` (discovers `app/*/concerns`) | Paths to scan for concerns. Setting it replaces discovery, so it can narrow as well as widen |
 | `frontend_paths` | Array | `nil` (auto-detect) | Override frontend file paths |
 | `extra_app_paths` | Array | `[]` | Extra directories under the app root to treat as application code |

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1353,7 +1353,7 @@ end
 | `excluded_concerns` | Array | framework regex patterns | Regex patterns for concerns to hide from model output |
 | `excluded_filters` | Array | `verify_authenticity_token`, etc. | Framework filter names hidden from controller output |
 | `excluded_middleware` | Array | standard Rails middleware | Default middleware hidden from config output |
-| `search_extensions` | Array | `rb js erb yml yaml json ts tsx vue svelte haml slim` | File extensions for Ruby fallback search |
+| `search_extensions` | Array | `rb js erb yml yaml json ts tsx vue svelte haml slim` | File extensions searched, on both the ripgrep and fallback paths |
 | `concern_paths` | Array | `nil` (discovers `app/*/concerns`) | Where to look for concern source files. Setting it replaces discovery |
 
 ### Root file generation

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1353,7 +1353,7 @@ end
 | `excluded_concerns` | Array | framework regex patterns | Regex patterns for concerns to hide from model output |
 | `excluded_filters` | Array | `verify_authenticity_token`, etc. | Framework filter names hidden from controller output |
 | `excluded_middleware` | Array | standard Rails middleware | Default middleware hidden from config output |
-| `search_extensions` | Array | `rb js erb yml yaml json ts tsx vue svelte haml slim` | File extensions searched, on both the ripgrep and fallback paths |
+| `search_extensions` | Array | `rb js erb yml yaml json ts tsx vue svelte haml slim` | File extensions the Ruby fallback searches (ripgrep, when installed, searches every file) |
 | `concern_paths` | Array | `nil` (discovers `app/*/concerns`) | Where to look for concern source files. Setting it replaces discovery |
 
 ### Root file generation

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -140,8 +140,13 @@ class RailsAiContextCLI < Thor
 
     desc "context", "Generate AI context files"
     option :format, type: :string, default: nil, desc: "Format: claude, cursor, copilot, opencode, codex, json, all (default: from config)"
+    option :no_boot, type: :boolean, default: false, desc: "Skip booting the app; serve static analysis only"
     def context
-      boot_rails!
+      # A repo you have just cloned is the case an agent most needs these files
+      # for, and it is the case least likely to boot. Every command that reads
+      # the app degrades the way `tool` does; doctor, whose job is diagnosing
+      # the boot, is the one that still fails.
+      boot_rails!(allow_static: true)
 
       if options[:format]
         cleanup_tools = options[:format] == "all" ? nil : [ options[:format].to_sym ]
@@ -180,8 +185,9 @@ class RailsAiContextCLI < Thor
     end
 
     desc "inspect", "Print introspection summary"
+    option :no_boot, type: :boolean, default: false, desc: "Skip booting the app; serve static analysis only"
     def inspect_app
-      boot_rails!
+      boot_rails!(allow_static: true)
       require "json"
 
       context = ::RailsAiContext.introspect
@@ -195,8 +201,9 @@ class RailsAiContextCLI < Thor
     commands["inspect"] = commands.delete("inspect_app")
 
     desc "watch", "Watch for changes and auto-regenerate context files"
+    option :no_boot, type: :boolean, default: false, desc: "Skip booting the app; serve static analysis only"
     def watch
-      boot_rails!
+      boot_rails!(allow_static: true)
       ::RailsAiContext::Watcher.new.start
     end
 
@@ -277,6 +284,7 @@ class RailsAiContextCLI < Thor
     end
 
     desc "preset NAME", "Run a multi-tool preset (architecture, debugging, migration)"
+    option :no_boot, type: :boolean, default: false, desc: "Skip booting the app; serve static analysis only"
     def preset(name = nil)
       require_relative "../lib/rails_ai_context/presets"
       presets = ::RailsAiContext::Presets::DEFINITIONS
@@ -294,7 +302,7 @@ class RailsAiContextCLI < Thor
         return
       end
 
-      boot_rails!
+      boot_rails!(allow_static: true)
 
       preset = presets[name]
       $stderr.puts "=" * 60
@@ -328,8 +336,9 @@ class RailsAiContextCLI < Thor
     end
 
     desc "facts", "Print concise schema facts summary (tables, associations, dependencies)"
+    option :no_boot, type: :boolean, default: false, desc: "Skip booting the app; serve static analysis only"
     def facts
-      boot_rails!
+      boot_rails!(allow_static: true)
 
       context = ::RailsAiContext.introspect
       puts ::RailsAiContext::FactsFormatter.render(context, inspect_hint: "rails-ai-context inspect")

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -532,6 +532,18 @@ class RailsAiContextCLI < Thor
       ENV["RAILS_ENV"] = environment_opt if environment_opt
 
       if allow_static && (no_boot || options[:no_boot])
+        # Still a Rails app, or the static tier describes a directory that is
+        # not one: in an empty folder this wrote a CLAUDE.md reporting
+        # "Migrations: 0 total" and exited 0. The static tier reads files, so
+        # config/application.rb is enough - environment.rb is the boot entry
+        # point and only the booting path needs it.
+        unless File.exist?(File.join(Dir.pwd, "config", "application.rb")) ||
+               File.exist?(File.join(Dir.pwd, "config", "environment.rb"))
+          $stderr.puts "Error: No Rails app found in #{Dir.pwd}"
+          $stderr.puts "Run this command from your Rails app root directory (or pass --app-path)."
+          exit 1
+        end
+
         enter_static_tier!("static mode requested with --no-boot")
         return
       end

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -267,7 +267,10 @@ class RailsAiContextCLI < Thor
       add_to_gitignore
 
       # --- Boot Rails, load config, generate context ---
-      boot_rails!
+      # The config files are already on disk by now, so failing here leaves the
+      # app half set up and calls the whole thing a failure. Setup is exactly
+      # what you run on a repo you have just cloned.
+      boot_rails!(allow_static: true)
 
       $stderr.puts ""
       $stderr.puts "Generating AI context files..."

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -472,6 +472,10 @@ class RailsAiContextCLI < Thor
 
       begin
         require_gem_without_app!
+        # Boot is what normally loads .rails-ai-context.yml, so without it the
+        # listing took the gem's defaults and advertised tools the app has
+        # configured off - which the very next call then refuses by name.
+        ::RailsAiContext::Configuration.auto_load!(Dir.pwd)
         puts ::RailsAiContext::CLI::ToolRunner.tool_list
         puts ""
         puts "Run inside a Rails app to execute tools - static source analysis works even when the app can't boot (see --no-boot)."

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -234,6 +234,7 @@ class RailsAiContextCLI < Thor
     end
 
     desc "init", "Set up rails-ai-context for standalone use (creates .rails-ai-context.yml and .mcp.json)"
+    option :no_boot, type: :boolean, default: false, desc: "Skip booting the app; serve static analysis only"
     def init
       config_path = File.join(Dir.pwd, "config", "environment.rb")
       unless File.exist?(config_path)
@@ -475,7 +476,8 @@ class RailsAiContextCLI < Thor
         # Boot is what normally loads .rails-ai-context.yml, so without it the
         # listing took the gem's defaults and advertised tools the app has
         # configured off - which the very next call then refuses by name.
-        ::RailsAiContext::Configuration.auto_load!(Dir.pwd)
+        # The app under analysis, which --app-path may have moved.
+        ::RailsAiContext::Configuration.auto_load!(File.expand_path(@app_path_override || options[:app_path] || Dir.pwd))
         puts ::RailsAiContext::CLI::ToolRunner.tool_list
         puts ""
         puts "Run inside a Rails app to execute tools - static source analysis works even when the app can't boot (see --no-boot)."

--- a/exe/rails-ai-context
+++ b/exe/rails-ai-context
@@ -532,13 +532,14 @@ class RailsAiContextCLI < Thor
       ENV["RAILS_ENV"] = environment_opt if environment_opt
 
       if allow_static && (no_boot || options[:no_boot])
-        # Still a Rails app, or the static tier describes a directory that is
-        # not one: in an empty folder this wrote a CLAUDE.md reporting
-        # "Migrations: 0 total" and exited 0. The static tier reads files, so
-        # config/application.rb is enough - environment.rb is the boot entry
-        # point and only the booting path needs it.
+        # Something to read, or the static tier describes a directory that is
+        # not an app: in an empty folder this wrote a CLAUDE.md reporting
+        # "Migrations: 0 total" and exited 0. The bar is source, not boot
+        # files - an engine keeps its dummy app under spec/dummy, so its root
+        # has app/ and no config/, and it is a real target.
         unless File.exist?(File.join(Dir.pwd, "config", "application.rb")) ||
-               File.exist?(File.join(Dir.pwd, "config", "environment.rb"))
+               File.exist?(File.join(Dir.pwd, "config", "environment.rb")) ||
+               Dir.glob(File.join(Dir.pwd, "app", "**", "*.rb")).any?
           $stderr.puts "Error: No Rails app found in #{Dir.pwd}"
           $stderr.puts "Run this command from your Rails app root directory (or pass --app-path)."
           exit 1

--- a/lib/generators/rails_ai_context/install/install_generator.rb
+++ b/lib/generators/rails_ai_context/install/install_generator.rb
@@ -283,10 +283,14 @@ module RailsAiContext
 
         SECTION
 
-        # All remaining sections use defaults (commented out)
+        # All remaining sections use defaults (commented out). They go through
+        # the same reindent the update path uses: the AI Tools section above
+        # carries the configure body's indent and these are written flush, so
+        # appending them raw left the file with two indents, and the guard wrap
+        # preserved the gap by indenting both equally.
         CONFIG_SECTIONS.each do |name, section_content|
           next if name == "AI Tools" # already added with dynamic values
-          content += section_content + "\n"
+          content += reindent_section_content(section_content, content) + "\n"
         end
 
         content += "end\n"

--- a/lib/generators/rails_ai_context/install/install_generator.rb
+++ b/lib/generators/rails_ai_context/install/install_generator.rb
@@ -203,7 +203,7 @@ module RailsAiContext
         SECTION
         "Search" => <<~SECTION,
             # ── Search ────────────────────────────────────────────────────────
-            # File extensions for fallback search (when ripgrep unavailable)
+            # File extensions searched, on the ripgrep path and the fallback alike
             # config.search_extensions = %w[rb js erb yml yaml json ts tsx vue svelte haml slim]
 
             # Where to look for concern source files. Left unset, every

--- a/lib/generators/rails_ai_context/install/install_generator.rb
+++ b/lib/generators/rails_ai_context/install/install_generator.rb
@@ -203,7 +203,7 @@ module RailsAiContext
         SECTION
         "Search" => <<~SECTION,
             # ── Search ────────────────────────────────────────────────────────
-            # File extensions searched, on the ripgrep path and the fallback alike
+            # File extensions the Ruby fallback searches (ripgrep searches every file)
             # config.search_extensions = %w[rb js erb yml yaml json ts tsx vue svelte haml slim]
 
             # Where to look for concern source files. Left unset, every

--- a/lib/rails_ai_context/configuration.rb
+++ b/lib/rails_ai_context/configuration.rb
@@ -253,7 +253,7 @@ module RailsAiContext
     attr_accessor :excluded_association_names # Framework association names hidden from model output
 
     # Search and file discovery
-    attr_accessor :search_extensions      # File extensions searched, on the ripgrep path and the fallback alike
+    attr_accessor :search_extensions      # File extensions the Ruby fallback searches; ripgrep searches every file
     attr_accessor :concern_paths          # Where to look for concern source files (default: nil, discovers app/*/concerns)
 
     # Frontend framework detection (optional overrides - auto-detected if nil)

--- a/lib/rails_ai_context/configuration.rb
+++ b/lib/rails_ai_context/configuration.rb
@@ -253,7 +253,7 @@ module RailsAiContext
     attr_accessor :excluded_association_names # Framework association names hidden from model output
 
     # Search and file discovery
-    attr_accessor :search_extensions      # File extensions for Ruby fallback search (default: rb,js,erb,yml,yaml,json)
+    attr_accessor :search_extensions      # File extensions searched, on the ripgrep path and the fallback alike
     attr_accessor :concern_paths          # Where to look for concern source files (default: nil, discovers app/*/concerns)
 
     # Frontend framework detection (optional overrides - auto-detected if nil)

--- a/lib/rails_ai_context/configuration.rb
+++ b/lib/rails_ai_context/configuration.rb
@@ -183,15 +183,9 @@ module RailsAiContext
     # Additional MCP tool classes to register alongside built-in tools
     attr_accessor :custom_tools
 
-    # Built-in tool names to skip (e.g. %w[rails_security_scan rails_query])
+    # Built-in tool names to skip (e.g. %w[rails_security_scan rails_query]).
+    # Written through a coercing setter - see #skip_tools=.
     attr_reader :skip_tools
-
-    # A tool name is a String, and both readers compare against one. Every
-    # neighbouring key here takes symbols, so %i[] is written often enough that
-    # accepting it as a no-op meant a configured skip silently kept the tool.
-    def skip_tools=(value)
-      @skip_tools = Array(value).map(&:to_s)
-    end
 
     # Which AI tools to generate context for (selected during install)
     # nil = all formats, or %i[claude cursor copilot opencode codex]
@@ -359,6 +353,14 @@ module RailsAiContext
       name = name.to_sym
       raise ArgumentError, "Unknown preset: #{name}. Valid presets: #{PRESETS.keys.join(", ")}" unless PRESETS.key?(name)
       @introspectors = PRESETS[name].dup
+    end
+
+    # A tool name is a String, and both the MCP server and the CLI compare
+    # against one. Every neighbouring key in the generated initializer takes
+    # symbols, so %i[] is written often enough that accepting it as a no-op
+    # meant a configured skip silently kept the tool.
+    def skip_tools=(value)
+      @skip_tools = Array(value).map(&:to_s)
     end
 
     def output_dir_for(app)

--- a/lib/rails_ai_context/configuration.rb
+++ b/lib/rails_ai_context/configuration.rb
@@ -184,7 +184,14 @@ module RailsAiContext
     attr_accessor :custom_tools
 
     # Built-in tool names to skip (e.g. %w[rails_security_scan rails_query])
-    attr_accessor :skip_tools
+    attr_reader :skip_tools
+
+    # A tool name is a String, and both readers compare against one. Every
+    # neighbouring key here takes symbols, so %i[] is written often enough that
+    # accepting it as a no-op meant a configured skip silently kept the tool.
+    def skip_tools=(value)
+      @skip_tools = Array(value).map(&:to_s)
+    end
 
     # Which AI tools to generate context for (selected during install)
     # nil = all formats, or %i[claude cursor copilot opencode codex]

--- a/lib/rails_ai_context/install/cleanup.rb
+++ b/lib/rails_ai_context/install/cleanup.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require "set"
 
 module RailsAiContext
   module Install

--- a/lib/rails_ai_context/introspectors/controller_introspector.rb
+++ b/lib/rails_ai_context/introspectors/controller_introspector.rb
@@ -107,7 +107,8 @@ module RailsAiContext
         RailsAiContext::PathResolver.controller_dirs(app.root).each_with_object({}) do |controllers_dir, result|
           Dir.glob(File.join(controllers_dir, "**", "*_controller.rb")).sort.each do |path|
             relative = path.sub("#{controllers_dir}/", "")
-            class_name = relative.sub(/\.rb\z/, "").split("/").map(&:camelize).join("::")
+            path_name = relative.sub(/\.rb\z/, "").split("/").map(&:camelize).join("::")
+            class_name = DeclaredConstant.resolve(RailsAiContext::SafeFile.read(path), path_name)
             next if class_name == "ApplicationController"
             next if class_name.start_with?("Rails::", "ActionMailbox::", "ActiveStorage::")
             result[class_name] ||= path

--- a/lib/rails_ai_context/introspectors/controller_introspector.rb
+++ b/lib/rails_ai_context/introspectors/controller_introspector.rb
@@ -30,9 +30,17 @@ module RailsAiContext
           hash[ctrl.name] = { error: e.message }
         end
 
-        # Discover controllers from filesystem that may not be loaded as classes
-        discover_from_filesystem.each do |name, path|
+        # Discover controllers from filesystem that may not be loaded as classes.
+        # Reflection has already named every controller it loaded, so the file's
+        # own source is only worth reading for the ones it did not - resolving
+        # the declared constant up front would read and parse every controller
+        # in the app to produce a name this loop throws away.
+        discover_from_filesystem.each do |path_name, path|
+          next if result.key?(path_name)
+
+          name = DeclaredConstant.resolve(RailsAiContext::SafeFile.read(path), path_name)
           next if result.key?(name)
+
           result[name] = extract_details_from_source(path, name)
         end
 
@@ -44,10 +52,13 @@ module RailsAiContext
       # Static tier: every controller goes through the source-only extractor;
       # class loading and reflection never run.
       def static_call
-        result = discover_from_filesystem.each_with_object({}) do |(name, path), hash|
+        # No reflection here, so every file's own source is the only source of
+        # its name as well as its details.
+        result = discover_from_filesystem.each_with_object({}) do |(path_name, path), hash|
+          name = DeclaredConstant.resolve(RailsAiContext::SafeFile.read(path), path_name)
           hash[name] = extract_details_from_source(path, name).merge(confidence: Confidence::STATIC)
         rescue => e
-          hash[name] = { error: e.message }
+          hash[path_name] = { error: e.message }
         end
         {
           controllers: result,
@@ -107,11 +118,13 @@ module RailsAiContext
         RailsAiContext::PathResolver.controller_dirs(app.root).each_with_object({}) do |controllers_dir, result|
           Dir.glob(File.join(controllers_dir, "**", "*_controller.rb")).sort.each do |path|
             relative = path.sub("#{controllers_dir}/", "")
+            # The candidate the path camelizes to. Callers resolve the constant
+            # the source declares where they need it; doing it here would read
+            # and parse every controller file for both tiers.
             path_name = relative.sub(/\.rb\z/, "").split("/").map(&:camelize).join("::")
-            class_name = DeclaredConstant.resolve(RailsAiContext::SafeFile.read(path), path_name)
-            next if class_name == "ApplicationController"
-            next if class_name.start_with?("Rails::", "ActionMailbox::", "ActiveStorage::")
-            result[class_name] ||= path
+            next if path_name == "ApplicationController"
+            next if path_name.start_with?("Rails::", "ActionMailbox::", "ActiveStorage::")
+            result[path_name] ||= path
           end
         end
       end

--- a/lib/rails_ai_context/introspectors/controller_introspector.rb
+++ b/lib/rails_ai_context/introspectors/controller_introspector.rb
@@ -133,6 +133,12 @@ module RailsAiContext
       def extract_details_from_source(path, class_name)
         source = RailsAiContext::SafeFile.read(path)
         return { error: "unreadable" } unless source
+
+        # The name comes from the source and no longer round-trips back to the
+        # path - `ActivityPub::CollectionsController`.underscore is
+        # `activity_pub/...` and the file is under `activitypub/`. Carry the
+        # file that was read so no consumer has to guess it.
+        relative_file = path.to_s.sub("#{app.root}/", "")
         parent = extract_parent_class_ast(source)
         rate_limit = rate_limit_entry(source)
         details = {
@@ -146,7 +152,8 @@ module RailsAiContext
           rescue_from: extract_rescue_from(source),
           rate_limit: extract_rate_limit(source, rate_limit),
           rate_limit_parsed: parse_rate_limit(rate_limit),
-          turbo_stream_actions: extract_turbo_stream_actions(source)
+          turbo_stream_actions: extract_turbo_stream_actions(source),
+          file: relative_file
         }.compact
         details
       rescue => e
@@ -168,8 +175,18 @@ module RailsAiContext
           rescue_from: extract_rescue_from(source),
           rate_limit: extract_rate_limit(source, rate_limit),
           rate_limit_parsed: parse_rate_limit(rate_limit),
-          turbo_stream_actions: extract_turbo_stream_actions(source)
+          turbo_stream_actions: extract_turbo_stream_actions(source),
+          file: relative_source_path(ctrl)
         }.compact
+      end
+
+      # App-relative path of the file the class was defined in, for consumers
+      # that would otherwise reconstruct it from the name.
+      def relative_source_path(ctrl)
+        path = source_path(ctrl)
+        return nil unless path && File.exist?(path)
+
+        path.to_s.sub("#{app.root}/", "")
       end
 
       def api_controller?(ctrl)
@@ -787,10 +804,21 @@ module RailsAiContext
         RailsAiContext::SafeFile.read(path)
       end
 
+      # Ruby knows where the class was defined; the underscored name only
+      # agrees when the app registers no inflection for any of its segments.
+      # `ActivityPub::CollectionsController`.underscore is `activity_pub/...`
+      # and Mastodon's file is under `activitypub/`.
       def source_path(ctrl)
-        root = app.root.to_s
-        underscored = ctrl.name.underscore
-        File.join(root, "app", "controllers", "#{underscored}.rb")
+        # Contained under the app root: a constant defined by a gem - or by a
+        # spec - is not this app's controller file.
+        located = Object.const_source_location(ctrl.name)&.first
+        if located && File.exist?(located) && located.to_s.start_with?("#{app.root}/")
+          return located
+        end
+
+        File.join(app.root.to_s, "app", "controllers", "#{ctrl.name.underscore}.rb")
+      rescue StandardError
+        File.join(app.root.to_s, "app", "controllers", "#{ctrl.name.underscore}.rb")
       end
     end
   end

--- a/lib/rails_ai_context/introspectors/controller_introspector.rb
+++ b/lib/rails_ai_context/introspectors/controller_introspector.rb
@@ -134,10 +134,8 @@ module RailsAiContext
         source = RailsAiContext::SafeFile.read(path)
         return { error: "unreadable" } unless source
 
-        # The name comes from the source and no longer round-trips back to the
-        # path - `ActivityPub::CollectionsController`.underscore is
-        # `activity_pub/...` and the file is under `activitypub/`. Carry the
-        # file that was read so no consumer has to guess it.
+        # Carry the file that was read: the declared name does not round-trip
+        # back to a path. See CONTEXT.md, "Declared constant".
         relative_file = path.to_s.sub("#{app.root}/", "")
         parent = extract_parent_class_ast(source)
         rate_limit = rate_limit_entry(source)
@@ -805,9 +803,8 @@ module RailsAiContext
       end
 
       # Ruby knows where the class was defined; the underscored name only
-      # agrees when the app registers no inflection for any of its segments.
-      # `ActivityPub::CollectionsController`.underscore is `activity_pub/...`
-      # and Mastodon's file is under `activitypub/`.
+      # agrees when the app registers no inflection. See CONTEXT.md,
+      # "Declared constant".
       def source_path(ctrl)
         # Contained under the app root: a constant defined by a gem - or by a
         # spec - is not this app's controller file.

--- a/lib/rails_ai_context/introspectors/declared_constant.rb
+++ b/lib/rails_ai_context/introspectors/declared_constant.rb
@@ -11,12 +11,13 @@ module RailsAiContext
     # static tier has not loaded, so the source is the only place the real
     # constant is written down.
     #
-    # The path stays the answer when the source does not carry the whole name -
-    # `application_cable/channel.rb` declaring a bare `class Channel` is the
-    # case the path exists for. A declared name is taken only when it names the
-    # same file: same number of segments, same last segment. Prism parses a
-    # file with a syntax error into a partial tree, so without the second
-    # condition a half-written `class Broken` renames the whole controller.
+    # An inflection only ever changes the case of a segment, so the declared
+    # class that names a file is the one equal to the path name ignoring case.
+    # Anything else - a second class in the file, a nested error class, a
+    # partial tree Prism recovered from a syntax error - is not this file's
+    # class, and there the path stays the answer: it is the only thing carrying
+    # the namespace when the source does not, which is what
+    # `application_cable/channel.rb` needs.
     module DeclaredConstant
       module_function
 
@@ -24,43 +25,70 @@ module RailsAiContext
       # @param path_name [String] the name derived from the file's path
       # @return [String] the constant to call this file's class
       def resolve(source, path_name)
-        declared = first_declared(source)
-        return path_name unless declared
-        return path_name unless declared.count(":") == path_name.count(":")
-        return path_name unless declared.split("::").last == path_name.split("::").last
-
-        declared
+        name_for(declared_classes(source), path_name)
       end
 
-      # Fully qualified name of the first class the source declares, module
-      # nesting included. Nil when nothing parses or nothing is declared.
-      def first_declared(source)
-        return nil unless source
+      # Whether the file declares a class of its own, as opposed to a module
+      # that happens to hold one. app/mailers is where ActionMailer
+      # interceptors live, and reporting one as a mailer offers
+      # `delivering_email` - a hook the framework calls - as an email to send.
+      def declares_own_class?(source, path_name)
+        own_class?(declared_classes(source), path_name)
+      end
+
+      # Fully qualified names of every class the source declares, module
+      # nesting included, in source order. Empty when nothing parses.
+      def declared_classes(source)
+        return [] unless source
 
         root = AstCache.parse_string(source)&.value
-        root && search(root, [])
+        return [] unless root
+
+        [].tap { |names| collect(root, [], names) }
       rescue StandardError, ScriptError => e
         $stderr.puts "[rails-ai-context] DeclaredConstant failed: #{e.message}" if ENV["DEBUG"]
-        nil
+        []
       end
 
-      def search(node, scope)
+      # --- decisions over an already-collected list ---
+
+      def name_for(declared, path_name)
+        declared.find { |name| name.casecmp?(path_name) } || path_name
+      end
+
+      # A class nested deeper than the file's own constant belongs to whatever
+      # declares it, not to the file.
+      def own_class?(declared, path_name)
+        depth = path_name.split("::").size
+        declared.any? { |name| name.split("::").size <= depth }
+      end
+
+      # --- walking ---
+
+      def collect(node, scope, names)
         case node
         when Prism::ClassNode
-          (scope + [ node.constant_path.slice ]).join("::")
+          names << qualify(scope, node)
+          descend(node, scope + [ segment(node) ], names)
         when Prism::ModuleNode
-          descend(node, scope + [ node.constant_path.slice ])
+          descend(node, scope + [ segment(node) ], names)
         else
-          descend(node, scope)
+          descend(node, scope, names)
         end
       end
 
-      def descend(node, scope)
-        node.child_nodes.compact.each do |child|
-          found = search(child, scope)
-          return found if found
-        end
-        nil
+      def descend(node, scope, names)
+        node.child_nodes.compact.each { |child| collect(child, scope, names) }
+      end
+
+      def qualify(scope, node)
+        (scope + [ segment(node) ]).join("::")
+      end
+
+      # `class ::Foo::Bar` is the same constant as `class Foo::Bar`; the root
+      # scope operator is not part of the name.
+      def segment(node)
+        node.constant_path.slice.delete_prefix("::")
       end
     end
   end

--- a/lib/rails_ai_context/introspectors/declared_constant.rb
+++ b/lib/rails_ai_context/introspectors/declared_constant.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module RailsAiContext
+  module Introspectors
+    # The constant a source file declares, for the static tier's naming.
+    #
+    # Camelizing the path is right often enough to look right always, and
+    # wrong wherever the app registers an inflection: `app/controllers/
+    # activitypub/` is `ActivityPub` in Mastodon and `Oauth` is nothing at all.
+    # Zeitwerk resolves the path through the app's own inflector, which the
+    # static tier has not loaded, so the source is the only place the real
+    # constant is written down.
+    #
+    # The path stays the answer when the source does not carry the whole name -
+    # `application_cable/channel.rb` declaring a bare `class Channel` is the
+    # case the path exists for. A declared name is taken only when it names the
+    # same file: same number of segments, same last segment. Prism parses a
+    # file with a syntax error into a partial tree, so without the second
+    # condition a half-written `class Broken` renames the whole controller.
+    module DeclaredConstant
+      module_function
+
+      # @param source [String] the file's source
+      # @param path_name [String] the name derived from the file's path
+      # @return [String] the constant to call this file's class
+      def resolve(source, path_name)
+        declared = first_declared(source)
+        return path_name unless declared
+        return path_name unless declared.count(":") == path_name.count(":")
+        return path_name unless declared.split("::").last == path_name.split("::").last
+
+        declared
+      end
+
+      # Fully qualified name of the first class the source declares, module
+      # nesting included. Nil when nothing parses or nothing is declared.
+      def first_declared(source)
+        return nil unless source
+
+        root = AstCache.parse_string(source)&.value
+        root && search(root, [])
+      rescue StandardError, ScriptError => e
+        $stderr.puts "[rails-ai-context] DeclaredConstant failed: #{e.message}" if ENV["DEBUG"]
+        nil
+      end
+
+      def search(node, scope)
+        case node
+        when Prism::ClassNode
+          (scope + [ node.constant_path.slice ]).join("::")
+        when Prism::ModuleNode
+          descend(node, scope + [ node.constant_path.slice ])
+        else
+          descend(node, scope)
+        end
+      end
+
+      def descend(node, scope)
+        node.child_nodes.compact.each do |child|
+          found = search(child, scope)
+          return found if found
+        end
+        nil
+      end
+    end
+  end
+end

--- a/lib/rails_ai_context/introspectors/declared_constant.rb
+++ b/lib/rails_ai_context/introspectors/declared_constant.rb
@@ -22,34 +22,32 @@ module RailsAiContext
       module_function
 
       # @param source [String] the file's source
-      # @param path_name [String] the name derived from the file's path
+      # @param path_name [String] the name the file's path camelizes to
       # @return [String] the constant to call this file's class
       def resolve(source, path_name)
-        name_for(declared_classes(source), path_name)
+        declarations(source)
+          .map { |d| d[:name] }
+          .find { |name| name.casecmp?(path_name) } || path_name
       end
 
-      # Whether the file declares a class of its own, as opposed to a module
-      # that happens to hold one. app/mailers is where ActionMailer
-      # interceptors live, and reporting one as a mailer offers
-      # `delivering_email` - a hook the framework calls - as an email to send.
-      def declares_own_class?(source, path_name)
-        own_class?(declared_classes(source), path_name)
+      # Whether the file declares, at its own level, a class that inherits
+      # something. A mailer and a channel always do; app/mailers is also where
+      # ActionMailer interceptors live, written as a module or as a bare class,
+      # and reporting one of those offers `delivering_email` - a hook the
+      # framework calls - as an email somebody can send.
+      #
+      # "At its own level" excludes a class nested deeper than the file's own
+      # constant, which belongs to whatever declares it rather than to the file.
+      def own_subclass?(source, path_name)
+        depth = path_name.split("::").size
+
+        declarations(source).any? do |d|
+          d[:superclass] && d[:name].split("::").size <= depth
+        end
       end
 
-      # Fully qualified names of every class the source declares, module
-      # nesting included, in source order. Empty when nothing parses.
-      def declared_classes(source)
-        declarations(source).map { |d| d[:name] }
-      end
-
-      # The same list narrowed to classes that inherit something. A mailer or a
-      # channel always does; an interceptor written as a bare class does not,
-      # and app/mailers is where interceptors live.
-      def declared_subclasses(source)
-        declarations(source).select { |d| d[:superclass] }.map { |d| d[:name] }
-      end
-
-      # @return [Array<Hash>] { name:, superclass: } per declared class
+      # Every class the source declares: fully qualified name, module nesting
+      # included, and the superclass as written. Empty when nothing parses.
       def declarations(source)
         return [] unless source
 
@@ -61,21 +59,6 @@ module RailsAiContext
         $stderr.puts "[rails-ai-context] DeclaredConstant failed: #{e.message}" if ENV["DEBUG"]
         []
       end
-
-      # --- decisions over an already-collected list ---
-
-      def name_for(declared, path_name)
-        declared.find { |name| name.casecmp?(path_name) } || path_name
-      end
-
-      # A class nested deeper than the file's own constant belongs to whatever
-      # declares it, not to the file.
-      def own_class?(declared, path_name)
-        depth = path_name.split("::").size
-        declared.any? { |name| name.split("::").size <= depth }
-      end
-
-      # --- walking ---
 
       def collect(node, scope, found)
         case node
@@ -102,6 +85,8 @@ module RailsAiContext
       def segment(node)
         node.constant_path.slice.delete_prefix("::")
       end
+
+      private_class_method :collect, :descend, :qualify, :segment
     end
   end
 end

--- a/lib/rails_ai_context/introspectors/declared_constant.rb
+++ b/lib/rails_ai_context/introspectors/declared_constant.rb
@@ -39,12 +39,24 @@ module RailsAiContext
       # Fully qualified names of every class the source declares, module
       # nesting included, in source order. Empty when nothing parses.
       def declared_classes(source)
+        declarations(source).map { |d| d[:name] }
+      end
+
+      # The same list narrowed to classes that inherit something. A mailer or a
+      # channel always does; an interceptor written as a bare class does not,
+      # and app/mailers is where interceptors live.
+      def declared_subclasses(source)
+        declarations(source).select { |d| d[:superclass] }.map { |d| d[:name] }
+      end
+
+      # @return [Array<Hash>] { name:, superclass: } per declared class
+      def declarations(source)
         return [] unless source
 
         root = AstCache.parse_string(source)&.value
         return [] unless root
 
-        [].tap { |names| collect(root, [], names) }
+        [].tap { |found| collect(root, [], found) }
       rescue StandardError, ScriptError => e
         $stderr.puts "[rails-ai-context] DeclaredConstant failed: #{e.message}" if ENV["DEBUG"]
         []
@@ -65,20 +77,20 @@ module RailsAiContext
 
       # --- walking ---
 
-      def collect(node, scope, names)
+      def collect(node, scope, found)
         case node
         when Prism::ClassNode
-          names << qualify(scope, node)
-          descend(node, scope + [ segment(node) ], names)
+          found << { name: qualify(scope, node), superclass: node.superclass&.slice }
+          descend(node, scope + [ segment(node) ], found)
         when Prism::ModuleNode
-          descend(node, scope + [ segment(node) ], names)
+          descend(node, scope + [ segment(node) ], found)
         else
-          descend(node, scope, names)
+          descend(node, scope, found)
         end
       end
 
-      def descend(node, scope, names)
-        node.child_nodes.compact.each { |child| collect(child, scope, names) }
+      def descend(node, scope, found)
+        node.child_nodes.compact.each { |child| collect(child, scope, found) }
       end
 
       def qualify(scope, node)

--- a/lib/rails_ai_context/introspectors/declared_constant.rb
+++ b/lib/rails_ai_context/introspectors/declared_constant.rb
@@ -25,30 +25,12 @@ module RailsAiContext
       # @param path_name [String] the name the file's path camelizes to
       # @return [String] the constant to call this file's class
       def resolve(source, path_name)
-        declarations(source)
-          .map { |d| d[:name] }
-          .find { |name| name.casecmp?(path_name) } || path_name
+        declared_names(source).find { |name| name.casecmp?(path_name) } || path_name
       end
 
-      # Whether the file declares, at its own level, a class that inherits
-      # something. A mailer and a channel always do; app/mailers is also where
-      # ActionMailer interceptors live, written as a module or as a bare class,
-      # and reporting one of those offers `delivering_email` - a hook the
-      # framework calls - as an email somebody can send.
-      #
-      # "At its own level" excludes a class nested deeper than the file's own
-      # constant, which belongs to whatever declares it rather than to the file.
-      def own_subclass?(source, path_name)
-        depth = path_name.split("::").size
-
-        declarations(source).any? do |d|
-          d[:superclass] && d[:name].split("::").size <= depth
-        end
-      end
-
-      # Every class the source declares: fully qualified name, module nesting
-      # included, and the superclass as written. Empty when nothing parses.
-      def declarations(source)
+      # Fully qualified name of every class the source declares, module
+      # nesting included. Empty when nothing parses.
+      def declared_names(source)
         return [] unless source
 
         root = AstCache.parse_string(source)&.value
@@ -63,7 +45,7 @@ module RailsAiContext
       def collect(node, scope, found)
         case node
         when Prism::ClassNode
-          found << { name: qualify(scope, node), superclass: node.superclass&.slice }
+          found << qualify(scope, node)
           descend(node, scope + [ segment(node) ], found)
         when Prism::ModuleNode
           descend(node, scope + [ segment(node) ], found)
@@ -86,7 +68,7 @@ module RailsAiContext
         node.constant_path.slice.delete_prefix("::")
       end
 
-      private_class_method :collect, :descend, :qualify, :segment
+      private_class_method :declared_names, :collect, :descend, :qualify, :segment
     end
   end
 end

--- a/lib/rails_ai_context/introspectors/declared_constant.rb
+++ b/lib/rails_ai_context/introspectors/declared_constant.rb
@@ -28,6 +28,12 @@ module RailsAiContext
         declared_names(source).find { |name| name.casecmp?(path_name) } || path_name
       end
 
+      # @return [Boolean] whether the source declares a class at all. A file
+      #   that declares only modules is a mixin, whatever directory it sits in.
+      def declares_class?(source)
+        declared_names(source).any?
+      end
+
       # Fully qualified name of every class the source declares, module
       # nesting included. Empty when nothing parses.
       def declared_names(source)

--- a/lib/rails_ai_context/introspectors/i18n_introspector.rb
+++ b/lib/rails_ai_context/introspectors/i18n_introspector.rb
@@ -213,38 +213,60 @@ module RailsAiContext
         []
       end
 
-      # Finds all YAML files contributing translations for the given locale:
-      #   config/locales/en.yml
-      #   config/locales/devise.en.yml
-      #   config/locales/en/users.yml
-      #   config/locales/admin/en.yml
-      def find_locale_paths(locale)
-        base = File.join(app.root, "config", "locales")
-        return [] unless Dir.exist?(base)
-        loc = locale.to_s
-        all = Dir.glob(File.join(base, "**/*.{yml,yaml}"))
-        named = all.select do |p|
-          name = File.basename(p, ".*")
-          rel = p.sub("#{base}/", "")
-          name == loc || name.end_with?(".#{loc}") || rel.start_with?("#{loc}/") || rel.include?("/#{loc}/")
-        end
-        # Nothing requires a locale file to be named for its locale, and a
-        # locale can have both: its own file and keys in a shared one. Reading
-        # the convention alone scores it on a fraction of what it translates,
-        # and reports a locale that lives only in a shared file as having no
-        # translations - a positive claim, and a false one.
-        (named + all.reject { |p| named.include?(p) }.select { |p| declares_locale?(p, loc) }).uniq
-      end
+# Finds all YAML files contributing translations for the given locale:
+#   config/locales/en.yml
+#   config/locales/devise.en.yml
+#   config/locales/en/users.yml
+#   config/locales/admin/en.yml
+def find_locale_paths(locale)
+  base = locales_dir
+  return [] unless base
 
-      def declares_locale?(path, loc)
-        content = RailsAiContext::SafeFile.read(path)
-        return false unless content
+  loc = locale.to_s
+  named = locale_file_paths.select do |p|
+    name = File.basename(p, ".*")
+    rel = p.sub("#{base}/", "")
+    name == loc || name.end_with?(".#{loc}") || rel.start_with?("#{loc}/") || rel.include?("/#{loc}/")
+  end
 
-        data = YAML.safe_load(content, permitted_classes: [ Symbol ], aliases: true)
-        data.is_a?(Hash) && data.keys.map(&:to_s).include?(loc)
-      rescue StandardError
-        false
-      end
+  # Nothing requires a locale file to be named for its locale, and a
+  # locale can have both: its own file and keys in a shared one. Reading
+  # the convention alone scores it on a fraction of what it translates,
+  # and reports a locale that lives only in a shared file as having no
+  # translations - a positive claim, and a false one.
+  (named + paths_by_declared_locale.fetch(loc, [])).uniq
+end
+
+def locales_dir
+  return @locales_dir if defined?(@locales_dir)
+
+  dir = File.join(app.root, "config", "locales")
+  @locales_dir = Dir.exist?(dir) ? dir : nil
+end
+
+def locale_file_paths
+  @locale_file_paths ||= locales_dir ? Dir.glob(File.join(locales_dir, "**/*.{yml,yaml}")).sort : []
+end
+
+# locale => the files declaring it, built in ONE pass. Asking every file
+# about every locale is O(locales x files): 187 locales over 108 files
+# took Discourse's i18n answer from under a second to four and a half
+# minutes.
+def paths_by_declared_locale
+  @paths_by_declared_locale ||= locale_file_paths.each_with_object({}) do |path, index|
+    top_level_locales(path).each { |loc| (index[loc] ||= []) << path }
+  end
+end
+
+def top_level_locales(path)
+  content = RailsAiContext::SafeFile.read(path)
+  return [] unless content
+
+  data = YAML.safe_load(content, permitted_classes: [ Symbol ], aliases: true)
+  data.is_a?(Hash) ? data.keys.map(&:to_s) : []
+rescue StandardError
+  []
+end
 
       def nested_key_paths(hash, prefix = nil, paths = [])
         return paths unless hash.is_a?(Hash)

--- a/lib/rails_ai_context/introspectors/i18n_introspector.rb
+++ b/lib/rails_ai_context/introspectors/i18n_introspector.rb
@@ -21,13 +21,15 @@ module RailsAiContext
       end
 
       def call
+        coverage, untranslated = detect_locale_coverage
         result = {
           default_locale: I18n.default_locale.to_s,
           available_locales: I18n.available_locales.map(&:to_s).sort,
           backend: I18n.backend.class.name,
           locale_files: extract_locale_files,
           total_locale_files: count_locale_files,
-          locale_coverage: detect_locale_coverage
+          locale_coverage: coverage,
+          locales_without_translations: untranslated
         }
         result.merge!(detect_fallback_config)
         result
@@ -41,6 +43,7 @@ module RailsAiContext
       def static_call
         locales = locales_from_files
         default = default_locale_from_config
+        coverage, untranslated = detect_locale_coverage(locales: locales.map(&:to_sym), default: default.to_sym)
 
         {
           default_locale: default,
@@ -48,7 +51,8 @@ module RailsAiContext
           backend: nil,
           locale_files: extract_locale_files,
           total_locale_files: count_locale_files,
-          locale_coverage: detect_locale_coverage(locales: locales.map(&:to_sym), default: default.to_sym)
+          locale_coverage: coverage,
+          locales_without_translations: untranslated
         }.merge(detect_fallback_config)
       rescue => e
         { error: e.message }
@@ -139,17 +143,31 @@ module RailsAiContext
         {}
       end
 
+      # @return [Array(Hash, Array<String>)] coverage per locale, and the
+      #   locales left out of it because they carry no translations.
       def detect_locale_coverage(locales: I18n.available_locales, default: I18n.default_locale)
-        return {} if locales.size < 2
+        return [ {}, [] ] if locales.size < 2
 
         # Coverage is the share of the default locale's keys that the other
         # locale also defines. Comparing raw counts instead reports over 100%
         # for a locale that translates few default keys but adds many of its
         # own - the one number a translator must not be told is fine.
         coverage = {}
+        untranslated = []
         default_keys = key_paths_for_locale(default)
         locales.reject { |l| l == default }.each do |locale|
           locale_keys = key_paths_for_locale(locale)
+
+          # A locale with no file of its own carries no translations to
+          # measure. Rails still lists it - a language-name lookup table under
+          # config/locales contributes a top-level key per language - but
+          # scoring it produces a row per language saying every key is missing,
+          # which describes a translation effort nobody started.
+          if locale_keys.empty?
+            untranslated << locale.to_s
+            next
+          end
+
           translated = (default_keys & locale_keys).size
           coverage[locale.to_s] = {
             keys: locale_keys.size,
@@ -158,10 +176,10 @@ module RailsAiContext
             coverage_pct: default_keys.any? ? ((translated.to_f / default_keys.size) * 100).round(1) : 0
           }
         end
-        coverage
+        [ coverage, untranslated ]
       rescue => e
         $stderr.puts "[rails-ai-context] detect_locale_coverage failed: #{e.message}" if ENV["DEBUG"]
-        {}
+        [ {}, [] ]
       end
 
       # Dotted key paths a locale defines, with the locale root stripped so

--- a/lib/rails_ai_context/introspectors/i18n_introspector.rb
+++ b/lib/rails_ai_context/introspectors/i18n_introspector.rb
@@ -12,7 +12,10 @@ module RailsAiContext
       # Both spellings apps use: `config.i18n.default_locale = :es` in
       # application.rb or an environment file, and a bare
       # `I18n.default_locale = :es` in an initializer.
-      DEFAULT_LOCALE_ASSIGNMENT = /(?:config\.i18n|I18n)\.default_locale\s*=\s*[:"']([\w-]+)/
+      # Anchored past the line start so a commented example does not win:
+      # GitLab ships `# config.i18n.default_locale = :de` and every coverage
+      # line then measured an English app against German.
+      DEFAULT_LOCALE_ASSIGNMENT = /^[^\S\n]*(?:config\.i18n|I18n)\.default_locale\s*=\s*[:"']([\w-]+)/
 
       attr_reader :app
 

--- a/lib/rails_ai_context/introspectors/i18n_introspector.rb
+++ b/lib/rails_ai_context/introspectors/i18n_introspector.rb
@@ -87,8 +87,15 @@ module RailsAiContext
       # Rails' own default is :en, so "en" is the right answer when the app
       # never says otherwise - not a guess.
       def default_locale_from_config
+        # config/environments/*.rb arrive in glob order, so whichever file
+        # carried an assignment first won whatever environment it belonged to -
+        # and development.rb sorts ahead of production.rb.
+        env = ENV["RAILS_ENV"] || "development"
+        environments = Dir.glob(File.join(root, "config", "environments", "*.rb"))
+          .partition { |path| File.basename(path, ".rb") == env }.flatten
+
         candidates = [ File.join(root, "config", "application.rb") ] +
-                     Dir.glob(File.join(root, "config", "environments", "*.rb")) +
+                     environments +
                      Dir.glob(File.join(root, "config", "initializers", "*.rb"))
 
         candidates.each do |path|
@@ -176,16 +183,16 @@ module RailsAiContext
           # lookup table under config/locales, and such a table shares a key or
           # two with the default by coincidence - on Discourse that produced
           # 138 rows reading "0.0% - 11918 missing", a translation effort
-          # nobody had started. Naming those locales is the honest form; a
-          # screen of zeroes is not.
-          if pct.zero?
-            # The key count travels with the name: a locale can define plenty and
-            # still share none with the default - GitLab's zh-CN has 109, all
-            # from gem-provided files - and a bare name reads as "not
-            # translated" when the truth is "translated something else".
-            untranslated << { locale: locale.to_s, keys: locale_keys.size }
-            next
-          end
+          # nobody had started.
+          #
+          # The key count travels with the name: a locale can define plenty and
+          # still share none with the default, and a bare name reads as "not
+          # translated" when the truth is "translated something else".
+          #
+          # The row is written either way. Naming a locale here only asks the
+          # renderer to group it; deleting its numbers would leave a
+          # translation genuinely started below the floor with nothing to read.
+          untranslated << { locale: locale.to_s, keys: locale_keys.size } if pct.zero?
 
           coverage[locale.to_s] = {
             keys: locale_keys.size,

--- a/lib/rails_ai_context/introspectors/i18n_introspector.rb
+++ b/lib/rails_ai_context/introspectors/i18n_introspector.rb
@@ -155,25 +155,34 @@ module RailsAiContext
         coverage = {}
         untranslated = []
         default_keys = key_paths_for_locale(default)
+
+        # Coverage is the share of the default locale's keys another locale
+        # also defines. With no keys to measure against - a default_locale the
+        # app configures but ships no file for - every locale scores zero, and
+        # bucketing them all as untranslated says something false about each.
+        return [ {}, [] ] if default_keys.empty?
         locales.reject { |l| l == default }.each do |locale|
           locale_keys = key_paths_for_locale(locale)
           translated = (default_keys & locale_keys).size
+          pct = ((translated.to_f / default_keys.size) * 100).round(1)
 
-          # A locale that translates none of the default's keys has no coverage
-          # to report. Rails lists it because a language-name lookup table
-          # under config/locales contributes a top-level key per language, and
-          # scoring those produced a row per language saying every key was
-          # missing - a translation effort nobody had started. Naming them is
-          # the honest form; a row of zeroes is not.
-          if translated.zero?
+          # Below the rounding floor there is nothing to show but zeroes. Rails
+          # lists a locale per language when the app keeps a language-name
+          # lookup table under config/locales, and such a table shares a key or
+          # two with the default by coincidence - on Discourse that produced
+          # 138 rows reading "0.0% - 11918 missing", a translation effort
+          # nobody had started. Naming those locales is the honest form; a
+          # screen of zeroes is not.
+          if pct.zero?
             untranslated << locale.to_s
             next
           end
+
           coverage[locale.to_s] = {
             keys: locale_keys.size,
             missing: (default_keys - locale_keys).size,
             extra: (locale_keys - default_keys).size,
-            coverage_pct: default_keys.any? ? ((translated.to_f / default_keys.size) * 100).round(1) : 0
+            coverage_pct: pct
           }
         end
         [ coverage, untranslated ]
@@ -219,12 +228,12 @@ module RailsAiContext
           rel = p.sub("#{base}/", "")
           name == loc || name.end_with?(".#{loc}") || rel.start_with?("#{loc}/") || rel.include?("/#{loc}/")
         end
-        return named if named.any?
-
-        # Nothing requires a locale file to be named for its locale. Reading
-        # the convention alone reports a locale carried in a shared file as
-        # having no translations, which is a positive claim and a false one.
-        all.select { |p| declares_locale?(p, loc) }
+        # Nothing requires a locale file to be named for its locale, and a
+        # locale can have both: its own file and keys in a shared one. Reading
+        # the convention alone scores it on a fraction of what it translates,
+        # and reports a locale that lives only in a shared file as having no
+        # translations - a positive claim, and a false one.
+        (named + all.reject { |p| named.include?(p) }.select { |p| declares_locale?(p, loc) }).uniq
       end
 
       def declares_locale?(path, loc)

--- a/lib/rails_ai_context/introspectors/i18n_introspector.rb
+++ b/lib/rails_ai_context/introspectors/i18n_introspector.rb
@@ -159,10 +159,9 @@ module RailsAiContext
         untranslated = []
         default_keys = key_paths_for_locale(default)
 
-        # Coverage is the share of the default locale's keys another locale
-        # also defines. With no keys to measure against - a default_locale the
-        # app configures but ships no file for - every locale scores zero, and
-        # bucketing them all as untranslated says something false about each.
+        # With nothing to measure against - a default_locale the app
+        # configures but ships no file for - every locale scores zero, and
+        # bucketing them all says something false about each.
         return [ {}, [] ] if default_keys.empty?
         locales.reject { |l| l == default }.each do |locale|
           locale_keys = key_paths_for_locale(locale)
@@ -275,14 +274,14 @@ module RailsAiContext
         []
       end
 
-            def nested_key_paths(hash, prefix = nil, paths = [])
-              return paths unless hash.is_a?(Hash)
-              hash.each do |key, value|
-                path = prefix ? "#{prefix}.#{key}" : key.to_s
-                value.is_a?(Hash) ? nested_key_paths(value, path, paths) : paths << path
-              end
-              paths
-            end
+      def nested_key_paths(hash, prefix = nil, paths = [])
+        return paths unless hash.is_a?(Hash)
+        hash.each do |key, value|
+          path = prefix ? "#{prefix}.#{key}" : key.to_s
+          value.is_a?(Hash) ? nested_key_paths(value, path, paths) : paths << path
+        end
+        paths
+      end
     end
   end
 end

--- a/lib/rails_ai_context/introspectors/i18n_introspector.rb
+++ b/lib/rails_ai_context/introspectors/i18n_introspector.rb
@@ -213,69 +213,69 @@ module RailsAiContext
         []
       end
 
-# Finds all YAML files contributing translations for the given locale:
-#   config/locales/en.yml
-#   config/locales/devise.en.yml
-#   config/locales/en/users.yml
-#   config/locales/admin/en.yml
-def find_locale_paths(locale)
-  base = locales_dir
-  return [] unless base
+      # Finds all YAML files contributing translations for the given locale:
+      #   config/locales/en.yml
+      #   config/locales/devise.en.yml
+      #   config/locales/en/users.yml
+      #   config/locales/admin/en.yml
+      def find_locale_paths(locale)
+        base = locales_dir
+        return [] unless base
 
-  loc = locale.to_s
-  named = locale_file_paths.select do |p|
-    name = File.basename(p, ".*")
-    rel = p.sub("#{base}/", "")
-    name == loc || name.end_with?(".#{loc}") || rel.start_with?("#{loc}/") || rel.include?("/#{loc}/")
-  end
-
-  # Nothing requires a locale file to be named for its locale, and a
-  # locale can have both: its own file and keys in a shared one. Reading
-  # the convention alone scores it on a fraction of what it translates,
-  # and reports a locale that lives only in a shared file as having no
-  # translations - a positive claim, and a false one.
-  (named + paths_by_declared_locale.fetch(loc, [])).uniq
-end
-
-def locales_dir
-  return @locales_dir if defined?(@locales_dir)
-
-  dir = File.join(app.root, "config", "locales")
-  @locales_dir = Dir.exist?(dir) ? dir : nil
-end
-
-def locale_file_paths
-  @locale_file_paths ||= locales_dir ? Dir.glob(File.join(locales_dir, "**/*.{yml,yaml}")).sort : []
-end
-
-# locale => the files declaring it, built in ONE pass. Asking every file
-# about every locale is O(locales x files): 187 locales over 108 files
-# took Discourse's i18n answer from under a second to four and a half
-# minutes.
-def paths_by_declared_locale
-  @paths_by_declared_locale ||= locale_file_paths.each_with_object({}) do |path, index|
-    top_level_locales(path).each { |loc| (index[loc] ||= []) << path }
-  end
-end
-
-def top_level_locales(path)
-  content = RailsAiContext::SafeFile.read(path)
-  return [] unless content
-
-  data = YAML.safe_load(content, permitted_classes: [ Symbol ], aliases: true)
-  data.is_a?(Hash) ? data.keys.map(&:to_s) : []
-rescue StandardError
-  []
-end
-
-      def nested_key_paths(hash, prefix = nil, paths = [])
-        return paths unless hash.is_a?(Hash)
-        hash.each do |key, value|
-          path = prefix ? "#{prefix}.#{key}" : key.to_s
-          value.is_a?(Hash) ? nested_key_paths(value, path, paths) : paths << path
+        loc = locale.to_s
+        named = locale_file_paths.select do |p|
+          name = File.basename(p, ".*")
+          rel = p.sub("#{base}/", "")
+          name == loc || name.end_with?(".#{loc}") || rel.start_with?("#{loc}/") || rel.include?("/#{loc}/")
         end
-        paths
+
+        # Nothing requires a locale file to be named for its locale, and a
+        # locale can have both: its own file and keys in a shared one. Reading
+        # the convention alone scores it on a fraction of what it translates,
+        # and reports a locale that lives only in a shared file as having no
+        # translations - a positive claim, and a false one.
+        (named + paths_by_declared_locale.fetch(loc, [])).uniq
       end
+
+      def locales_dir
+        return @locales_dir if defined?(@locales_dir)
+
+        dir = File.join(app.root, "config", "locales")
+        @locales_dir = Dir.exist?(dir) ? dir : nil
+      end
+
+      def locale_file_paths
+        @locale_file_paths ||= locales_dir ? Dir.glob(File.join(locales_dir, "**/*.{yml,yaml}")).sort : []
+      end
+
+      # locale => the files declaring it, built in ONE pass. Asking every file
+      # about every locale is O(locales x files): 187 locales over 108 files
+      # took Discourse's i18n answer from under a second to four and a half
+      # minutes.
+      def paths_by_declared_locale
+        @paths_by_declared_locale ||= locale_file_paths.each_with_object({}) do |path, index|
+          top_level_locales(path).each { |loc| (index[loc] ||= []) << path }
+        end
+      end
+
+      def top_level_locales(path)
+        content = RailsAiContext::SafeFile.read(path)
+        return [] unless content
+
+        data = YAML.safe_load(content, permitted_classes: [ Symbol ], aliases: true)
+        data.is_a?(Hash) ? data.keys.map(&:to_s) : []
+      rescue StandardError
+        []
+      end
+
+            def nested_key_paths(hash, prefix = nil, paths = [])
+              return paths unless hash.is_a?(Hash)
+              hash.each do |key, value|
+                path = prefix ? "#{prefix}.#{key}" : key.to_s
+                value.is_a?(Hash) ? nested_key_paths(value, path, paths) : paths << path
+              end
+              paths
+            end
     end
   end
 end

--- a/lib/rails_ai_context/introspectors/i18n_introspector.rb
+++ b/lib/rails_ai_context/introspectors/i18n_introspector.rb
@@ -114,6 +114,9 @@ module RailsAiContext
             begin
               data = YAML.load_file(path, permitted_classes: [ Symbol ], aliases: true) || {}
               info[:key_count] = count_keys(data)
+              # Which locales this file actually serves. The filename is only a
+              # convention, and a gem-provided file is named for the gem.
+              info[:locales] = data.is_a?(Hash) ? data.keys.map(&:to_s) : []
             rescue => e
               $stderr.puts "[rails-ai-context] extract_locale_files failed: #{e.message}" if ENV["DEBUG"]
               info[:parse_error] = true
@@ -174,7 +177,11 @@ module RailsAiContext
           # nobody had started. Naming those locales is the honest form; a
           # screen of zeroes is not.
           if pct.zero?
-            untranslated << locale.to_s
+            # The key count travels with the name: a locale can define plenty and
+            # still share none with the default - GitLab's zh-CN has 109, all
+            # from gem-provided files - and a bare name reads as "not
+            # translated" when the truth is "translated something else".
+            untranslated << { locale: locale.to_s, keys: locale_keys.size }
             next
           end
 

--- a/lib/rails_ai_context/introspectors/i18n_introspector.rb
+++ b/lib/rails_ai_context/introspectors/i18n_introspector.rb
@@ -157,18 +157,18 @@ module RailsAiContext
         default_keys = key_paths_for_locale(default)
         locales.reject { |l| l == default }.each do |locale|
           locale_keys = key_paths_for_locale(locale)
+          translated = (default_keys & locale_keys).size
 
-          # A locale with no file of its own carries no translations to
-          # measure. Rails still lists it - a language-name lookup table under
-          # config/locales contributes a top-level key per language - but
-          # scoring it produces a row per language saying every key is missing,
-          # which describes a translation effort nobody started.
-          if locale_keys.empty?
+          # A locale that translates none of the default's keys has no coverage
+          # to report. Rails lists it because a language-name lookup table
+          # under config/locales contributes a top-level key per language, and
+          # scoring those produced a row per language saying every key was
+          # missing - a translation effort nobody had started. Naming them is
+          # the honest form; a row of zeroes is not.
+          if translated.zero?
             untranslated << locale.to_s
             next
           end
-
-          translated = (default_keys & locale_keys).size
           coverage[locale.to_s] = {
             keys: locale_keys.size,
             missing: (default_keys - locale_keys).size,
@@ -213,11 +213,28 @@ module RailsAiContext
         base = File.join(app.root, "config", "locales")
         return [] unless Dir.exist?(base)
         loc = locale.to_s
-        Dir.glob(File.join(base, "**/*.{yml,yaml}")).select do |p|
+        all = Dir.glob(File.join(base, "**/*.{yml,yaml}"))
+        named = all.select do |p|
           name = File.basename(p, ".*")
           rel = p.sub("#{base}/", "")
           name == loc || name.end_with?(".#{loc}") || rel.start_with?("#{loc}/") || rel.include?("/#{loc}/")
         end
+        return named if named.any?
+
+        # Nothing requires a locale file to be named for its locale. Reading
+        # the convention alone reports a locale carried in a shared file as
+        # having no translations, which is a positive claim and a false one.
+        all.select { |p| declares_locale?(p, loc) }
+      end
+
+      def declares_locale?(path, loc)
+        content = RailsAiContext::SafeFile.read(path)
+        return false unless content
+
+        data = YAML.safe_load(content, permitted_classes: [ Symbol ], aliases: true)
+        data.is_a?(Hash) && data.keys.map(&:to_s).include?(loc)
+      rescue StandardError
+        false
       end
 
       def nested_key_paths(hash, prefix = nil, paths = [])

--- a/lib/rails_ai_context/introspectors/job_introspector.rb
+++ b/lib/rails_ai_context/introspectors/job_introspector.rb
@@ -280,9 +280,23 @@ module RailsAiContext
       # inherits too, so a public helper on a base class is an action the
       # booted tier reports and this one cannot - the entries are tagged STATIC
       # for that reason.
+      # ActionMailer's interceptor and observer hooks. A class or module under
+      # app/mailers that implements one is registered with the framework, not
+      # delivered by it: reporting OpenProject's Interceptors::DefaultHeaders
+      # as a mailer offered `delivering_email` as an email somebody can send.
+      # Everything else in that directory stays - a mailer's actions are as
+      # often written as modules mixed into one class as they are methods on
+      # it, and GitLab keeps 20 such modules holding every notification it
+      # sends.
+      MAILER_FRAMEWORK_HOOKS = %w[delivering_email previewing_email delivered_email].freeze
+
       def extract_mailers_from_source
         source_classes(File.join(app.root, "app", "mailers")).filter_map do |name, methods|
           next if name == "ApplicationMailer"
+
+          # The hook is as often a class method as an instance one, so the
+          # whole declared method list is what decides, not the action list.
+          next if Array(methods).any? { |m| MAILER_FRAMEWORK_HOOKS.include?(m[:name].to_s) }
 
           actions = ActionResolver.own_actions(methods, class_name: name)
           next if actions.empty?
@@ -328,14 +342,11 @@ module RailsAiContext
           source = RailsAiContext::SafeFile.read(path)
           next unless source
 
-          # Only a class that inherits something names a mailer or a channel.
-          # app/mailers is also where ActionMailer interceptors live, written
-          # as a module or as a bare class, and reporting one of those offers
-          # `delivering_email` - a hook the framework calls - as an email
-          # somebody can send.
+          # Whether a declaration belongs here is decided by its own methods -
+          # see MAILER_FRAMEWORK_HOOKS - because a mailer's actions are as
+          # often written as modules mixed into one class as they are methods
+          # on it. Reading the file is only about naming it.
           path_name = path_name_for(path, dir)
-          next unless DeclaredConstant.own_subclass?(source, path_name)
-
           walked = SourceIntrospector.walk_source(source, { methods: Listeners::MethodsListener })
           [ DeclaredConstant.resolve(source, path_name), walked[:methods] || [] ]
         rescue StandardError, ScriptError => e

--- a/lib/rails_ai_context/introspectors/job_introspector.rb
+++ b/lib/rails_ai_context/introspectors/job_introspector.rb
@@ -308,10 +308,12 @@ module RailsAiContext
       # Class name plus method list for every .rb under `dir`, read from the
       # AST. Yields nothing when the directory is absent.
       #
-      # The name comes from the path, not the AST: Zeitwerk requires the two to
-      # agree, and only the path carries the namespace. Reading `class Channel`
-      # out of `application_cable/channel.rb` yields "Channel", which matches
-      # no base-class filter and no name the booted app would report.
+      # The name comes from the constant the source declares, with the path as
+      # the fallback - see DeclaredConstant for which wins when. The path has
+      # to stay in the picture because it is the only thing carrying the
+      # namespace when the source does not: `class Channel` in
+      # `application_cable/channel.rb` matches no base-class filter and no name
+      # the booted app would report.
       def source_classes(dir)
         return [] unless Dir.exist?(dir)
 
@@ -329,17 +331,22 @@ module RailsAiContext
           # Only a class names a mailer or a channel. app/mailers is also where
           # ActionMailer interceptors live, and reporting one of those offers
           # `delivering_email` - a hook - as an email somebody can send.
-          next unless DeclaredConstant.first_declared(source)
+          path_name = path_name_for(path, dir)
+          declared = DeclaredConstant.declared_classes(source)
+          next unless DeclaredConstant.own_class?(declared, path_name)
 
           walked = SourceIntrospector.walk_source(source, { methods: Listeners::MethodsListener })
-          [ DeclaredConstant.resolve(source, constant_name_for(path, dir)), walked[:methods] || [] ]
+          [ DeclaredConstant.name_for(declared, path_name), walked[:methods] || [] ]
         rescue StandardError, ScriptError => e
           $stderr.puts "[rails-ai-context] source_classes failed for #{path}: #{e.message}" if ENV["DEBUG"]
           nil
         end
       end
 
-      def constant_name_for(path, dir)
+      # The candidate a path camelizes to. Not the constant when the app
+      # registers an inflection for one of its segments, which is why the
+      # source gets the first word.
+      def path_name_for(path, dir)
         path.sub("#{dir}/", "").sub(/\.rb\z/, "").camelize
       end
 

--- a/lib/rails_ai_context/introspectors/job_introspector.rb
+++ b/lib/rails_ai_context/introspectors/job_introspector.rb
@@ -328,15 +328,18 @@ module RailsAiContext
           source = RailsAiContext::SafeFile.read(path)
           next unless source
 
-          # Only a class names a mailer or a channel. app/mailers is also where
-          # ActionMailer interceptors live, and reporting one of those offers
-          # `delivering_email` - a hook - as an email somebody can send.
+          # Only a class that inherits something names a mailer or a channel.
+          # app/mailers is also where ActionMailer interceptors live, written
+          # as a module or as a bare class, and reporting one of those offers
+          # `delivering_email` - a hook the framework calls - as an email
+          # somebody can send.
           path_name = path_name_for(path, dir)
-          declared = DeclaredConstant.declared_classes(source)
-          next unless DeclaredConstant.own_class?(declared, path_name)
+          declarations = DeclaredConstant.declarations(source)
+          subclasses = declarations.select { |d| d[:superclass] }.map { |d| d[:name] }
+          next unless DeclaredConstant.own_class?(subclasses, path_name)
 
           walked = SourceIntrospector.walk_source(source, { methods: Listeners::MethodsListener })
-          [ DeclaredConstant.name_for(declared, path_name), walked[:methods] || [] ]
+          [ DeclaredConstant.name_for(declarations.map { |d| d[:name] }, path_name), walked[:methods] || [] ]
         rescue StandardError, ScriptError => e
           $stderr.puts "[rails-ai-context] source_classes failed for #{path}: #{e.message}" if ENV["DEBUG"]
           nil

--- a/lib/rails_ai_context/introspectors/job_introspector.rb
+++ b/lib/rails_ai_context/introspectors/job_introspector.rb
@@ -323,8 +323,16 @@ module RailsAiContext
           # the path would invent a `Concerns::` namespace that never exists.
           next if path.sub("#{dir}/", "").start_with?("concerns/")
 
-          walked = SourceIntrospector.walk(path, { methods: Listeners::MethodsListener })
-          [ constant_name_for(path, dir), walked[:methods] || [] ]
+          source = RailsAiContext::SafeFile.read(path)
+          next unless source
+
+          # Only a class names a mailer or a channel. app/mailers is also where
+          # ActionMailer interceptors live, and reporting one of those offers
+          # `delivering_email` - a hook - as an email somebody can send.
+          next unless DeclaredConstant.first_declared(source)
+
+          walked = SourceIntrospector.walk_source(source, { methods: Listeners::MethodsListener })
+          [ DeclaredConstant.resolve(source, constant_name_for(path, dir)), walked[:methods] || [] ]
         rescue StandardError, ScriptError => e
           $stderr.puts "[rails-ai-context] source_classes failed for #{path}: #{e.message}" if ENV["DEBUG"]
           nil

--- a/lib/rails_ai_context/introspectors/job_introspector.rb
+++ b/lib/rails_ai_context/introspectors/job_introspector.rb
@@ -346,6 +346,10 @@ module RailsAiContext
           # see MAILER_FRAMEWORK_HOOKS - because a mailer's actions are as
           # often written as modules mixed into one class as they are methods
           # on it. Reading the file is only about naming it.
+          #
+          # The methods are the file's, not one class's, which is what lets a
+          # mixin's actions count. The cost: a file declaring both a mailer and
+          # an interceptor is read as one, and the hook drops both.
           path_name = path_name_for(path, dir)
           walked = SourceIntrospector.walk_source(source, { methods: Listeners::MethodsListener })
           [ DeclaredConstant.resolve(source, path_name), walked[:methods] || [] ]

--- a/lib/rails_ai_context/introspectors/job_introspector.rb
+++ b/lib/rails_ai_context/introspectors/job_introspector.rb
@@ -334,12 +334,10 @@ module RailsAiContext
           # `delivering_email` - a hook the framework calls - as an email
           # somebody can send.
           path_name = path_name_for(path, dir)
-          declarations = DeclaredConstant.declarations(source)
-          subclasses = declarations.select { |d| d[:superclass] }.map { |d| d[:name] }
-          next unless DeclaredConstant.own_class?(subclasses, path_name)
+          next unless DeclaredConstant.own_subclass?(source, path_name)
 
           walked = SourceIntrospector.walk_source(source, { methods: Listeners::MethodsListener })
-          [ DeclaredConstant.name_for(declarations.map { |d| d[:name] }, path_name), walked[:methods] || [] ]
+          [ DeclaredConstant.resolve(source, path_name), walked[:methods] || [] ]
         rescue StandardError, ScriptError => e
           $stderr.puts "[rails-ai-context] source_classes failed for #{path}: #{e.message}" if ENV["DEBUG"]
           nil

--- a/lib/rails_ai_context/introspectors/migration_replay.rb
+++ b/lib/rails_ai_context/introspectors/migration_replay.rb
@@ -116,7 +116,13 @@ module RailsAiContext
       # A replayed create_table implies its id column the way a dumped one
       # does; leaving it out gave the same app two answers depending on which
       # file it committed.
+      # A table the replay cannot name is a table it cannot report. Canvas
+      # calls `create_table table_name do |t|` with a local computed at run
+      # time, and keeping the entry put a nil key in the schema that took a
+      # whole context run down the moment a serializer sorted the names.
       def seed_table(tables, table, options, pk_type)
+        return if table.nil? || table.to_s.empty?
+
         tables[table] ||= {
           columns: implicit_pk_columns(options, pk_type),
           indexes: [],

--- a/lib/rails_ai_context/introspectors/migration_replay.rb
+++ b/lib/rails_ai_context/introspectors/migration_replay.rb
@@ -32,12 +32,7 @@ module RailsAiContext
         })
 
         current_table = nil
-        # parse_string returns nil for an oversize source, and a migration can
-        # sit between max_file_size and max_schema_file_size.
-        parsed = AstCache.parse_string(content)
-        return unless parsed
-
-        root = parsed.value
+        root = AstCache.parse_string(content).value
 
         # A `def down` says what to undo, not what the schema holds. Replaying
         # it alongside `up` cancels the migration out: the ordinary
@@ -87,9 +82,15 @@ module RailsAiContext
         end
       end
 
-      # Line ranges of every `def down` / `def self.down` in the file.
-      # Every way a migration spells "this part only runs on the way down":
-      # `def down`, `reversible { |dir| dir.down { ... } }`, and `revert`.
+      # Line ranges of the parts that only run on the way down: `def down`,
+      # `reversible { |dir| dir.down { ... } }`, and a `revert` block.
+      #
+      # `revert` is skipped rather than inverted. Inverting it properly means
+      # running each operation backwards, and the failure modes are not
+      # symmetric: skipping under-reports a table that reverting a drop would
+      # restore, while guessing over-reports one the app does not have. This
+      # gem would rather omit than invent. `revert SomeMigration`, the
+      # argument form, is not seen at all.
       def find_down_bodies(node, ranges)
         case node
         when Prism::DefNode

--- a/lib/rails_ai_context/introspectors/migration_replay.rb
+++ b/lib/rails_ai_context/introspectors/migration_replay.rb
@@ -40,14 +40,17 @@ module RailsAiContext
         # reverse pair invented one it dropped.
         down_ranges = []
         find_down_bodies(root, down_ranges)
-        entries = (ast_data[:migration] + ast_data[:schema])
+        all_entries = (ast_data[:migration] + ast_data[:schema])
           .reject { |r| down_ranges.any? { |range| range.cover?(r[:location]) } }
-        all_entries = entries.sort_by { |r| r[:location] }
+          .sort_by { |r| r[:location] }
 
         # t.timestamps has no column-name argument, so SchemaDslListener skips
-        # it; a direct walk finds the call sites.
+        # it; a direct walk finds the call sites. The walk sees the whole file,
+        # so a down body's timestamps would be attributed to the last table
+        # created on the way up - the same filter has to apply here.
         timestamps_lines = Set.new
         find_timestamps_calls(root, timestamps_lines)
+        timestamps_lines.delete_if { |line| down_ranges.any? { |range| range.cover?(line) } }
 
         all_entries.each do |entry|
           if entry.key?(:action)
@@ -80,9 +83,16 @@ module RailsAiContext
       end
 
       # Line ranges of every `def down` / `def self.down` in the file.
+      # Every way a migration spells "this part only runs on the way down":
+      # `def down`, `reversible { |dir| dir.down { ... } }`, and `revert`.
       def find_down_bodies(node, ranges)
-        if node.is_a?(Prism::DefNode) && node.name == :down
-          ranges << (node.location.start_line..node.location.end_line)
+        case node
+        when Prism::DefNode
+          ranges << (node.location.start_line..node.location.end_line) if node.name == :down
+        when Prism::CallNode
+          if %i[down revert].include?(node.name) && node.block
+            ranges << (node.location.start_line..node.location.end_line)
+          end
         end
         node.child_nodes.compact.each { |child| find_down_bodies(child, ranges) }
       end

--- a/lib/rails_ai_context/introspectors/migration_replay.rb
+++ b/lib/rails_ai_context/introspectors/migration_replay.rb
@@ -32,7 +32,12 @@ module RailsAiContext
         })
 
         current_table = nil
-        root = AstCache.parse_string(content).value
+        # parse_string returns nil for an oversize source, and a migration can
+        # sit between max_file_size and max_schema_file_size.
+        parsed = AstCache.parse_string(content)
+        return unless parsed
+
+        root = parsed.value
 
         # A `def down` says what to undo, not what the schema holds. Replaying
         # it alongside `up` cancels the migration out: the ordinary
@@ -115,10 +120,9 @@ module RailsAiContext
 
       # A replayed create_table implies its id column the way a dumped one
       # does; leaving it out gave the same app two answers depending on which
-      # file it committed.
-      # A table the replay cannot name is a table it cannot report. Canvas
-      # calls `create_table table_name do |t|` with a local computed at run
-      # time, and keeping the entry put a nil key in the schema that took a
+      # file it committed. A table the replay cannot name it cannot report -
+      # Canvas calls `create_table table_name do |t|` with a local computed at
+      # run time, and keeping the entry put a nil key in the schema that took a
       # whole context run down the moment a serializer sorted the names.
       def seed_table(tables, table, options, pk_type)
         return if table.nil? || table.to_s.empty?

--- a/lib/rails_ai_context/introspectors/migration_replay.rb
+++ b/lib/rails_ai_context/introspectors/migration_replay.rb
@@ -32,12 +32,22 @@ module RailsAiContext
         })
 
         current_table = nil
-        all_entries = (ast_data[:migration] + ast_data[:schema]).sort_by { |r| r[:location] }
+        root = AstCache.parse_string(content).value
+
+        # A `def down` says what to undo, not what the schema holds. Replaying
+        # it alongside `up` cancels the migration out: the ordinary
+        # up-creates/down-drops pair erased a table the app really has, and the
+        # reverse pair invented one it dropped.
+        down_ranges = []
+        find_down_bodies(root, down_ranges)
+        entries = (ast_data[:migration] + ast_data[:schema])
+          .reject { |r| down_ranges.any? { |range| range.cover?(r[:location]) } }
+        all_entries = entries.sort_by { |r| r[:location] }
 
         # t.timestamps has no column-name argument, so SchemaDslListener skips
         # it; a direct walk finds the call sites.
         timestamps_lines = Set.new
-        find_timestamps_calls(AstCache.parse_string(content).value, timestamps_lines)
+        find_timestamps_calls(root, timestamps_lines)
 
         all_entries.each do |entry|
           if entry.key?(:action)
@@ -67,6 +77,14 @@ module RailsAiContext
             tables[table_for_line][:columns].concat(SchemaConventions.timestamps_columns)
           end
         end
+      end
+
+      # Line ranges of every `def down` / `def self.down` in the file.
+      def find_down_bodies(node, ranges)
+        if node.is_a?(Prism::DefNode) && node.name == :down
+          ranges << (node.location.start_line..node.location.end_line)
+        end
+        node.child_nodes.compact.each { |child| find_down_bodies(child, ranges) }
       end
 
       def find_timestamps_calls(node, lines)

--- a/lib/rails_ai_context/introspectors/model_introspector.rb
+++ b/lib/rails_ai_context/introspectors/model_introspector.rb
@@ -613,7 +613,11 @@ module RailsAiContext
         data = SourceIntrospector.call(path)
         {
           confidence: Confidence::STATIC,
-          table_name: class_name.demodulize.underscore.pluralize,
+          # Rails derives the table through its own inflector, and the file's
+          # name already carries that inflection - Zeitwerk resolved the
+          # constant from it. Underscoring the constant instead turns
+          # OAuthClientConfig into o_auth_client_configs, a table no app has.
+          table_name: File.basename(path, ".rb").pluralize,
           associations: data[:associations],
           validations: data[:validations],
           scopes: data[:scopes],

--- a/lib/rails_ai_context/introspectors/model_introspector.rb
+++ b/lib/rails_ai_context/introspectors/model_introspector.rb
@@ -63,12 +63,9 @@ module RailsAiContext
         RailsAiContext::PathResolver.model_dirs(app.root).each_with_object({}) do |models_dir, result|
           Dir.glob(File.join(models_dir, "**", "*.rb")).sort.each do |path|
             relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
-            # `concerns/` is the directory Rails autoloads, but an app may nest
-            # one anywhere - OpenProject has app/models/queries/operators/
-            # concerns - and a mixin there is not a model of the app.
-            next if relative == "application_record" || relative.split("/").include?("concerns")
+            next if relative == "application_record" || mixin_path?(relative, path)
 
-            class_name = relative.camelize
+            class_name = declared_model_name(path, relative.camelize)
             next if result.key?(class_name)
             next if config.excluded_models.include?(class_name)
 
@@ -84,6 +81,27 @@ module RailsAiContext
       end
 
       private
+
+      # Zeitwerk resolves a path through the app's own inflector, which the
+      # static tier never loads, so camelizing invents `Activitypub::` for an
+      # app that declares `ActivityPub::`.
+      def declared_model_name(path, path_name)
+        source = RailsAiContext::SafeFile.read(path, max_size: RailsAiContext.configuration.max_file_size)
+        DeclaredConstant.resolve(source, path_name)
+      end
+
+      # `concerns/` under app/models is the Zeitwerk root for mixins: it does
+      # not namespace its files, so the path is not their name. A nested
+      # concerns/ is an ordinary namespace - OpenProject fills one with mixins,
+      # but a class declared there is a model like any other.
+      def mixin_path?(relative, path)
+        segments = relative.split("/")
+        return false unless segments.include?("concerns")
+        return true if segments.first == "concerns"
+
+        source = RailsAiContext::SafeFile.read(path, max_size: RailsAiContext.configuration.max_file_size)
+        !DeclaredConstant.declares_class?(source)
+      end
 
       def eager_load_models!
         return if Rails.application.config.eager_load
@@ -154,6 +172,7 @@ module RailsAiContext
 
         details = {
           table_name:       model.table_name,
+          file:             relative_to_root(model_source_path(model)),
           # Reflection-based (runtime, most accurate for these)
           associations:     extract_associations(model),
           validations:      extract_validations(model),
@@ -513,10 +532,19 @@ module RailsAiContext
 
       # ── Helpers ────────────────────────────────────────────────────
 
+      # Ruby knows where the class was defined, and the name does not: a model
+      # in a pack or engine does not live under app/models, and an inflected
+      # namespace does not underscore back to its own directory. The
+      # containment check keeps a gem-defined constant from being reported as
+      # the app's own file.
       def model_source_path(model)
         root = app.root.to_s
-        underscored = model.name.underscore
-        File.join(root, "app", "models", "#{underscored}.rb")
+        located = Object.const_source_location(model.name)&.first
+        return located if located && File.expand_path(located).start_with?("#{File.expand_path(root)}/")
+
+        File.join(root, "app", "models", "#{model.name.underscore}.rb")
+      rescue NameError, TypeError
+        File.join(root, "app", "models", "#{model.name.underscore}.rb")
       end
 
       DEVISE_CLASS_METHOD_PATTERNS = %w[
@@ -585,8 +613,16 @@ module RailsAiContext
           callbacks: group_callbacks_by_type(data[:callbacks]),
           concerns: static_concerns(data[:mixins]),
           macros: data[:macros],
-          methods: ActionResolver.own_methods(data[:methods], class_name)
+          methods: ActionResolver.own_methods(data[:methods], class_name),
+          file: relative_to_root(path)
         }
+      end
+
+      # Six tools turn a model name back into app/models/<underscored>.rb,
+      # which is wrong for a model in a pack or engine and wrong wherever the
+      # app registers an inflection. The path travels with the model instead.
+      def relative_to_root(path)
+        path.to_s.sub(%r{\A#{Regexp.escape(app.root.to_s)}/}, "")
       end
 
       # This sees the model file alone, where the booted tier also walks what
@@ -603,10 +639,7 @@ module RailsAiContext
         RailsAiContext::PathResolver.model_dirs(app.root).each_with_object({}) do |models_dir, result|
           Dir.glob(File.join(models_dir, "**", "*.rb")).sort.each do |path|
             relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
-            # `concerns/` is the directory Rails autoloads, but an app may nest
-            # one anywhere - OpenProject has app/models/queries/operators/
-            # concerns - and a mixin there is not a model of the app.
-            next if relative == "application_record" || relative.split("/").include?("concerns")
+            next if relative == "application_record" || mixin_path?(relative, path)
 
             class_name = relative.camelize
             next if result.key?(class_name)

--- a/lib/rails_ai_context/introspectors/model_introspector.rb
+++ b/lib/rails_ai_context/introspectors/model_introspector.rb
@@ -63,18 +63,25 @@ module RailsAiContext
         RailsAiContext::PathResolver.model_dirs(app.root).each_with_object({}) do |models_dir, result|
           Dir.glob(File.join(models_dir, "**", "*.rb")).sort.each do |path|
             relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
-            next if relative == "application_record" || mixin_path?(relative, path)
-
-            class_name = declared_model_name(path, relative.camelize)
-            next if result.key?(class_name)
-            next if config.excluded_models.include?(class_name)
+            next if relative == "application_record"
 
             begin
+              # SafeFile.read answers nil for both "too big" and "cannot read
+              # it", and those are different answers: a model the process
+              # cannot stat is an error entry rather than one that quietly is
+              # not there. The count is an answer too.
               next if File.size(path) > RailsAiContext.configuration.max_file_size
+
+              source = model_source(path)
+              next if source.nil? || mixin_path?(relative, source) || abstract_class?(source)
+
+              class_name = declared_model_name(source, relative.camelize)
+              next if result.key?(class_name)
+              next if config.excluded_models.include?(class_name)
 
               result[class_name] = static_model_details(path, class_name)
             rescue => e
-              result[class_name] = { error: e.message }
+              result[relative.camelize] = { error: e.message }
             end
           end
         end
@@ -85,21 +92,27 @@ module RailsAiContext
       # Zeitwerk resolves a path through the app's own inflector, which the
       # static tier never loads, so camelizing invents `Activitypub::` for an
       # app that declares `ActivityPub::`.
-      def declared_model_name(path, path_name)
-        source = RailsAiContext::SafeFile.read(path, max_size: RailsAiContext.configuration.max_file_size)
+      def declared_model_name(source, path_name)
         DeclaredConstant.resolve(source, path_name)
+      end
+
+      # The booted tier rejects `abstract_class?`, and a namespaced base class -
+      # GitLab has Ci::ApplicationRecord, PackageMetadata::ApplicationRecord and
+      # SecApplicationRecord - is one. Excluding only the root
+      # application_record by path gave the same app two model counts.
+      def abstract_class?(source)
+        source.match?(/^[^\S\n]*self\.abstract_class\s*=\s*true/)
       end
 
       # `concerns/` under app/models is the Zeitwerk root for mixins: it does
       # not namespace its files, so the path is not their name. A nested
       # concerns/ is an ordinary namespace - OpenProject fills one with mixins,
       # but a class declared there is a model like any other.
-      def mixin_path?(relative, path)
+      def mixin_path?(relative, source)
         segments = relative.split("/")
         return false unless segments.include?("concerns")
         return true if segments.first == "concerns"
 
-        source = RailsAiContext::SafeFile.read(path, max_size: RailsAiContext.configuration.max_file_size)
         !DeclaredConstant.declares_class?(source)
       end
 
@@ -618,9 +631,10 @@ module RailsAiContext
         }
       end
 
-      # Six tools turn a model name back into app/models/<underscored>.rb,
-      # which is wrong for a model in a pack or engine and wrong wherever the
-      # app registers an inflection. The path travels with the model instead.
+      # Consumers used to turn a model name back into
+      # app/models/<underscored>.rb, which is wrong for a model in a pack or an
+      # engine and wrong wherever the app registers an inflection. The path
+      # travels with the model instead.
       def relative_to_root(path)
         path.to_s.sub(%r{\A#{Regexp.escape(app.root.to_s)}/}, "")
       end
@@ -639,35 +653,36 @@ module RailsAiContext
         RailsAiContext::PathResolver.model_dirs(app.root).each_with_object({}) do |models_dir, result|
           Dir.glob(File.join(models_dir, "**", "*.rb")).sort.each do |path|
             relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
-            next if relative == "application_record" || mixin_path?(relative, path)
-
-            class_name = relative.camelize
-            next if result.key?(class_name)
-            next if config.excluded_models.include?(class_name)
+            next if relative == "application_record"
 
             begin
               next if File.size(path) > RailsAiContext.configuration.max_file_size
 
-              result[class_name] = if mongoid_document_source?(path)
-                mongoid_model_details(path)
+              source = model_source(path)
+              next if source.nil? || mixin_path?(relative, source) || abstract_class?(source)
+
+              class_name = declared_model_name(source, relative.camelize)
+              next if result.key?(class_name)
+              next if config.excluded_models.include?(class_name)
+
+              result[class_name] = if source.include?("Mongoid::Document")
+                mongoid_model_details(path).merge(file: relative_to_root(path))
               else
                 static_model_details(path, class_name)
               end
             rescue => e
-              result[class_name] = { error: e.message }
+              result[relative.camelize] = { error: e.message }
             end
           end
         end
       end
 
-      # A hybrid app (ActiveRecord primary, Mongoid gem present) mixes
-      # AR-backed models in with actual Mongoid documents under the same
-      # model directories. Only files that really `include Mongoid::Document`
-      # get the Mongoid listener stack; everything else falls back to the
-      # regular AR-style static pass so it still gets a table_name.
-      def mongoid_document_source?(path)
-        content = RailsAiContext::SafeFile.read(path)
-        !!content&.include?("Mongoid::Document")
+      # The file's source, or nil when it is unreadable or over the size cap.
+      # One read feeds the name, the mixin test and - in a hybrid app, where
+      # AR-backed models sit under the same directories as real documents -
+      # the Mongoid::Document test that picks the listener stack.
+      def model_source(path)
+        RailsAiContext::SafeFile.read(path, max_size: RailsAiContext.configuration.max_file_size)
       end
 
       def mongoid_model_details(path)

--- a/lib/rails_ai_context/introspectors/model_introspector.rb
+++ b/lib/rails_ai_context/introspectors/model_introspector.rb
@@ -63,7 +63,10 @@ module RailsAiContext
         RailsAiContext::PathResolver.model_dirs(app.root).each_with_object({}) do |models_dir, result|
           Dir.glob(File.join(models_dir, "**", "*.rb")).sort.each do |path|
             relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
-            next if relative == "application_record" || relative.start_with?("concerns/")
+            # `concerns/` is the directory Rails autoloads, but an app may nest
+            # one anywhere - OpenProject has app/models/queries/operators/
+            # concerns - and a mixin there is not a model of the app.
+            next if relative == "application_record" || relative.split("/").include?("concerns")
 
             class_name = relative.camelize
             next if result.key?(class_name)
@@ -600,7 +603,10 @@ module RailsAiContext
         RailsAiContext::PathResolver.model_dirs(app.root).each_with_object({}) do |models_dir, result|
           Dir.glob(File.join(models_dir, "**", "*.rb")).sort.each do |path|
             relative = path.sub("#{models_dir}/", "").sub(/\.rb\z/, "")
-            next if relative == "application_record" || relative.start_with?("concerns/")
+            # `concerns/` is the directory Rails autoloads, but an app may nest
+            # one anywhere - OpenProject has app/models/queries/operators/
+            # concerns - and a mixin there is not a model of the app.
+            next if relative == "application_record" || relative.split("/").include?("concerns")
 
             class_name = relative.camelize
             next if result.key?(class_name)

--- a/lib/rails_ai_context/legacy_cleanup.rb
+++ b/lib/rails_ai_context/legacy_cleanup.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# The install path loads this file without the entry file - before Rails,
+# before Zeitwerk - so it requires its own stdlib. Set is not autoloaded on
+# Ruby 3.1, where `[...].to_set` raised NoMethodError.
+require "set"
+
 module RailsAiContext
   # One-time cleanup for files that were removed in a breaking release.
   # Handles v5.0.0's removal of design-system UI pattern rules and

--- a/lib/rails_ai_context/payload.rb
+++ b/lib/rails_ai_context/payload.rb
@@ -64,6 +64,19 @@ module RailsAiContext
       carried || "app/models/#{name.to_s.underscore}.rb"
     end
 
+    # The model a file declares, as [name, data].
+    #
+    # Camelizing the path is the wrong way back: `oauth_client_config.rb` is
+    # `OAuthClientConfig` wherever the app registers the acronym, and a checker
+    # walking the models directory has only the path to start from.
+    def model_for_file(ctx, file)
+      models = ctx.is_a?(Hash) ? ctx[:models] : nil
+      return nil unless models.is_a?(Hash) && !models[:error]
+
+      wanted = file.to_s
+      models.find { |_, data| data.is_a?(Hash) && data[:file].to_s == wanted }
+    end
+
     # The controller Rails routes under a path, as [name, data].
     #
     # A view directory names the route key, not the constant: camelizing

--- a/lib/rails_ai_context/payload.rb
+++ b/lib/rails_ai_context/payload.rb
@@ -43,5 +43,23 @@ module RailsAiContext
     LISTS.each do |name, (section_key, key)|
       define_singleton_method(name) { |ctx| list(ctx, section_key, key) }
     end
+
+    # The file a controller was read from. Reconstructing it from the class
+    # name breaks wherever the app registers an inflection, so the
+    # introspector carries it - and one reader here means a rename of the key
+    # fails loudly rather than sending every consumer back to guessing.
+    def controller_file(ctx, name)
+      section(ctx, :controllers)&.dig(:controllers, name.to_s)&.dig(:file)
+    end
+
+    # The key Rails routes a controller by: its path, minus the controllers
+    # root and the _controller suffix. Packs and in-repo engines put that root
+    # somewhere other than the start of the path.
+    def controller_route_key(ctx, name)
+      file = controller_file(ctx, name)
+      return name.to_s.underscore.delete_suffix("_controller") unless file
+
+      file.to_s.sub(%r{\A.*app/controllers/}, "").sub(/_controller\.rb\z/, "")
+    end
   end
 end

--- a/lib/rails_ai_context/payload.rb
+++ b/lib/rails_ai_context/payload.rb
@@ -54,11 +54,14 @@ module RailsAiContext
 
     # The file a model was read from. `models` is a bare Hash of name =>
     # details, not a section with its own wrapper.
+    #
+    # The derivation is the fallback for a model reflection found and no file
+    # was recorded for, and it lives here so there is one of it.
     def model_file(ctx, name)
       models = ctx.is_a?(Hash) ? ctx[:models] : nil
-      return nil unless models.is_a?(Hash) && !models[:error]
+      carried = models.dig(name.to_s, :file) if models.is_a?(Hash) && !models[:error]
 
-      models.dig(name.to_s, :file)
+      carried || "app/models/#{name.to_s.underscore}.rb"
     end
 
     # The controller Rails routes under a path, as [name, data].
@@ -66,11 +69,22 @@ module RailsAiContext
     # A view directory names the route key, not the constant: camelizing
     # `app/views/activitypub/` back gives `Activitypub`, and the controllers
     # hash is keyed by what the app declares.
+    # Indexed, not scanned: the only caller runs per view file, and deriving
+    # every controller's key again for each one is O(views x controllers).
     def controller_for_route_key(ctx, key)
       controllers = section(ctx, :controllers)&.dig(:controllers)
       return nil unless controllers.is_a?(Hash)
 
-      controllers.find { |name, _| controller_route_key(ctx, name) == key.to_s }
+      # One slot, holding the hash it indexed: keeping the reference is what
+      # makes identity safe to compare on, and it drops as soon as the next
+      # context arrives.
+      unless @indexed_controllers.equal?(controllers)
+        @route_key_index = controllers.to_h { |name, _| [ controller_route_key(ctx, name), name ] }
+        @indexed_controllers = controllers
+      end
+
+      name = @route_key_index[key.to_s]
+      name ? [ name, controllers[name] ] : nil
     end
 
     # The key Rails routes a controller by: its path, minus the controllers

--- a/lib/rails_ai_context/payload.rb
+++ b/lib/rails_ai_context/payload.rb
@@ -52,6 +52,27 @@ module RailsAiContext
       section(ctx, :controllers)&.dig(:controllers, name.to_s)&.dig(:file)
     end
 
+    # The file a model was read from. `models` is a bare Hash of name =>
+    # details, not a section with its own wrapper.
+    def model_file(ctx, name)
+      models = ctx.is_a?(Hash) ? ctx[:models] : nil
+      return nil unless models.is_a?(Hash) && !models[:error]
+
+      models.dig(name.to_s, :file)
+    end
+
+    # The controller Rails routes under a path, as [name, data].
+    #
+    # A view directory names the route key, not the constant: camelizing
+    # `app/views/activitypub/` back gives `Activitypub`, and the controllers
+    # hash is keyed by what the app declares.
+    def controller_for_route_key(ctx, key)
+      controllers = section(ctx, :controllers)&.dig(:controllers)
+      return nil unless controllers.is_a?(Hash)
+
+      controllers.find { |name, _| controller_route_key(ctx, name) == key.to_s }
+    end
+
     # The key Rails routes a controller by: its path, minus the controllers
     # root and the _controller suffix. Packs and in-repo engines put that root
     # somewhere other than the start of the path.
@@ -59,7 +80,7 @@ module RailsAiContext
       file = controller_file(ctx, name)
       return name.to_s.underscore.delete_suffix("_controller") unless file
 
-      file.to_s.sub(%r{\A.*app/controllers/}, "").sub(/_controller\.rb\z/, "")
+      file.to_s.sub(%r{\A.*app/controllers/}, "").sub(/(?:_controller)?\.rb\z/, "")
     end
   end
 end

--- a/lib/rails_ai_context/serializers/context_file_serializer.rb
+++ b/lib/rails_ai_context/serializers/context_file_serializer.rb
@@ -52,7 +52,11 @@ module RailsAiContext
         when Array            then format.empty? ? [] : format | [ :json ]
         else Array(format)
         end
-        output_dir = RailsAiContext.configuration.output_dir_for(Rails.application)
+        # `default_app` is the tier-aware handle: the booted application, or the
+        # filesystem-rooted stand-in. Reaching for `Rails.application` directly
+        # raises NameError under `--no-boot`, where Rails is never loaded at all
+        # - a different path from a boot that started and failed.
+        output_dir = RailsAiContext.configuration.output_dir_for(RailsAiContext.default_app)
         generate_root = RailsAiContext.configuration.generate_root_files
         written = []
         skipped = []

--- a/lib/rails_ai_context/serializers/context_file_serializer.rb
+++ b/lib/rails_ai_context/serializers/context_file_serializer.rb
@@ -42,7 +42,16 @@ module RailsAiContext
       # Write context files, skipping unchanged ones.
       # @return [Hash] { written: [paths], skipped: [paths] }
       def call
-        formats = format == :all ? ALL_FORMATS : Array(format)
+        # `.ai-context.json` is the machine artifact, not an AI tool, so no
+        # install menu can offer it. A recorded tool selection arrives here as
+        # a list and used to switch the file off for good, while the generator
+        # went on gitignoring it. A single explicit format is a request for one
+        # file and stays one.
+        formats = case format
+        when :all   then ALL_FORMATS
+        when Array  then format | [ :json ]
+        else Array(format)
+        end
         output_dir = RailsAiContext.configuration.output_dir_for(Rails.application)
         generate_root = RailsAiContext.configuration.generate_root_files
         written = []

--- a/lib/rails_ai_context/serializers/context_file_serializer.rb
+++ b/lib/rails_ai_context/serializers/context_file_serializer.rb
@@ -48,8 +48,8 @@ module RailsAiContext
         # went on gitignoring it. A single explicit format is a request for one
         # file and stays one.
         formats = case format
-        when :all   then ALL_FORMATS
-        when Array  then format | [ :json ]
+        when :all             then ALL_FORMATS
+        when Array            then format.empty? ? [] : format | [ :json ]
         else Array(format)
         end
         output_dir = RailsAiContext.configuration.output_dir_for(Rails.application)

--- a/lib/rails_ai_context/serializers/stack_overview_helper.rb
+++ b/lib/rails_ai_context/serializers/stack_overview_helper.rb
@@ -198,11 +198,22 @@ module RailsAiContext
         []
       end
 
-      # Extract before_action names from ApplicationController source.
+      # The filters ApplicationController runs on every request.
+      #
+      # "Global" is the claim the generated files make, so two shapes are not
+      # it: `skip_before_action`, which says the opposite, and a filter carrying
+      # only:/except:/if:/unless:, which runs on some requests.
       def detect_before_actions(root = project_root)
         app_ctrl_file = File.join(root, "app", "controllers", "application_controller.rb")
         return [] unless File.exist?(app_ctrl_file)
-        File.read(app_ctrl_file).scan(/before_action\s+:([\w!?]+)/).flatten
+
+        File.read(app_ctrl_file).lines.filter_map do |line|
+          match = line.match(/(?<!skip_)\bbefore_action\s+:(?<name>[\w!?]+)(?<rest>.*)/)
+          next unless match
+          next if match[:rest].match?(/\b(only|except|if|unless):/)
+
+          match[:name]
+        end
       rescue => e
         $stderr.puts "[rails-ai-context] Before actions scan skipped: #{e.message}" if ENV["DEBUG"]
         []

--- a/lib/rails_ai_context/tools/analyze_feature.rb
+++ b/lib/rails_ai_context/tools/analyze_feature.rb
@@ -55,14 +55,14 @@ module RailsAiContext
         discover_jobs(root, pattern, lines)
         discover_views(ctx, root, pattern, lines)
         discover_stimulus(ctx, pattern, lines)
-        test_files = discover_tests(root, pattern, lines)
+        test_files, tests_truncated = discover_tests(root, pattern, lines)
         discover_related_models(ctx, matched_models, lines)
         discover_concerns(ctx, matched_models, lines)
         discover_callbacks(ctx, matched_models, lines)
         discover_channels(root, pattern, lines)
         discover_mailers(root, pattern, lines)
         discover_env_dependencies(root, pattern, matched_models, lines)
-        discover_test_gaps(root, pattern, matched_models, ctx, test_files || [], lines)
+        discover_test_gaps(root, pattern, matched_models, ctx, test_files || [], lines, truncated: tests_truncated)
         discover_components(ctx, pattern, lines)
 
         # For auth-related keywords, also discover auth gems
@@ -370,7 +370,7 @@ module RailsAiContext
             end
           end
           found.uniq!
-          return found if found.empty?
+          return [ found, truncated ] if found.empty?
 
           header = "## Tests (#{found.size}#{truncated ? " - first #{MAX_SCAN_FILES} per glob scanned" : ""})"
           lines << header
@@ -383,16 +383,26 @@ module RailsAiContext
             lines << "- `#{relative}` (#{count_phrase(test_count, "test")})"
           end
           lines << ""
-          found
+          [ found, truncated ]
         rescue => e
           $stderr.puts "[rails-ai-context] discover_tests failed: #{e.message}" if ENV["DEBUG"]
-          []
+          [ [], false ]
         end
 
         # --- Test coverage gaps ---
-        def discover_test_gaps(root, pattern, matched_models, ctx, test_files, lines)
+        def discover_test_gaps(root, pattern, matched_models, ctx, test_files, lines, truncated: false)
+          # A gap is a claim that something has no test, and a scan that stopped
+          # at MAX_SCAN_FILES cannot make it: Discourse has 1,672 spec files, so
+          # the first 500 missed the ones that cover the feature and every
+          # controller was reported as untested.
+          return if truncated
+
           gaps = []
-          test_basenames = test_files.map { |f| File.basename(f, ".rb") }
+          # Paths, not basenames: a namespaced name underscores to admin/badges,
+          # which no basename can contain, so every namespaced controller was
+          # reported as having no test - Discourse's Admin::BadgesController
+          # against spec/requests/admin/badges_controller_spec.rb.
+          test_basenames = test_files.map { |f| f.to_s.sub(/\.rb\z/, "").sub("#{root}/", "") }
 
           # Check models
           matched_models&.each do |name, _data|
@@ -406,7 +416,7 @@ module RailsAiContext
           controllers = ctx[:controllers]&.dig(:controllers) || {}
           controllers.each_key do |ctrl_name|
             next unless feature_word_match?(ctrl_name, pattern)
-            snake = ctrl_name.underscore.delete_suffix("_controller")
+            snake = RailsAiContext::Payload.controller_route_key(ctx, ctrl_name)
             unless test_basenames.any? { |t| t.include?(snake) }
               gaps << "Controller `#{ctrl_name}` - no test file found"
             end

--- a/lib/rails_ai_context/tools/generate_test.rb
+++ b/lib/rails_ai_context/tools/generate_test.rb
@@ -403,7 +403,7 @@ module RailsAiContext
           ctrl_name = ctrl_name.strip
           # Normalize: "posts" → "PostsController", "PostsController" stays
           ctrl_class = ctrl_name.end_with?("Controller") ? ctrl_name : "#{ctrl_name.camelize}Controller"
-          snake = ctrl_class.underscore.delete_suffix("_controller")
+          snake = RailsAiContext::Payload.controller_route_key(cached_context, ctrl_class)
 
           routes = cached_context[:routes] || {}
           by_ctrl = routes[:by_controller] || {}

--- a/lib/rails_ai_context/tools/generate_test.rb
+++ b/lib/rails_ai_context/tools/generate_test.rb
@@ -123,8 +123,16 @@ module RailsAiContext
           end
         end
 
+        # The model's file, minus the models root and the extension.
+        def model_path_stem(name)
+          RailsAiContext::Payload.model_file(cached_context, name)
+            .sub(%r{\A.*app/models/}, "").sub(/\.rb\z/, "")
+        end
+
         def generate_rspec_model(name, data, patterns, tests_data)
-          file_path = "spec/models/#{name.underscore}_spec.rb"
+          # The spec mirrors the model's own path, and underscoring the name
+          # does not reproduce it: OAuthClientConfig is oauth_client_config.rb.
+          file_path = "spec/models/#{model_path_stem(name)}_spec.rb"
           factory = find_factory_name(name, tests_data)
           lines = []
           lines << "# #{file_path}"
@@ -259,9 +267,9 @@ module RailsAiContext
         end
 
         def generate_minitest_model(name, data, _patterns, tests_data)
-          file_path = "test/models/#{name.underscore}_test.rb"
+          file_path = "test/models/#{model_path_stem(name)}_test.rb"
           factory = find_factory_name(name, tests_data)
-          table = data[:table_name] || name.underscore.pluralize
+          table = data[:table_name] || model_path_stem(name).split("/").last.pluralize
           lines = []
           lines << "# #{file_path}"
           lines << ""

--- a/lib/rails_ai_context/tools/get_callbacks.rb
+++ b/lib/rails_ai_context/tools/get_callbacks.rb
@@ -229,7 +229,7 @@ module RailsAiContext
       end
 
       private_class_method def self.extract_callback_source(model_name, method_name)
-        path = rails_app.root.join("app", "models", "#{model_name.underscore}.rb")
+        path = rails_app.root.join(RailsAiContext::Payload.model_file(cached_context, model_name))
         extract_method_source_from_file(path, method_name)
       end
 

--- a/lib/rails_ai_context/tools/get_context.rb
+++ b/lib/rails_ai_context/tools/get_context.rb
@@ -43,21 +43,6 @@ module RailsAiContext
 
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
-        # Rails keys a route by the controller's PATH, not by its class name,
-        # and the two diverge wherever the app registers an inflection:
-        # `ActivityPub::CollectionsController` lives at `activitypub/`. The
-        # introspector carries the file it read, so use that when it is there.
-        def self.route_key_for(controller_name)
-          file = begin
-            cached_context.dig(:controllers, :controllers, controller_name.to_s, :file)
-          rescue StandardError
-            nil
-          end
-          return controller_name.to_s.underscore.delete_suffix("_controller") unless file
-
-          file.to_s.sub(%r{\Aapp/controllers/}, "").sub(/_controller\.rb\z/, "")
-        end
-
       def self.call(controller: nil, action: nil, model: nil, feature: nil, include: nil, server_context: nil)
         base_text = if controller && action
           controller_action_context(controller, action)
@@ -242,7 +227,7 @@ module RailsAiContext
         ctrl_result = GetControllers.call(controller: controller_name)
         lines << ctrl_result.content.first[:text]
 
-        snake = route_key_for(controller_name)
+        snake = RailsAiContext::Payload.controller_route_key(cached_context, controller_name)
 
         # Routes for this controller
         route_result = GetRoutes.call(controller: snake)

--- a/lib/rails_ai_context/tools/get_context.rb
+++ b/lib/rails_ai_context/tools/get_context.rb
@@ -76,7 +76,7 @@ module RailsAiContext
         lines << ctrl_result.content.first[:text]
 
         # Infer model from controller
-        snake = controller_name.to_s.underscore.delete_suffix("_controller")
+        snake = RailsAiContext::Payload.controller_route_key(cached_context, controller_name)
         model_name = snake.split("/").last.singularize.camelize
 
         # Model details

--- a/lib/rails_ai_context/tools/get_context.rb
+++ b/lib/rails_ai_context/tools/get_context.rb
@@ -43,6 +43,21 @@ module RailsAiContext
 
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
+        # Rails keys a route by the controller's PATH, not by its class name,
+        # and the two diverge wherever the app registers an inflection:
+        # `ActivityPub::CollectionsController` lives at `activitypub/`. The
+        # introspector carries the file it read, so use that when it is there.
+        def self.route_key_for(controller_name)
+          file = begin
+            cached_context.dig(:controllers, :controllers, controller_name.to_s, :file)
+          rescue StandardError
+            nil
+          end
+          return controller_name.to_s.underscore.delete_suffix("_controller") unless file
+
+          file.to_s.sub(%r{\Aapp/controllers/}, "").sub(/_controller\.rb\z/, "")
+        end
+
       def self.call(controller: nil, action: nil, model: nil, feature: nil, include: nil, server_context: nil)
         base_text = if controller && action
           controller_action_context(controller, action)
@@ -227,7 +242,7 @@ module RailsAiContext
         ctrl_result = GetControllers.call(controller: controller_name)
         lines << ctrl_result.content.first[:text]
 
-        snake = controller_name.to_s.underscore.delete_suffix("_controller")
+        snake = route_key_for(controller_name)
 
         # Routes for this controller
         route_result = GetRoutes.call(controller: snake)

--- a/lib/rails_ai_context/tools/get_controllers.rb
+++ b/lib/rails_ai_context/tools/get_controllers.rb
@@ -173,6 +173,14 @@ module RailsAiContext
         end
       end
 
+      # The file the introspector read this controller from. Reconstructing it
+      # from the name breaks wherever the app registers an inflection:
+      # `ActivityPub::CollectionsController`.underscore is `activity_pub/...`
+      # and the file is under `activitypub/`.
+      private_class_method def self.controller_file(info)
+        (info || {})[:file]
+      end
+
       private_class_method def self.format_action_source(controller_name, info, action_name)
         actions = info[:actions] || []
         # Case-insensitive action lookup for consistency with other tools
@@ -193,7 +201,8 @@ module RailsAiContext
         end
 
         # Detect skip_before_action declarations in the child controller source
-        source_path = rails_app.root.join("app", "controllers", "#{controller_name.underscore}.rb")
+        source_path = controller_file(info) ? rails_app.root.join(controller_file(info)) :
+          rails_app.root.join("app", "controllers", "#{controller_name.underscore}.rb")
         skipped_filters = detect_skipped_filters(source_path, action_name)
 
         # Include inherited filters from parent controller, excluding skipped ones
@@ -205,7 +214,7 @@ module RailsAiContext
         source_with_lines = extract_method_with_lines(source_path, action_name)
 
         lines = [ "# #{controller_name}##{action_name}", "" ]
-        lines << "**File:** `app/controllers/#{controller_name.underscore}.rb`"
+        lines << "**File:** `#{controller_file(info) || "app/controllers/#{controller_name.underscore}.rb"}`"
 
         if parent_filters.any? || filters.any? || skipped_filters.any?
           lines << "" << "## Applicable Filters"

--- a/lib/rails_ai_context/tools/get_controllers.rb
+++ b/lib/rails_ai_context/tools/get_controllers.rb
@@ -173,14 +173,6 @@ module RailsAiContext
         end
       end
 
-      # The file the introspector read this controller from. Reconstructing it
-      # from the name breaks wherever the app registers an inflection:
-      # `ActivityPub::CollectionsController`.underscore is `activity_pub/...`
-      # and the file is under `activitypub/`.
-      private_class_method def self.controller_file(info)
-        (info || {})[:file]
-      end
-
       private_class_method def self.format_action_source(controller_name, info, action_name)
         actions = info[:actions] || []
         # Case-insensitive action lookup for consistency with other tools
@@ -201,7 +193,8 @@ module RailsAiContext
         end
 
         # Detect skip_before_action declarations in the child controller source
-        source_path = controller_file(info) ? rails_app.root.join(controller_file(info)) :
+        carried = RailsAiContext::Payload.controller_file(cached_context, controller_name)
+        source_path = carried ? rails_app.root.join(carried) :
           rails_app.root.join("app", "controllers", "#{controller_name.underscore}.rb")
         skipped_filters = detect_skipped_filters(source_path, action_name)
 
@@ -214,7 +207,7 @@ module RailsAiContext
         source_with_lines = extract_method_with_lines(source_path, action_name)
 
         lines = [ "# #{controller_name}##{action_name}", "" ]
-        lines << "**File:** `#{controller_file(info) || "app/controllers/#{controller_name.underscore}.rb"}`"
+        lines << "**File:** `#{carried || "app/controllers/#{controller_name.underscore}.rb"}`"
 
         if parent_filters.any? || filters.any? || skipped_filters.any?
           lines << "" << "## Applicable Filters"

--- a/lib/rails_ai_context/tools/get_controllers.rb
+++ b/lib/rails_ai_context/tools/get_controllers.rb
@@ -551,14 +551,17 @@ module RailsAiContext
 
         # Hydrate with schema hints for models referenced in this controller
         if RailsAiContext.configuration.hydration_enabled
-          source_path = rails_app.root.join("app", "controllers", "#{name.underscore}.rb")
+          carried = RailsAiContext::Payload.controller_file(cached_context, name)
+          source_path = carried ? rails_app.root.join(carried) :
+            rails_app.root.join("app", "controllers", "#{name.underscore}.rb")
           hydration = Hydrators::ControllerHydrator.call(source_path.to_s, context: cached_context)
           hydration_text = Hydrators::HydrationFormatter.format(hydration)
           lines << "" << hydration_text unless hydration_text.empty?
         end
 
-        # Cross-reference hints
-        ctrl_path = name.underscore.delete_suffix("_controller")
+        # Cross-reference hints. The route key is the controller's path, which
+        # the class name does not reproduce wherever an inflection is in play.
+        ctrl_path = RailsAiContext::Payload.controller_route_key(cached_context, name)
         model_name = ctrl_path.split("/").last.singularize.camelize
         lines << ""
         lines << "_Next: `rails_get_routes(controller:\"#{ctrl_path}\")` for routes"

--- a/lib/rails_ai_context/tools/get_i18n.rb
+++ b/lib/rails_ai_context/tools/get_i18n.rb
@@ -78,8 +78,9 @@ module RailsAiContext
           untranslated = i18n[:locales_without_translations] || []
           if untranslated.any?
             total = (i18n[:available_locales] || []).size
-            lines << "" << "_#{untranslated.size} of #{total} locales have no translations of their own " \
-                           "and are left out of coverage: #{untranslated.sort.join(', ')}._"
+            lines << "" << "_#{untranslated.size} of #{total} locales translate none of " \
+                           "#{i18n[:default_locale]}'s keys and are left out of coverage: " \
+                           "#{untranslated.sort.join(', ')}._"
           end
 
           fallbacks = i18n[:fallbacks] || {}
@@ -103,6 +104,11 @@ module RailsAiContext
           if coverage
             lines << ""
             lines << "- **Unique keys:** #{coverage[:keys]} (#{coverage[:coverage_pct]}% of #{i18n[:default_locale]})#{coverage_gap(coverage)}"
+          elsif Array(i18n[:locales_without_translations]).include?(locale)
+            # Otherwise the coverage line every other locale carries is simply
+            # missing here, and the reader cannot tell absent from zero.
+            lines << ""
+            lines << "- **Coverage:** none - `#{locale}` translates none of #{i18n[:default_locale]}'s keys."
           end
 
           fallbacks = i18n[:fallbacks] || {}

--- a/lib/rails_ai_context/tools/get_i18n.rb
+++ b/lib/rails_ai_context/tools/get_i18n.rb
@@ -78,8 +78,8 @@ module RailsAiContext
           untranslated = i18n[:locales_without_translations] || []
           if untranslated.any?
             total = (i18n[:available_locales] || []).size
-            lines << "" << "_#{untranslated.size} of #{total} locales translate under 0.1% of " \
-                           "#{i18n[:default_locale]}'s keys and are left out of coverage: " \
+            lines << "" << "_#{untranslated.size} of #{total} locales round to 0.0% against " \
+                           "#{i18n[:default_locale]} and are left out of coverage: " \
                            "#{untranslated.sort.join(', ')}._"
           end
 
@@ -108,7 +108,7 @@ module RailsAiContext
             # Otherwise the coverage line every other locale carries is simply
             # missing here, and the reader cannot tell absent from zero.
             lines << ""
-            lines << "- **Coverage:** `#{locale}` translates under 0.1% of #{i18n[:default_locale]}'s keys."
+            lines << "- **Coverage:** `#{locale}` rounds to 0.0% against #{i18n[:default_locale]}."
           end
 
           fallbacks = i18n[:fallbacks] || {}

--- a/lib/rails_ai_context/tools/get_i18n.rb
+++ b/lib/rails_ai_context/tools/get_i18n.rb
@@ -78,7 +78,7 @@ module RailsAiContext
           untranslated = i18n[:locales_without_translations] || []
           if untranslated.any?
             total = (i18n[:available_locales] || []).size
-            lines << "" << "_#{untranslated.size} of #{total} locales translate none of " \
+            lines << "" << "_#{untranslated.size} of #{total} locales translate under 0.1% of " \
                            "#{i18n[:default_locale]}'s keys and are left out of coverage: " \
                            "#{untranslated.sort.join(', ')}._"
           end
@@ -108,7 +108,7 @@ module RailsAiContext
             # Otherwise the coverage line every other locale carries is simply
             # missing here, and the reader cannot tell absent from zero.
             lines << ""
-            lines << "- **Coverage:** none - `#{locale}` translates none of #{i18n[:default_locale]}'s keys."
+            lines << "- **Coverage:** `#{locale}` translates under 0.1% of #{i18n[:default_locale]}'s keys."
           end
 
           fallbacks = i18n[:fallbacks] || {}

--- a/lib/rails_ai_context/tools/get_i18n.rb
+++ b/lib/rails_ai_context/tools/get_i18n.rb
@@ -72,6 +72,16 @@ module RailsAiContext
             end
           end
 
+          # A language-name table under config/locales makes Rails list a
+          # locale per language. Saying so is what keeps the available count
+          # and the shorter coverage list from reading as a contradiction.
+          untranslated = i18n[:locales_without_translations] || []
+          if untranslated.any?
+            total = (i18n[:available_locales] || []).size
+            lines << "" << "_#{untranslated.size} of #{total} locales have no translations of their own " \
+                           "and are left out of coverage: #{untranslated.sort.join(', ')}._"
+          end
+
           fallbacks = i18n[:fallbacks] || {}
           if fallbacks.any?
             lines << "" << "## Fallbacks"

--- a/lib/rails_ai_context/tools/get_i18n.rb
+++ b/lib/rails_ai_context/tools/get_i18n.rb
@@ -64,24 +64,27 @@ module RailsAiContext
           lines << "- **Available locales:** #{available_list(i18n)}"
           lines << "- **Locale files:** #{i18n[:total_locale_files] || files.size}"
 
+          # A language-name table under config/locales makes Rails list a
+          # locale per language, and on Discourse that is 138 rows of zeroes.
+          # They are summarised as a group rather than listed - and rows for
+          # them still exist, so asking for one by name answers with numbers.
+          untranslated = i18n[:locales_without_translations] || []
+          grouped = untranslated.map { |u| (u.is_a?(Hash) ? u[:locale] : u).to_s }.to_set
+
           coverage = i18n[:locale_coverage] || {}
-          if coverage.any?
+          listed = coverage.reject { |loc, _| grouped.include?(loc.to_s) }
+          if listed.any?
             lines << "" << "## Coverage (vs #{i18n[:default_locale]})"
-            coverage.sort.each do |loc, data|
+            listed.sort.each do |loc, data|
               lines << "- **#{loc}**: #{data[:coverage_pct]}% - #{count_phrase(data[:keys], "unique key")}#{coverage_gap(data)}"
             end
           end
 
-          # A language-name table under config/locales makes Rails list a
-          # locale per language. Saying so is what keeps the available count
-          # and the shorter coverage list from reading as a contradiction.
-          untranslated = i18n[:locales_without_translations] || []
           if untranslated.any?
             total = (i18n[:available_locales] || []).size
-            named = untranslated.map { |u| u.is_a?(Hash) ? "#{u[:locale]} (#{u[:keys]} keys)" : u.to_s }.sort
             lines << "" << "_#{untranslated.size} of #{total} locales round to 0.0% against " \
-                           "#{i18n[:default_locale]} and are left out of coverage. Their own key " \
-                           "counts: #{named.join(', ')}._"
+                           "#{i18n[:default_locale]} and are grouped here instead of listed above. " \
+                           "Ask for one by name for its numbers. #{own_key_counts(untranslated)}_"
           end
 
           fallbacks = i18n[:fallbacks] || {}
@@ -118,6 +121,22 @@ module RailsAiContext
 
           render_file_list(lines, page, "Files for #{locale}", "_No locale files found for '#{locale}'._")
           text_response(lines.join("\n"))
+        end
+
+        # A language-name table gives every locale in it the same key count,
+        # and repeating it per name ran to 138 copies of "(2 keys)".
+        def own_key_counts(untranslated)
+          named = untranslated.map { |u| u.is_a?(Hash) ? u : { locale: u.to_s } }
+          counts = named.map { |u| u[:keys] }.uniq
+          locales = named.map { |u| u[:locale].to_s }.sort
+
+          if counts.size == 1 && counts.first
+            "Each defines #{count_phrase(counts.first, "key")} of its own: #{locales.join(', ')}."
+          else
+            listed = named.sort_by { |u| u[:locale].to_s }
+              .map { |u| u[:keys] ? "#{u[:locale]} (#{count_phrase(u[:keys], "key")})" : u[:locale].to_s }
+            "Their own key counts: #{listed.join(', ')}."
+          end
         end
 
         def coverage_gap(data)

--- a/lib/rails_ai_context/tools/get_i18n.rb
+++ b/lib/rails_ai_context/tools/get_i18n.rb
@@ -78,9 +78,10 @@ module RailsAiContext
           untranslated = i18n[:locales_without_translations] || []
           if untranslated.any?
             total = (i18n[:available_locales] || []).size
+            named = untranslated.map { |u| u.is_a?(Hash) ? "#{u[:locale]} (#{u[:keys]} keys)" : u.to_s }.sort
             lines << "" << "_#{untranslated.size} of #{total} locales round to 0.0% against " \
-                           "#{i18n[:default_locale]} and are left out of coverage: " \
-                           "#{untranslated.sort.join(', ')}._"
+                           "#{i18n[:default_locale]} and are left out of coverage. Their own key " \
+                           "counts: #{named.join(', ')}._"
           end
 
           fallbacks = i18n[:fallbacks] || {}
@@ -96,7 +97,7 @@ module RailsAiContext
         end
 
         def render_locale(i18n, locale, offset:, limit:)
-          files = (i18n[:locale_files] || []).select { |f| locale_file_match?(f[:file], locale) }
+          files = (i18n[:locale_files] || []).select { |f| serves_locale?(f, locale) }
           page = paginate(files.sort_by { |f| f[:file] }, offset: offset, limit: limit, default_limit: 50)
 
           lines = [ "# I18n: #{locale}" ]
@@ -104,11 +105,12 @@ module RailsAiContext
           if coverage
             lines << ""
             lines << "- **Unique keys:** #{coverage[:keys]} (#{coverage[:coverage_pct]}% of #{i18n[:default_locale]})#{coverage_gap(coverage)}"
-          elsif Array(i18n[:locales_without_translations]).include?(locale)
+          elsif (left_out = Array(i18n[:locales_without_translations]).find { |u| (u.is_a?(Hash) ? u[:locale] : u).to_s == locale.to_s })
             # Otherwise the coverage line every other locale carries is simply
             # missing here, and the reader cannot tell absent from zero.
             lines << ""
-            lines << "- **Coverage:** `#{locale}` rounds to 0.0% against #{i18n[:default_locale]}."
+            own = left_out.is_a?(Hash) ? " It defines #{count_phrase(left_out[:keys], "key")} of its own." : ""
+            lines << "- **Coverage:** `#{locale}` rounds to 0.0% against #{i18n[:default_locale]}.#{own}"
           end
 
           fallbacks = i18n[:fallbacks] || {}
@@ -143,8 +145,16 @@ module RailsAiContext
           line
         end
 
-        # Mirrors the introspector's locale-file matching: en.yml, devise.en.yml,
-        # en/users.yml, admin/en.yml.
+        # A file serves a locale when it declares it. The filename convention
+        # is the fallback for a payload written before locales were recorded.
+        def serves_locale?(entry, locale)
+          declared = entry[:locales]
+          return declared.map(&:to_s).include?(locale.to_s) if declared
+
+          locale_file_match?(entry[:file], locale)
+        end
+
+        # en.yml, devise.en.yml, en/users.yml, admin/en.yml.
         def locale_file_match?(file, locale)
           name = File.basename(file, ".*")
           name == locale || name.end_with?(".#{locale}") ||

--- a/lib/rails_ai_context/tools/get_model_details.rb
+++ b/lib/rails_ai_context/tools/get_model_details.rb
@@ -402,11 +402,9 @@ module RailsAiContext
 
       # The model's own file, not app/models/<underscored>.rb rebuilt from its
       # name - that misses a pack, an engine, and any inflection the app
-      # registers. The introspector carries it; the derivation is the fallback
-      # for a model reflection found and no file was recorded for.
+      # registers.
       private_class_method def self.relative_model_path(model_name)
-        RailsAiContext::Payload.model_file(cached_context, model_name) ||
-          "app/models/#{model_name.underscore}.rb"
+        RailsAiContext::Payload.model_file(cached_context, model_name)
       end
 
       private_class_method def self.model_source_path(model_name)

--- a/lib/rails_ai_context/tools/get_model_details.rb
+++ b/lib/rails_ai_context/tools/get_model_details.rb
@@ -400,9 +400,22 @@ module RailsAiContext
         lines.join("\n")
       end
 
+      # The model's own file, not app/models/<underscored>.rb rebuilt from its
+      # name - that misses a pack, an engine, and any inflection the app
+      # registers. The introspector carries it; the derivation is the fallback
+      # for a model reflection found and no file was recorded for.
+      private_class_method def self.relative_model_path(model_name)
+        RailsAiContext::Payload.model_file(cached_context, model_name) ||
+          "app/models/#{model_name.underscore}.rb"
+      end
+
+      private_class_method def self.model_source_path(model_name)
+        rails_app.root.join(relative_model_path(model_name))
+      end
+
       # Extract bodies of custom validate methods (single-line or first meaningful line)
       private_class_method def self.extract_custom_validate_bodies(model_name, method_names)
-        path = rails_app.root.join("app", "models", "#{model_name.underscore}.rb")
+        path = model_source_path(model_name)
         return {} unless File.exist?(path) && File.size(path) <= max_file_size
 
         source = RailsAiContext::SafeFile.read(path)
@@ -423,7 +436,7 @@ module RailsAiContext
 
       # Extract class methods defined in the model source (not inherited)
       private_class_method def self.extract_source_defined_methods(model_name, class_methods: false)
-        path = rails_app.root.join("app", "models", "#{model_name.underscore}.rb")
+        path = model_source_path(model_name)
         return nil unless File.exist?(path)
         return nil if File.size(path) > max_file_size
 
@@ -446,7 +459,7 @@ module RailsAiContext
 
       # Extract public method signatures (name + params) from model source
       private_class_method def self.extract_method_signatures(model_name)
-        path = rails_app.root.join("app", "models", "#{model_name.underscore}.rb")
+        path = model_source_path(model_name)
         return nil unless File.exist?(path)
         return nil if File.size(path) > max_file_size
 
@@ -500,7 +513,7 @@ module RailsAiContext
       end
 
       private_class_method def self.extract_model_structure(model_name)
-        path = "app/models/#{model_name.underscore}.rb"
+        path = relative_model_path(model_name)
         full_path = rails_app.root.join(path)
         return nil unless File.exist?(full_path)
         return nil if File.size(full_path) > max_file_size

--- a/lib/rails_ai_context/tools/get_routes.rb
+++ b/lib/rails_ai_context/tools/get_routes.rb
@@ -68,7 +68,7 @@ module RailsAiContext
 
           # Filter by controller - accepts "posts", "PostsController", "posts_controller", "Api::V1::Posts"
           if controller
-            normalized = controller.underscore.delete_suffix("_controller")
+            normalized = RailsAiContext::Payload.controller_route_key(cached_context, controller)
             normalized_alt = controller.downcase.delete_suffix("_controller").delete_suffix("controller")
             filtered = by_controller.select { |k, _| k.downcase.include?(normalized) || k.downcase.include?(normalized_alt) }
             return text_response("No routes for '#{controller}'. Controllers: #{by_controller.keys.sort.join(', ')}") if filtered.empty?

--- a/lib/rails_ai_context/tools/get_test_info.rb
+++ b/lib/rails_ai_context/tools/get_test_info.rb
@@ -189,7 +189,11 @@ module RailsAiContext
 
       private_class_method def self.find_test_file(name, type, detail = "full")
         # Normalize: accept "Admin::PostsController", "admin/posts", "Posts", "posts" (plural)
-        snake = name.to_s.tr("/", "::").underscore.sub(/_controller$/, "")
+        snake = if type == :controller
+          RailsAiContext::Payload.controller_route_key(cached_context, name)
+        else
+          name.to_s.tr("/", "::").underscore.sub(/_controller$/, "")
+        end
         # For models, also try singular form (posts → post)
         snake_singular = snake.singularize
         candidates = case type

--- a/lib/rails_ai_context/tools/get_test_info.rb
+++ b/lib/rails_ai_context/tools/get_test_info.rb
@@ -189,8 +189,14 @@ module RailsAiContext
 
       private_class_method def self.find_test_file(name, type, detail = "full")
         # Normalize: accept "Admin::PostsController", "admin/posts", "Posts", "posts" (plural)
-        snake = if type == :controller
+        snake = case type
+        when :controller
           RailsAiContext::Payload.controller_route_key(cached_context, name)
+        when :model
+          # The spec mirrors the model's own path, which a pack or an engine
+          # moves out from under app/models.
+          RailsAiContext::Payload.model_file(cached_context, name)
+            .sub(%r{\A.*app/models/}, "").sub(/\.rb\z/, "")
         else
           name.to_s.tr("/", "::").underscore.sub(/_controller$/, "")
         end

--- a/lib/rails_ai_context/tools/get_view.rb
+++ b/lib/rails_ai_context/tools/get_view.rb
@@ -62,7 +62,7 @@ module RailsAiContext
 
         if controller
           # Normalize: accept "PostsController", "posts", "posts_controller", "Admin::PostsController"
-          ctrl_lower = controller.underscore.delete_suffix("_controller")
+          ctrl_lower = RailsAiContext::Payload.controller_route_key(cached_context, controller)
           ctrl_lower_alt = controller.downcase.delete_suffix("controller")
           filtered_templates = templates.select { |k, _|
             k_down = k.downcase
@@ -536,7 +536,7 @@ module RailsAiContext
           .sort
 
         if controller
-          ctrl_lower = controller.underscore.delete_suffix("_controller")
+          ctrl_lower = RailsAiContext::Payload.controller_route_key(cached_context, controller)
           ctrl_lower_alt = controller.downcase.delete_suffix("controller")
           templates = templates.select { |t|
             t_down = t.downcase

--- a/lib/rails_ai_context/tools/runtime_info.rb
+++ b/lib/rails_ai_context/tools/runtime_info.rb
@@ -226,14 +226,27 @@ module RailsAiContext
 
         # ── Cache section ────────────────────────────────────────────────
 
+        # A store's #stats is a Hash - memcached returns curr_items, bytes and
+        # friends. Rendering it with #inspect puts a Ruby literal in an answer
+        # a reader has to parse; the pairs are the facts.
+        def cache_stat_lines(stats)
+          return [ "**Stats:** #{stats}" ] unless stats.is_a?(Hash)
+          return [ "_No cache stats reported._" ] if stats.empty?
+
+          [ "**Stats:**" ] + stats.map { |key, value| "- #{key}: #{format_stat_value(value)}" }
+        end
+
+        def format_stat_value(value)
+          value.is_a?(Hash) ? value.map { |k, v| "#{k}: #{v}" }.join(", ") : value.to_s
+        end
+
         def gather_cache
           cache = Rails.cache
           lines = [ "## Cache", "" ]
           lines << "**Store:** #{cache.class.name.demodulize}"
 
           if cache.respond_to?(:stats)
-            stats = cache.stats
-            lines << "**Stats:** #{stats.inspect}"
+            cache_stat_lines(cache.stats).each { |line| lines << line }
           elsif cache.respond_to?(:redis)
             begin
               info = cache.redis.info("stats")
@@ -247,9 +260,12 @@ module RailsAiContext
               lines << "_Redis stats not available: #{e.message}_"
             end
           elsif defined?(ActiveSupport::Cache::MemoryStore) && cache.is_a?(ActiveSupport::Cache::MemoryStore)
-            # MemoryStore has no #stats method - its own #inspect (entry
-            # count, byte size, options) is the closest thing it exposes.
-            lines << "**Stats:** #{cache.inspect}"
+            # MemoryStore has no #stats method - its own #inspect is where the
+            # entry count and byte size live. Read the numbers out of it; the
+            # string itself is an object dumped into prose.
+            shape = cache.inspect
+            lines << "**Entries:** #{shape[/entries=(\d+)/, 1] || "unknown"}"
+            lines << "**Size:** #{shape[/size=(\d+)/, 1] || "unknown"} bytes"
           else
             lines << "_Stats not available for #{cache.class.name}. Supported: Redis, MemoryStore._"
           end

--- a/lib/rails_ai_context/tools/search_code.rb
+++ b/lib/rails_ai_context/tools/search_code.rb
@@ -266,14 +266,14 @@ module RailsAiContext
 
         if file_type
           cmd.push("--type-add", "custom:*.#{file_type}", "--type", "custom")
-        else
-          # Without this, `search_extensions` reached the Ruby fallback only,
-          # and the same configuration gave two different answers depending on
-          # whether ripgrep happened to be installed.
-          RailsAiContext.configuration.search_extensions.each do |ext|
-            cmd << "--glob=*.#{ext.to_s.delete_prefix('.')}"
-          end
         end
+        # `search_extensions` is deliberately NOT applied here. Turning it into
+        # a positive glob list makes ripgrep agree with the Ruby fallback and
+        # costs the reach that makes the tool useful: `gem "devise"` in a
+        # Gemfile, a TODO in a .md, a task in a Rakefile all stop being
+        # findable, because none of those names carry a listed extension. The
+        # fallback keeps the list because scanning every file in Ruby is the
+        # expensive path; ripgrep does not need the help.
 
         cmd << "--" # Prevent pattern from being parsed as flags
         cmd << pattern

--- a/lib/rails_ai_context/tools/search_code.rb
+++ b/lib/rails_ai_context/tools/search_code.rb
@@ -266,6 +266,13 @@ module RailsAiContext
 
         if file_type
           cmd.push("--type-add", "custom:*.#{file_type}", "--type", "custom")
+        else
+          # Without this, `search_extensions` reached the Ruby fallback only,
+          # and the same configuration gave two different answers depending on
+          # whether ripgrep happened to be installed.
+          RailsAiContext.configuration.search_extensions.each do |ext|
+            cmd << "--glob=*.#{ext.to_s.delete_prefix('.')}"
+          end
         end
 
         cmd << "--" # Prevent pattern from being parsed as flags

--- a/lib/rails_ai_context/tools/validate_semantics.rb
+++ b/lib/rails_ai_context/tools/validate_semantics.rb
@@ -445,8 +445,7 @@ module RailsAiContext
         schema = context[:schema]
         return nil unless models && schema
 
-        model_name = file.sub("app/models/", "").sub(/\.rb$/, "").camelize
-        model_data = models[model_name]
+        model_name, model_data = RailsAiContext::Payload.model_for_file(context, file)
         return nil unless model_data
 
         table_name = model_data[:table_name]
@@ -522,8 +521,7 @@ module RailsAiContext
         models = context[:models]
         return warnings unless models
 
-        model_name = file.sub("app/models/", "").sub(/\.rb$/, "").camelize
-        model_data = models[model_name]
+        model_name, model_data = RailsAiContext::Payload.model_for_file(context, file)
         return warnings unless model_data
 
         # Build set of known methods (instance + from source content)
@@ -558,7 +556,7 @@ module RailsAiContext
         # Map file to controller name: app/controllers/posts_controller.rb → posts
         relative = file.sub("app/controllers/", "").sub(/_controller\.rb$/, "")
         ctrl_key = relative.gsub("/", "::")
-        ctrl_class = ctrl_key.camelize + "Controller"
+        ctrl_class = RailsAiContext::Payload.controller_for_route_key(context, ctrl_key)&.first
 
         # Get controller actions
         ctrl_data = controllers[:controllers] && controllers[:controllers][ctrl_class]
@@ -589,8 +587,7 @@ module RailsAiContext
         models = context[:models]
         return warnings unless models
 
-        model_name = file.sub("app/models/", "").sub(/\.rb$/, "").camelize
-        model_data = models[model_name]
+        model_name, model_data = RailsAiContext::Payload.model_for_file(context, file)
         return warnings unless model_data
 
         (model_data[:associations] || []).each do |assoc|
@@ -612,8 +609,7 @@ module RailsAiContext
         models = context[:models]
         return warnings unless schema && models
 
-        model_name = file.sub("app/models/", "").sub(/\.rb$/, "").camelize
-        model_data = models[model_name]
+        model_name, model_data = RailsAiContext::Payload.model_for_file(context, file)
         return warnings unless model_data
 
         table_name = model_data[:table_name]
@@ -846,7 +842,7 @@ module RailsAiContext
 
         # Check 14: Missing FK indexes on tables referenced in validated files
         if file.start_with?("app/models/") && perf[:missing_fk_indexes]&.any?
-          model_name = file.sub("app/models/", "").sub(/\.rb$/, "").tr("/", "::").camelize
+          model_name = RailsAiContext::Payload.model_for_file(context, file)&.first
           perf[:missing_fk_indexes].each do |finding|
             next unless finding.is_a?(Hash) && finding[:model] == model_name
             warnings << "#{finding[:column]} on #{finding[:table]} - missing index on foreign key (performance)"

--- a/lib/rails_ai_context/tools/validate_semantics.rb
+++ b/lib/rails_ai_context/tools/validate_semantics.rb
@@ -701,14 +701,18 @@ module RailsAiContext
         parts = file.sub("app/views/", "").split("/")
         return warnings if parts.size < 2
 
+        # A view directory names the route key, not the constant: camelizing
+        # app/views/activitypub/ back gives Activitypub, which is not what the
+        # app declares, and the check then stops running for that whole tree.
         ctrl_dir = parts[0..-2].join("/")
-        ctrl_class = "#{ctrl_dir.camelize}Controller"
-        controllers = context.dig(:controllers, :controllers) || {}
-        ctrl_data = controllers[ctrl_class]
+        ctrl_class, ctrl_data = RailsAiContext::Payload.controller_for_route_key(context, ctrl_dir)
         return warnings unless ctrl_data
 
         # Get all instance variables set across all actions
-        source_path = rails_app.root.join("app", "controllers", "#{ctrl_class.underscore}.rb")
+        ctrl_file = RailsAiContext::Payload.controller_file(context, ctrl_class)
+        return warnings unless ctrl_file
+
+        source_path = rails_app.root.join(ctrl_file)
         return warnings unless File.exist?(source_path)
 
         ctrl_source = RailsAiContext::SafeFile.read(source_path)

--- a/lib/rails_ai_context/version.rb
+++ b/lib/rails_ai_context/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiContext
-  VERSION = "5.23.0"
+  VERSION = "5.23.1"
 end

--- a/lib/rails_ai_context/version.rb
+++ b/lib/rails_ai_context/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiContext
-  VERSION = "5.23.1"
+  VERSION = "5.24.0"
 end

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/crisnahine/rails-ai-context",
     "source": "github"
   },
-  "version": "5.23.0",
+  "version": "5.23.1",
   "packages": [
     {
       "registryType": "mcpb",

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/crisnahine/rails-ai-context",
     "source": "github"
   },
-  "version": "5.23.1",
+  "version": "5.24.0",
   "packages": [
     {
       "registryType": "mcpb",

--- a/spec/cli_smoke_spec.rb
+++ b/spec/cli_smoke_spec.rb
@@ -16,6 +16,23 @@ RSpec.describe "CLI smoke: every tool executes", type: :smoke do
     end
   end
 
+  # --no-boot returned before the "is this a Rails app" guard, so in an empty
+  # directory the gem wrote a CLAUDE.md describing an app that is not there -
+  # "Migrations: 0 total", "This project has 45 MCP tools" - and exited 0.
+  it "refuses --no-boot outside a Rails app" do
+    exe = File.expand_path("../exe/rails-ai-context", __dir__)
+    lib = File.expand_path("../lib", __dir__)
+
+    Dir.mktmpdir do |dir|
+      out = `cd #{dir} && ruby -I #{lib} #{exe} context --no-boot 2>&1`
+      status = $?.exitstatus
+
+      expect(status).to eq(1), out
+      expect(out).to include("No Rails app found")
+      expect(Dir.children(dir)).to be_empty
+    end
+  end
+
   it "documents the static-tier flags" do
     help = `ruby #{File.expand_path('../exe/rails-ai-context', __dir__)} help serve 2>&1`
     expect(help).to include("--no-boot")

--- a/spec/cli_smoke_spec.rb
+++ b/spec/cli_smoke_spec.rb
@@ -33,6 +33,24 @@ RSpec.describe "CLI smoke: every tool executes", type: :smoke do
     end
   end
 
+  # An engine keeps its dummy app under spec/dummy, so its root has app/ and
+  # no config/. There is real source to read there, and the guard against an
+  # empty directory must not take the whole repo shape with it.
+  it "still reads an engine repo with --no-boot" do
+    exe = File.expand_path("../exe/rails-ai-context", __dir__)
+    lib = File.expand_path("../lib", __dir__)
+
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "app", "models"))
+      File.write(File.join(dir, "app", "models", "widget.rb"), "class Widget < ApplicationRecord\nend\n")
+
+      out = `cd #{dir} && ruby -I #{lib} #{exe} tool model_details --no-boot 2>&1`
+
+      expect($?.exitstatus).to eq(0), out
+      expect(out).to include("Widget")
+    end
+  end
+
   it "documents the static-tier flags" do
     help = `ruby #{File.expand_path('../exe/rails-ai-context', __dir__)} help serve 2>&1`
     expect(help).to include("--no-boot")

--- a/spec/e2e/boot_resilience_spec.rb
+++ b/spec/e2e/boot_resilience_spec.rb
@@ -89,6 +89,34 @@ RSpec.describe "E2E: boot resilience", type: :e2e do
       end
     end
 
+    # The listing is what an agent reads to learn which tools exist. When the
+    # app cannot boot it took the gem's defaults instead of the app's own
+    # .rails-ai-context.yml, so it advertised tools that the very next call
+    # refuses by name.
+    # YAML is the only way a standalone install configures the gem, so this is
+    # the shape that matters: no initializer, config in .rails-ai-context.yml.
+    # The initializer is moved aside because its configure block legitimately
+    # wins over the YAML, and with it in place there is nothing to load.
+    it "tool --list honours the app's config on an app that cannot boot" do
+      yml = File.join(@builder.app_path, ".rails-ai-context.yml")
+      init = File.join(@initializer_dir, "rails_ai_context.rb")
+      moved = "#{init}.qa-moved"
+      File.rename(init, moved) if File.exist?(init)
+      File.write(yml, "---\nskip_tools:\n  - rails_query\n  - rails_read_logs\n")
+
+      with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING"\n)) do
+        result = @cli.cli("tool", "--list")
+        expect(result.exit_status).to eq(0), result.to_s
+        expect(result.stdout).not_to match(/^\s+query\s/)
+        expect(result.stdout).not_to match(/^\s+read_logs\s/)
+      end
+    ensure
+      FileUtils.rm_f(File.join(@builder.app_path, ".rails-ai-context.yml"))
+      File.rename("#{File.join(@initializer_dir, 'rails_ai_context.rb')}.qa-moved",
+                  File.join(@initializer_dir, "rails_ai_context.rb")) if
+        File.exist?("#{File.join(@initializer_dir, 'rails_ai_context.rb')}.qa-moved")
+    end
+
     it "context honours --no-boot on an app that would boot fine" do
       result = @cli.cli("context", "--no-boot")
       expect(result.exit_status).to eq(0), result.to_s

--- a/spec/e2e/boot_resilience_spec.rb
+++ b/spec/e2e/boot_resilience_spec.rb
@@ -70,6 +70,25 @@ RSpec.describe "E2E: boot resilience", type: :e2e do
       end
     end
 
+    # init writes its config files before it boots, so a boot failure left the
+    # app half set up - .mcp.json and .rails-ai-context.yml on disk, no context
+    # files, and a non-zero exit reporting the whole thing as a failure.
+    it "init finishes its setup from static analysis instead of dying" do
+      with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING"\n)) do
+        result = @cli.cli("init")
+        expect(result.exit_status).to eq(0), result.to_s
+        expect(File).to exist(File.join(@builder.app_path, ".rails-ai-context.yml"))
+        expect(File).to exist(File.join(@builder.app_path, "CLAUDE.md"))
+      end
+    ensure
+      # init configures the app it runs in, and every later example in this
+      # file shares that app. Leaving the config behind changes what the MCP
+      # server loads for them.
+      %w[.rails-ai-context.yml .mcp.json].each do |f|
+        FileUtils.rm_f(File.join(@builder.app_path, f))
+      end
+    end
+
     it "context honours --no-boot on an app that would boot fine" do
       result = @cli.cli("context", "--no-boot")
       expect(result.exit_status).to eq(0), result.to_s

--- a/spec/e2e/boot_resilience_spec.rb
+++ b/spec/e2e/boot_resilience_spec.rb
@@ -39,6 +39,43 @@ RSpec.describe "E2E: boot resilience", type: :e2e do
       end
     end
 
+    # A repo you have just cloned is the case an agent most needs a CLAUDE.md
+    # for, and it is exactly the case that cannot boot. Every command that
+    # reads the app should degrade the way `tool` does; only doctor, whose job
+    # is diagnosing the boot, is entitled to fail.
+    it "context writes its files from static analysis instead of dying" do
+      with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING: REDIS_URL is not set"\n)) do
+        result = @cli.cli("context")
+        expect(result.exit_status).to eq(0), result.to_s
+        expect(result.stderr).to include("static tier active")
+        expect(File).to exist(File.join(@builder.app_path, "CLAUDE.md"))
+      end
+    end
+
+    %w[facts inspect].each do |command|
+      it "#{command} falls back to static analysis instead of dying" do
+        with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING"\n)) do
+          result = @cli.cli(command)
+          expect(result.exit_status).to eq(0), result.to_s
+          expect(result.stdout).not_to be_empty
+        end
+      end
+    end
+
+    it "preset falls back to static analysis instead of dying" do
+      with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING"\n)) do
+        result = @cli.cli("preset", "architecture")
+        expect(result.exit_status).to eq(0), result.to_s
+        expect(result.stdout).not_to be_empty
+      end
+    end
+
+    it "context honours --no-boot on an app that would boot fine" do
+      result = @cli.cli("context", "--no-boot")
+      expect(result.exit_status).to eq(0), result.to_s
+      expect(result.stderr).to include("static")
+    end
+
     it "doctor fails with the same friendly diagnostic" do
       with_initializer("zz_kaboom.rb", %(raise "FATAL_ENV_MISSING"\n)) do
         result = @cli.cli("doctor")

--- a/spec/lib/generators/rails_ai_context/install_generator_spec.rb
+++ b/spec/lib/generators/rails_ai_context/install_generator_spec.rb
@@ -43,6 +43,23 @@ RSpec.describe RailsAiContext::Generators::InstallGenerator do
       expect(content).to end_with("  end\nend\n")
     end
 
+    # This file lands in the app's repo and is read by whoever maintains it
+    # next, so its own Rubocop sees it. The AI Tools section was written at one
+    # indent and every section after it at another, and the guard wrap kept the
+    # gap by indenting both equally.
+    it "indents the whole configure body the same way" do
+      generator.create_initializer
+
+      body = File.read(initializer_path)
+        .lines
+        .drop_while { |l| !l.include?("RailsAiContext.configure do |config|") }
+        .drop(1)
+      body = body.take_while { |l| l !~ /\A  end$/ }
+      indents = body.reject { |l| l.strip.empty? }.map { |l| l[/\A */].size }
+
+      expect(indents.uniq).to eq([ 4 ])
+    end
+
     it "adds the guard when updating an existing unguarded initializer" do
       File.write(initializer_path, <<~RUBY)
         # frozen_string_literal: true

--- a/spec/lib/rails_ai_context/cli/tool_runner_spec.rb
+++ b/spec/lib/rails_ai_context/cli/tool_runner_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe RailsAiContext::CLI::ToolRunner do
       tool_names = tools.map(&:tool_name)
       expect(tool_names).not_to include("rails_security_scan")
     end
+
+    # Every neighbouring key in the generated initializer takes symbols
+    # (ai_tools, tool_mode, preset), so %i[] is the spelling a reader reaches
+    # for - and it used to skip nothing at all, silently.
+    it "respects skip_tools written as symbols" do
+      RailsAiContext.configuration.skip_tools = %i[rails_security_scan]
+      tool_names = described_class.available_tools.map(&:tool_name)
+      expect(tool_names).not_to include("rails_security_scan")
+    ensure
+      RailsAiContext.configuration.skip_tools = []
+    end
   end
 
   describe ".short_name" do

--- a/spec/lib/rails_ai_context/docs_static_tier_spec.rb
+++ b/spec/lib/rails_ai_context/docs_static_tier_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe "docs/COMPATIBILITY.md operating tiers" do
     end
   end
 
+  it "names exactly the alternate-source introspectors" do
+    alternate = keys_for(:alternate_source)
+    section = flat[/\*\*alternate-source\*\*.*?\*\*runtime-only\*\*/].to_s
+
+    expect(section).to include("(#{alternate.size})")
+    alternate.each do |key|
+      expect(section).to include("`#{key}`"), "the alternate-source table omits #{key}"
+    end
+  end
+
   it "names exactly the runtime-only introspectors as unavailable" do
     runtime = keys_for(:runtime_only)
     section = flat[/\*\*runtime-only\*\*.*?observability`\./].to_s

--- a/spec/lib/rails_ai_context/docs_static_tier_spec.rb
+++ b/spec/lib/rails_ai_context/docs_static_tier_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# docs/COMPATIBILITY.md tells a reader how much of the gem still answers when
+# their app will not boot, and that is the question they use to decide whether
+# it is worth installing at all. The page once said 6 introspectors answered
+# and 34 reported unavailable, naming eight examples - every one of which
+# actually answers. Counting is what rots; pin the counts to the code.
+RSpec.describe "docs/COMPATIBILITY.md operating tiers" do
+  let(:doc) { File.read(File.expand_path("../../../docs/COMPATIBILITY.md", __dir__)) }
+  # Prose wraps, so a sentence can carry a newline between two of its words.
+  let(:flat) { doc.gsub(/\s+/, " ") }
+  let(:map) { RailsAiContext::Introspector::INTROSPECTOR_MAP }
+
+  def keys_for(kind)
+    map.select { |_, klass| klass.static_tier == kind }.keys.map(&:to_s).sort
+  end
+
+  it "states the number of introspectors that answer in the static tier" do
+    answering = keys_for(:files_only).size + keys_for(:alternate_source).size
+
+    expect(flat).to include("#{answering} of the #{map.size} introspectors")
+  end
+
+  it "names every files-only introspector and no others" do
+    keys_for(:files_only).each do |key|
+      expect(doc).to include("`#{key}`"), "docs/COMPATIBILITY.md never names the files-only introspector #{key}"
+    end
+  end
+
+  it "names exactly the runtime-only introspectors as unavailable" do
+    runtime = keys_for(:runtime_only)
+    section = flat[/\*\*runtime-only\*\*.*?observability`\./].to_s
+
+    expect(section).to include("(#{runtime.size})")
+    runtime.each do |key|
+      expect(section).to include("`#{key}`"), "the runtime-only list omits #{key}"
+    end
+    (map.keys.map(&:to_s) - runtime).each do |key|
+      expect(section).not_to include("`#{key}`"), "#{key} answers statically but is listed as runtime-only"
+    end
+  end
+end

--- a/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe RailsAiContext::Introspectors::ControllerIntrospector do
       expect(result[:controllers]).to have_key("PostsController")
     end
 
+    # The consumers read :file through Payload in both tiers, so a booted app
+    # that answered without it would send them all back to guessing the path.
+    it "carries the file each controller was read from" do
+      expect(result[:controllers]["PostsController"][:file]).to eq("app/controllers/posts_controller.rb")
+    end
+
     it "extracts all CRUD actions from PostsController" do
       actions = result[:controllers]["PostsController"][:actions]
       expect(actions).to include("index", "show", "new", "create", "edit", "update", "destroy")
@@ -333,6 +339,22 @@ RSpec.describe RailsAiContext::Introspectors::ControllerIntrospector do
         expect(widgets[:parent_class]).to eq("ApplicationController")
         expect(widgets[:confidence]).to eq("[STATIC]")
         expect(result[:controllers]["Api::PingsController"][:api_controller]).to be(true)
+      end
+    end
+
+    # Six tools turn a controller name back into a path, and the name alone
+    # cannot carry it: the app's inflector decides the directory. `:file` is
+    # the answer they read through Payload, so it has to be here.
+    it "carries the file each controller was read from" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "controllers", "activitypub"))
+        File.write(File.join(dir, "app", "controllers", "activitypub", "inboxes_controller.rb"),
+                   "class ActivityPub::InboxesController < ApplicationController\n  def create; end\nend\n")
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result[:controllers]["ActivityPub::InboxesController"][:file])
+          .to eq("app/controllers/activitypub/inboxes_controller.rb")
       end
     end
 

--- a/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
@@ -343,6 +343,26 @@ RSpec.describe RailsAiContext::Introspectors::ControllerIntrospector do
       end
     end
 
+    # Reading the name from the source means the name no longer round-trips
+    # back to the path: `ActivityPub::CollectionsController`.underscore is
+    # `activity_pub/collections_controller`, and the file is under
+    # `activitypub/`. Every consumer that wants the file must be handed it.
+    it "carries the file each controller was read from" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "controllers", "activitypub"))
+        File.write(File.join(dir, "app", "controllers", "activitypub", "collections_controller.rb"), <<~RUBY)
+          class ActivityPub::CollectionsController < ApplicationController
+            def show; end
+          end
+        RUBY
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result[:controllers]["ActivityPub::CollectionsController"][:file])
+          .to eq("app/controllers/activitypub/collections_controller.rb")
+      end
+    end
+
     # Zeitwerk resolves a path through the app's own inflections, so a
     # directory named `activitypub` is `ActivityPub` in an app that registers
     # that acronym - and camelizing the path alone invents `Activitypub`, a

--- a/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
@@ -343,6 +343,59 @@ RSpec.describe RailsAiContext::Introspectors::ControllerIntrospector do
       end
     end
 
+    # Zeitwerk resolves a path through the app's own inflections, so a
+    # directory named `activitypub` is `ActivityPub` in an app that registers
+    # that acronym - and camelizing the path alone invents `Activitypub`, a
+    # constant Mastodon does not define anywhere in 818 references.
+    it "names a controller from the constant its source declares" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "controllers", "activitypub"))
+        File.write(File.join(dir, "app", "controllers", "activitypub", "collections_controller.rb"), <<~RUBY)
+          class ActivityPub::CollectionsController < ApplicationController
+            def show; end
+          end
+        RUBY
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result[:controllers].keys).to contain_exactly("ActivityPub::CollectionsController")
+      end
+    end
+
+    it "names a controller declared inside a module block" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "controllers", "oauth"))
+        File.write(File.join(dir, "app", "controllers", "oauth", "tokens_controller.rb"), <<~RUBY)
+          module OAuth
+            class TokensController < ApplicationController
+              def create; end
+            end
+          end
+        RUBY
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result[:controllers].keys).to contain_exactly("OAuth::TokensController")
+      end
+    end
+
+    # The path is the only thing carrying the namespace when the source does
+    # not, so it stays the answer there.
+    it "falls back to the path when the source declares a bare name" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "controllers", "admin"))
+        File.write(File.join(dir, "app", "controllers", "admin", "widgets_controller.rb"), <<~RUBY)
+          class WidgetsController < ApplicationController
+            def index; end
+          end
+        RUBY
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result[:controllers].keys).to contain_exactly("Admin::WidgetsController")
+      end
+    end
+
     it "discovers controllers in packs and engines directories" do
       Dir.mktmpdir do |dir|
         FileUtils.mkdir_p(File.join(dir, "app", "controllers"))

--- a/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/controller_introspector_spec.rb
@@ -342,9 +342,9 @@ RSpec.describe RailsAiContext::Introspectors::ControllerIntrospector do
       end
     end
 
-    # Six tools turn a controller name back into a path, and the name alone
-    # cannot carry it: the app's inflector decides the directory. `:file` is
-    # the answer they read through Payload, so it has to be here.
+    # Every tool that needs a path for a controller reads `:file` through
+    # Payload, because the name alone cannot carry it - the app's inflector
+    # decides the directory.
     it "carries the file each controller was read from" do
       Dir.mktmpdir do |dir|
         FileUtils.mkdir_p(File.join(dir, "app", "controllers", "activitypub"))

--- a/spec/lib/rails_ai_context/introspectors/declared_constant_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/declared_constant_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiContext::Introspectors::DeclaredConstant do
+  describe ".resolve" do
+    it "prefers the constant the source declares over the path" do
+      source = "class ActivityPub::CollectionsController < ApplicationController\nend\n"
+
+      expect(described_class.resolve(source, "Activitypub::CollectionsController"))
+        .to eq("ActivityPub::CollectionsController")
+    end
+
+    it "reads the name through module nesting" do
+      source = "module OAuth\n  class TokensController\n  end\nend\n"
+
+      expect(described_class.resolve(source, "Oauth::TokensController")).to eq("OAuth::TokensController")
+    end
+
+    # A bare name in a namespaced directory is the shape the path exists for:
+    # only the path carries the namespace, so only the path can name the class.
+    it "keeps the path name when the source declares fewer segments" do
+      source = "class Channel\nend\n"
+
+      expect(described_class.resolve(source, "ApplicationCable::Channel")).to eq("ApplicationCable::Channel")
+    end
+
+    it "keeps the path name when the source declares no class" do
+      source = "SOME_CONSTANT = 1\n"
+
+      expect(described_class.resolve(source, "Admin::WidgetsController")).to eq("Admin::WidgetsController")
+    end
+
+    # Prism recovers from a syntax error into a partial tree, so a half-written
+    # file still declares something. Naming the file after it would rename the
+    # controller on every reader's screen.
+    it "keeps the path name when the declared name is not this file's" do
+      source = "class Broken < ApplicationController\n  def index\n" # never closed
+
+      expect(described_class.resolve(source, "BrokenController")).to eq("BrokenController")
+    end
+
+    it "keeps the path name when there is no source to read" do
+      expect(described_class.resolve(nil, "WidgetsController")).to eq("WidgetsController")
+    end
+
+    it "takes the outermost class when one is nested inside another" do
+      source = "class PostsController < ApplicationController\n  class Error < StandardError\n  end\nend\n"
+
+      expect(described_class.resolve(source, "PostsController")).to eq("PostsController")
+    end
+  end
+end

--- a/spec/lib/rails_ai_context/introspectors/declared_constant_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/declared_constant_spec.rb
@@ -78,11 +78,11 @@ RSpec.describe RailsAiContext::Introspectors::DeclaredConstant do
   # "Does this file's own subject exist as a class" is a different question
   # from "what is it called", and app/mailers needs the first one: a module
   # holding a nested error class declares a class, but not its own.
-  describe ".declares_own_class?" do
+  describe ".own_subclass?" do
     it "is true for a class at the file's own level" do
       source = "module OAuth\n  class TokenMailer < ApplicationMailer\n  end\nend\n"
 
-      expect(described_class.declares_own_class?(source, "Oauth::TokenMailer")).to be(true)
+      expect(described_class.own_subclass?(source, "Oauth::TokenMailer")).to be(true)
     end
 
     it "is false for a module whose only class is nested deeper" do
@@ -97,17 +97,17 @@ RSpec.describe RailsAiContext::Introspectors::DeclaredConstant do
         end
       RUBY
 
-      expect(described_class.declares_own_class?(source, "Interceptors::DefaultHeaders")).to be(false)
+      expect(described_class.own_subclass?(source, "Interceptors::DefaultHeaders")).to be(false)
     end
 
     it "is true for a bare class in a namespaced directory" do
       source = "class Channel < ActionCable::Channel::Base\nend\n"
 
-      expect(described_class.declares_own_class?(source, "ApplicationCable::Channel")).to be(true)
+      expect(described_class.own_subclass?(source, "ApplicationCable::Channel")).to be(true)
     end
 
     it "is false when nothing is declared" do
-      expect(described_class.declares_own_class?("X = 1\n", "Widgets")).to be(false)
+      expect(described_class.own_subclass?("X = 1\n", "Widgets")).to be(false)
     end
   end
 end

--- a/spec/lib/rails_ai_context/introspectors/declared_constant_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/declared_constant_spec.rb
@@ -74,40 +74,4 @@ RSpec.describe RailsAiContext::Introspectors::DeclaredConstant do
       expect(described_class.resolve(source, "PostsController")).to eq("PostsController")
     end
   end
-
-  # "Does this file's own subject exist as a class" is a different question
-  # from "what is it called", and app/mailers needs the first one: a module
-  # holding a nested error class declares a class, but not its own.
-  describe ".own_subclass?" do
-    it "is true for a class at the file's own level" do
-      source = "module OAuth\n  class TokenMailer < ApplicationMailer\n  end\nend\n"
-
-      expect(described_class.own_subclass?(source, "Oauth::TokenMailer")).to be(true)
-    end
-
-    it "is false for a module whose only class is nested deeper" do
-      source = <<~RUBY
-        module Interceptors
-          module DefaultHeaders
-            class Error < StandardError
-            end
-
-            def delivering_email(mail); end
-          end
-        end
-      RUBY
-
-      expect(described_class.own_subclass?(source, "Interceptors::DefaultHeaders")).to be(false)
-    end
-
-    it "is true for a bare class in a namespaced directory" do
-      source = "class Channel < ActionCable::Channel::Base\nend\n"
-
-      expect(described_class.own_subclass?(source, "ApplicationCable::Channel")).to be(true)
-    end
-
-    it "is false when nothing is declared" do
-      expect(described_class.own_subclass?("X = 1\n", "Widgets")).to be(false)
-    end
-  end
 end

--- a/spec/lib/rails_ai_context/introspectors/declared_constant_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/declared_constant_spec.rb
@@ -44,10 +44,70 @@ RSpec.describe RailsAiContext::Introspectors::DeclaredConstant do
       expect(described_class.resolve(nil, "WidgetsController")).to eq("WidgetsController")
     end
 
+    # An acronym in the last segment is the same defect as one in the
+    # namespace: `APIController` in api_controller.rb, `CSVController` in
+    # csv_controller.rb.
+    it "prefers a declared name that differs from the path only by case" do
+      source = "class APIController < ApplicationController\nend\n"
+
+      expect(described_class.resolve(source, "ApiController")).to eq("APIController")
+    end
+
+    it "reads a root-scoped declaration" do
+      source = "class ::ActivityPub::CollectionsController < ApplicationController\nend\n"
+
+      expect(described_class.resolve(source, "Activitypub::CollectionsController"))
+        .to eq("ActivityPub::CollectionsController")
+    end
+
+    # A file may open more than one class. Only the one Zeitwerk expects at
+    # this path names the file, and it is not always written first.
+    it "picks the declared class this path names, not the first one" do
+      source = "class Legacy::WidgetsController\nend\n\nclass Admin::WidgetsController\nend\n"
+
+      expect(described_class.resolve(source, "Admin::WidgetsController")).to eq("Admin::WidgetsController")
+    end
+
     it "takes the outermost class when one is nested inside another" do
       source = "class PostsController < ApplicationController\n  class Error < StandardError\n  end\nend\n"
 
       expect(described_class.resolve(source, "PostsController")).to eq("PostsController")
+    end
+  end
+
+  # "Does this file's own subject exist as a class" is a different question
+  # from "what is it called", and app/mailers needs the first one: a module
+  # holding a nested error class declares a class, but not its own.
+  describe ".declares_own_class?" do
+    it "is true for a class at the file's own level" do
+      source = "module OAuth\n  class TokenMailer < ApplicationMailer\n  end\nend\n"
+
+      expect(described_class.declares_own_class?(source, "Oauth::TokenMailer")).to be(true)
+    end
+
+    it "is false for a module whose only class is nested deeper" do
+      source = <<~RUBY
+        module Interceptors
+          module DefaultHeaders
+            class Error < StandardError
+            end
+
+            def delivering_email(mail); end
+          end
+        end
+      RUBY
+
+      expect(described_class.declares_own_class?(source, "Interceptors::DefaultHeaders")).to be(false)
+    end
+
+    it "is true for a bare class in a namespaced directory" do
+      source = "class Channel < ActionCable::Channel::Base\nend\n"
+
+      expect(described_class.declares_own_class?(source, "ApplicationCable::Channel")).to be(true)
+    end
+
+    it "is false when nothing is declared" do
+      expect(described_class.declares_own_class?("X = 1\n", "Widgets")).to be(false)
     end
   end
 end

--- a/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
@@ -231,6 +231,24 @@ RSpec.describe RailsAiContext::Introspectors::I18nIntrospector do
       expect(result[:locale_coverage]["es"]).to include(coverage_pct: 100.0, extra: 1)
     end
 
+    # Reading every file to answer "which files hold locale X" once per locale
+    # is O(locales x files): on Discourse, 187 locales over 108 files took the
+    # introspector from under a second to four and a half minutes.
+    it "reads each locale file a bounded number of times" do
+      reads = 0
+      allow(RailsAiContext::SafeFile).to receive(:read).and_wrap_original do |orig, *args, **kw|
+        reads += 1
+        orig.call(*args, **kw)
+      end
+
+      files = (1..12).to_h { |i| [ "loc#{i}.yml", "loc#{i}:\n  hello: H#{i}\n" ] }
+      static_result(files.merge("en.yml" => "en:\n  hello: Hello\n"))
+
+      # One pass to index the files, plus each locale's own matched files. The
+      # per-locale full scan this guards against is 13 x 13 = 169 and up.
+      expect(reads).to be < 100
+    end
+
     # Coverage is measured against the default locale's keys. With none to
     # measure against, every locale scores zero - and calling them all
     # untranslated says something false about each one.

--- a/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
@@ -218,6 +218,33 @@ RSpec.describe RailsAiContext::Introspectors::I18nIntrospector do
       expect(result[:locales_without_translations]).to be_empty
     end
 
+    # A locale can have both: a file of its own AND keys in a shared file.
+    # Reading only the named one scores it on a fraction of what it translates.
+    it "reads a locale's own file and the shared file together" do
+      result = static_result(
+        "en.yml"     => "en:\n  a: A\n  b: B\n",
+        "es.yml"     => "es:\n  only_es: X\n",
+        "shared.yml" => "es:\n  a: Aa\n  b: Bb\n"
+      )
+
+      expect(result[:locales_without_translations]).to be_empty
+      expect(result[:locale_coverage]["es"]).to include(coverage_pct: 100.0, extra: 1)
+    end
+
+    # Coverage is measured against the default locale's keys. With none to
+    # measure against, every locale scores zero - and calling them all
+    # untranslated says something false about each one.
+    it "claims nothing about coverage when the default locale has no keys" do
+      result = static_result(
+        "en.yml" => "en:\n  a: A\n",
+        "fr.yml" => "fr:\n  a: Aa\n"
+      ) { |dir| File.write(File.join(dir, "config", "application.rb"), "config.i18n.default_locale = :de\n") }
+
+      expect(result[:default_locale]).to eq("de")
+      expect(result[:locale_coverage]).to be_empty
+      expect(result[:locales_without_translations]).to be_empty
+    end
+
     it "honours a bare I18n.default_locale in an initializer" do
       result = static_result("en.yml" => "en:\n  hello: Hello\n", "de.yml" => "de:\n  hello: Hallo\n") do |dir|
         FileUtils.mkdir_p(File.join(dir, "config", "initializers"))

--- a/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
@@ -178,6 +178,33 @@ RSpec.describe RailsAiContext::Introspectors::I18nIntrospector do
       expect(result[:available_locales]).to include("en", "en-GB")
     end
 
+    # A language-name lookup table is an ordinary thing to keep under
+    # config/locales, and Rails really does load every one of its top-level
+    # keys as an available locale. What it does not have is translations: on
+    # Discourse, 138 of 186 coverage rows read "0.0% - 0 unique keys - 11918
+    # missing" for languages nobody ever translated.
+    describe "a locale-name table under config/locales" do
+      let(:result) do
+        static_result(
+          "en.yml"    => "en:\n  hello: Hello\n  bye: Bye\n",
+          "es.yml"    => "es:\n  hello: Hola\n",
+          "names.yml" => "aa:\n  name: Afar\nzu:\n  name: Zulu\n"
+        )
+      end
+
+      it "still lists its keys as available locales, the way Rails does" do
+        expect(result[:available_locales]).to include("aa", "zu")
+      end
+
+      it "reports no coverage for a locale with no translations of its own" do
+        expect(result[:locale_coverage].keys).to contain_exactly("es")
+      end
+
+      it "names the locales it left out of coverage" do
+        expect(result[:locales_without_translations]).to contain_exactly("aa", "zu")
+      end
+    end
+
     it "honours a bare I18n.default_locale in an initializer" do
       result = static_result("en.yml" => "en:\n  hello: Hello\n", "de.yml" => "de:\n  hello: Hallo\n") do |dir|
         FileUtils.mkdir_p(File.join(dir, "config", "initializers"))

--- a/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
@@ -205,6 +205,19 @@ RSpec.describe RailsAiContext::Introspectors::I18nIntrospector do
       end
     end
 
+    # Locale files are usually named for their locale, but nothing requires it.
+    # A locale carried in a shared file has translations; saying it has none
+    # would be a positive claim that is false.
+    it "scores a locale whose translations live in a shared file" do
+      result = static_result(
+        "en.yml"           => "en:\n  hello: Hello\n  bye: Bye\n",
+        "translations.yml" => "es:\n  hello: Hola\n"
+      )
+
+      expect(result[:locale_coverage].keys).to contain_exactly("es")
+      expect(result[:locales_without_translations]).to be_empty
+    end
+
     it "honours a bare I18n.default_locale in an initializer" do
       result = static_result("en.yml" => "en:\n  hello: Hello\n", "de.yml" => "de:\n  hello: Hallo\n") do |dir|
         FileUtils.mkdir_p(File.join(dir, "config", "initializers"))

--- a/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
@@ -181,8 +181,8 @@ RSpec.describe RailsAiContext::Introspectors::I18nIntrospector do
     # A language-name lookup table is an ordinary thing to keep under
     # config/locales, and Rails really does load every one of its top-level
     # keys as an available locale. What it does not have is translations: on
-    # Discourse, 138 of 186 coverage rows read "0.0% - 0 unique keys - 11918
-    # missing" for languages nobody ever translated.
+    # Discourse, 138 of its 187 locales define 2 keys each and score 0.0%
+    # against an English locale with 11,918.
     describe "a locale-name table under config/locales" do
       let(:result) do
         static_result(

--- a/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
@@ -196,8 +196,13 @@ RSpec.describe RailsAiContext::Introspectors::I18nIntrospector do
         expect(result[:available_locales]).to include("aa", "zu")
       end
 
-      it "reports no coverage for a locale with no translations of its own" do
-        expect(result[:locale_coverage].keys).to contain_exactly("es")
+      # Naming them keeps 138 rows of zeroes off the screen, but the row
+      # itself is the only place the numbers live - a translation genuinely
+      # started below the rounding floor still has to be able to read its own
+      # missing count.
+      it "still carries a coverage row for a locale that rounds to zero" do
+        expect(result[:locale_coverage].keys).to contain_exactly("es", "aa", "zu")
+        expect(result[:locale_coverage]["aa"]).to include(coverage_pct: 0.0, missing: 2)
       end
 
       it "names the locales it left out of coverage" do
@@ -205,9 +210,8 @@ RSpec.describe RailsAiContext::Introspectors::I18nIntrospector do
       end
 
       # A locale can define plenty of keys and still share none with the
-      # default - GitLab's zh-CN has 109, all from gem-provided files. Hiding
-      # it behind a bare name reads as "not translated"; the count says what
-      # it actually is.
+      # default. Naming it without the count reads as "not translated"; the
+      # count says what it actually is.
       it "carries each left-out locale's own key count" do
         expect(result[:locales_without_translations]).to include(hash_including(locale: "aa", keys: 1))
       end
@@ -295,6 +299,22 @@ RSpec.describe RailsAiContext::Introspectors::I18nIntrospector do
         File.write(File.join(dir, "config", "initializers", "locale.rb"), "I18n.default_locale = :de\n")
       end
       expect(result[:default_locale]).to eq("de")
+    end
+
+    # config/environments/*.rb arrive in glob order, so the first file to
+    # carry an assignment won whatever environment it belonged to - and
+    # development.rb sorts ahead of production.rb.
+    it "prefers the running environment's file over the other environments" do
+      original = ENV["RAILS_ENV"]
+      ENV["RAILS_ENV"] = "production"
+      result = static_result("en.yml" => "en:\n  hello: Hello\n", "ja.yml" => "ja:\n  hello: Konnichiwa\n") do |dir|
+        FileUtils.mkdir_p(File.join(dir, "config", "environments"))
+        File.write(File.join(dir, "config", "environments", "development.rb"), "config.i18n.default_locale = :ja\n")
+        File.write(File.join(dir, "config", "environments", "production.rb"), "config.i18n.default_locale = :en\n")
+      end
+      expect(result[:default_locale]).to eq("en")
+    ensure
+      ENV["RAILS_ENV"] = original
     end
   end
 end

--- a/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
@@ -257,6 +257,24 @@ RSpec.describe RailsAiContext::Introspectors::I18nIntrospector do
       expect(reads).to be < 100
     end
 
+    # GitLab's config/application.rb carries `# config.i18n.default_locale =
+    # :de` as a commented example, and an unanchored match took it as the
+    # app's choice: every coverage line then read "against de" for an app that
+    # runs in English.
+    it "ignores a default_locale that is commented out" do
+      result = static_result("en.yml" => "en:\n  hello: Hello\n") do |dir|
+        File.write(File.join(dir, "config", "application.rb"), <<~RUBY)
+          module Dummy
+            class Application < Rails::Application
+              # config.i18n.default_locale = :de
+            end
+          end
+        RUBY
+      end
+
+      expect(result[:default_locale]).to eq("en")
+    end
+
     # Coverage is measured against the default locale's keys. With none to
     # measure against, every locale scores zero - and calling them all
     # untranslated says something false about each one.

--- a/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/i18n_introspector_spec.rb
@@ -201,7 +201,15 @@ RSpec.describe RailsAiContext::Introspectors::I18nIntrospector do
       end
 
       it "names the locales it left out of coverage" do
-        expect(result[:locales_without_translations]).to contain_exactly("aa", "zu")
+        expect(result[:locales_without_translations].map { |l| l[:locale] }).to contain_exactly("aa", "zu")
+      end
+
+      # A locale can define plenty of keys and still share none with the
+      # default - GitLab's zh-CN has 109, all from gem-provided files. Hiding
+      # it behind a bare name reads as "not translated"; the count says what
+      # it actually is.
+      it "carries each left-out locale's own key count" do
+        expect(result[:locales_without_translations]).to include(hash_including(locale: "aa", keys: 1))
       end
     end
 

--- a/spec/lib/rails_ai_context/introspectors/job_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/job_introspector_spec.rb
@@ -255,6 +255,32 @@ RSpec.describe RailsAiContext::Introspectors::JobIntrospector do
       expect(result[:mailers].map { |m| m[:name] }).to contain_exactly("UserMailer")
     end
 
+    # An interceptor is as often a class as a module, and a mailer always
+    # inherits something. A bare class under app/mailers is neither.
+    it "does not report a parentless class in app/mailers as a mailer" do
+      result = static_result do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "mailers", "interceptors"))
+        File.write(File.join(dir, "app", "mailers", "user_mailer.rb"), <<~RUBY)
+          class UserMailer < ApplicationMailer
+            def welcome
+              mail(to: "a@b.c")
+            end
+          end
+        RUBY
+        File.write(File.join(dir, "app", "mailers", "interceptors", "default_headers.rb"), <<~RUBY)
+          module Interceptors
+            class DefaultHeaders
+              def self.delivering_email(mail); end
+
+              def default_headers; end
+            end
+          end
+        RUBY
+      end
+
+      expect(result[:mailers].map { |m| m[:name] }).to contain_exactly("UserMailer")
+    end
+
     it "names a namespaced mailer by the constant its source declares" do
       result = static_result do |dir|
         FileUtils.mkdir_p(File.join(dir, "app", "mailers", "oauth"))

--- a/spec/lib/rails_ai_context/introspectors/job_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/job_introspector_spec.rb
@@ -281,6 +281,32 @@ RSpec.describe RailsAiContext::Introspectors::JobIntrospector do
       expect(result[:mailers].map { |m| m[:name] }).to contain_exactly("UserMailer")
     end
 
+    # A mailer's actions are often written as modules mixed into one class -
+    # GitLab keeps 20 of them under app/mailers/emails, holding every
+    # notification it sends. Those are a mailer's interface; an interceptor is
+    # not, and the framework hook is what tells them apart.
+    it "keeps a module whose methods are mailer actions" do
+      result = static_result do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "mailers", "emails"))
+        File.write(File.join(dir, "app", "mailers", "notify.rb"), <<~RUBY)
+          class Notify < ApplicationMailer
+            include Emails::Issues
+          end
+        RUBY
+        File.write(File.join(dir, "app", "mailers", "emails", "issues.rb"), <<~RUBY)
+          module Emails
+            module Issues
+              def new_issue_email(recipient_id)
+                mail(to: recipient_id)
+              end
+            end
+          end
+        RUBY
+      end
+
+      expect(result[:mailers].map { |m| m[:name] }).to include("Emails::Issues")
+    end
+
     it "names a namespaced mailer by the constant its source declares" do
       result = static_result do |dir|
         FileUtils.mkdir_p(File.join(dir, "app", "mailers", "oauth"))

--- a/spec/lib/rails_ai_context/introspectors/job_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/job_introspector_spec.rb
@@ -226,6 +226,52 @@ RSpec.describe RailsAiContext::Introspectors::JobIntrospector do
       expect(result[:mailers].map { |m| m[:name] }).not_to include("ApplicationMailer")
     end
 
+    # ActionMailer interceptors are modules, and app/mailers is where they
+    # live. Reporting one as a mailer offers `delivering_email` - an interceptor
+    # hook - as an email an agent can send.
+    it "does not report a module in app/mailers as a mailer" do
+      result = static_result do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "mailers", "interceptors"))
+        File.write(File.join(dir, "app", "mailers", "user_mailer.rb"), <<~RUBY)
+          class UserMailer < ApplicationMailer
+            def welcome
+              mail(to: "a@b.c")
+            end
+          end
+        RUBY
+        File.write(File.join(dir, "app", "mailers", "interceptors", "default_headers.rb"), <<~RUBY)
+          module Interceptors
+            module DefaultHeaders
+              module_function
+
+              def delivering_email(mail); end
+
+              def default_headers; end
+            end
+          end
+        RUBY
+      end
+
+      expect(result[:mailers].map { |m| m[:name] }).to contain_exactly("UserMailer")
+    end
+
+    it "names a namespaced mailer by the constant its source declares" do
+      result = static_result do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "mailers", "oauth"))
+        File.write(File.join(dir, "app", "mailers", "oauth", "token_mailer.rb"), <<~RUBY)
+          module OAuth
+            class TokenMailer < ApplicationMailer
+              def issued
+                mail(to: "a@b.c")
+              end
+            end
+          end
+        RUBY
+      end
+
+      expect(result[:mailers].map { |m| m[:name] }).to contain_exactly("OAuth::TokenMailer")
+    end
+
     it "finds channels from source" do
       result = static_result do |dir|
         FileUtils.mkdir_p(File.join(dir, "app", "channels", "application_cable"))

--- a/spec/lib/rails_ai_context/introspectors/migration_replay_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/migration_replay_spec.rb
@@ -182,6 +182,26 @@ RSpec.describe RailsAiContext::Introspectors::MigrationReplay do
     expect(tables.keys).to include("project_types")
   end
 
+  # Canvas has a migration that calls `create_table table_name do |t|`, where
+  # the name is a local computed at run time. A table the replay cannot name is
+  # a table it cannot report, and keeping it produced a nil key that took the
+  # whole context run down when a serializer sorted the table names.
+  it "skips a create_table whose name it cannot resolve" do
+    tables = replay([ <<~RUBY ])
+      class CreateComputed < ActiveRecord::Migration[7.1]
+        def change
+          table_name = "widgets_\#{Shard.current.id}"
+          create_table table_name do |t|
+            t.string :name
+          end
+        end
+      end
+    RUBY
+
+    expect(tables.keys).to all(be_a(String))
+    expect(tables.keys).not_to include(nil)
+  end
+
   # The fix must not reach so far that it stops honouring a real drop.
   it "still drops a table a later migration removes on the way up" do
     tables = replay([ <<~RUBY, <<~RUBY2 ])

--- a/spec/lib/rails_ai_context/introspectors/migration_replay_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/migration_replay_spec.rb
@@ -99,4 +99,64 @@ RSpec.describe RailsAiContext::Introspectors::MigrationReplay do
 
     expect(tables["events"][:columns].map { |c| c[:name] }).to include("created_at", "updated_at")
   end
+
+  # `def up` creates, `def down` undoes it - the ordinary shape of an
+  # irreversible migration. Replaying both bodies cancels the table out, and
+  # the table the app really has disappears from the schema answer.
+  it "ignores a drop_table that only runs on the way down" do
+    tables = replay([ <<~RUBY ])
+      class CreateProjectTypes < ActiveRecord::Migration[7.1]
+        def up
+          create_table :project_types do |t|
+            t.string :name
+          end
+        end
+
+        def down
+          drop_table :project_types
+        end
+      end
+    RUBY
+
+    expect(tables.keys).to include("project_types")
+  end
+
+  it "ignores a create_table that only runs on the way down" do
+    tables = replay([ <<~RUBY ])
+      class DropLegacyThings < ActiveRecord::Migration[7.1]
+        def up
+          drop_table :legacy_things
+        end
+
+        def down
+          create_table :legacy_things do |t|
+            t.string :name
+          end
+        end
+      end
+    RUBY
+
+    expect(tables.keys).not_to include("legacy_things")
+  end
+
+  # The fix must not reach so far that it stops honouring a real drop.
+  it "still drops a table a later migration removes on the way up" do
+    tables = replay([ <<~RUBY, <<~RUBY2 ])
+      class CreateWidgets < ActiveRecord::Migration[7.1]
+        def change
+          create_table :widgets do |t|
+            t.string :name
+          end
+        end
+      end
+    RUBY
+      class DropWidgets < ActiveRecord::Migration[7.1]
+        def up
+          drop_table :widgets
+        end
+      end
+    RUBY2
+
+    expect(tables.keys).not_to include("widgets")
+  end
 end

--- a/spec/lib/rails_ai_context/introspectors/migration_replay_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/migration_replay_spec.rb
@@ -139,6 +139,49 @@ RSpec.describe RailsAiContext::Introspectors::MigrationReplay do
     expect(tables.keys).not_to include("legacy_things")
   end
 
+  # t.timestamps is found by its own walk over the whole file, so a `down`
+  # body's timestamps were attributed to the last table created on the way up.
+  it "does not give an up table the timestamps of a down table" do
+    tables = replay([ <<~RUBY ])
+      class SwapWidgets < ActiveRecord::Migration[7.1]
+        def up
+          create_table :widgets do |t|
+            t.string :name
+          end
+        end
+
+        def down
+          create_table :old_widgets do |t|
+            t.string :name
+            t.timestamps
+          end
+        end
+      end
+    RUBY
+
+    expect(tables["widgets"][:columns].map { |c| c[:name] }).to eq(%w[id name])
+  end
+
+  # `reversible` and `revert` are the modern spelling of the same intent, and
+  # they are blocks inside `change` rather than a method named down.
+  it "ignores a drop inside reversible's down block" do
+    tables = replay([ <<~RUBY ])
+      class CreateProjectTypes < ActiveRecord::Migration[7.1]
+        def change
+          create_table :project_types do |t|
+            t.string :name
+          end
+
+          reversible do |dir|
+            dir.down { drop_table :project_types }
+          end
+        end
+      end
+    RUBY
+
+    expect(tables.keys).to include("project_types")
+  end
+
   # The fix must not reach so far that it stops honouring a real drop.
   it "still drops a table a later migration removes on the way up" do
     tables = replay([ <<~RUBY, <<~RUBY2 ])

--- a/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
@@ -351,6 +351,35 @@ RSpec.describe RailsAiContext::Introspectors::ModelIntrospector do
   end
 
   describe "#static_call" do
+    # The skip was `relative.start_with?("concerns/")`, which only sees the
+    # top-level directory Rails autoloads. A nested one - OpenProject has
+    # app/models/queries/operators/concerns - walked straight past it, and four
+    # mixins were reported as models of the app.
+    it "does not report a module in a nested concerns directory as a model" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "models", "queries", "operators", "concerns"))
+        File.write(File.join(dir, "app", "models", "widget.rb"), <<~RUBY)
+          class Widget < ApplicationRecord
+          end
+        RUBY
+        File.write(File.join(dir, "app", "models", "queries", "operators", "concerns", "contains.rb"), <<~RUBY)
+          module Queries
+            module Operators
+              module Concerns
+                module Contains
+                  def contains?(x) = true
+                end
+              end
+            end
+          end
+        RUBY
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result.keys).to contain_exactly("Widget")
+      end
+    end
+
     it "discovers and parses models from source without constantizing" do
       Dir.mktmpdir do |dir|
         FileUtils.mkdir_p(File.join(dir, "app", "models", "concerns"))

--- a/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
@@ -631,4 +631,78 @@ RSpec.describe RailsAiContext::Introspectors::ModelIntrospector do
       end
     end
   end
+  # `concerns/` under app/models is the Zeitwerk root for mixins, and an app
+  # may also nest one anywhere - OpenProject has app/models/queries/operators/
+  # concerns. But a nested concerns/ is an ordinary namespace, so a class
+  # declared there is a model like any other and dropping it by directory name
+  # loses it.
+  describe "models under a concerns directory" do
+    def models_in(files)
+      Dir.mktmpdir do |dir|
+        files.each do |relative, body|
+          full = File.join(dir, "app", "models", relative)
+          FileUtils.mkdir_p(File.dirname(full))
+          File.write(full, body)
+        end
+        return described_class.new(RailsAiContext::StaticApp.new(dir)).static_call.keys
+      end
+    end
+
+    it "keeps a class declared in a nested concerns namespace" do
+      expect(models_in(
+        "billing/concerns/plan.rb" => "module Billing\n  module Concerns\n    class Plan < ApplicationRecord\n    end\n  end\nend\n"
+      )).to include("Billing::Concerns::Plan")
+    end
+
+    it "drops a mixin in a nested concerns namespace" do
+      expect(models_in(
+        "queries/operators/concerns/dateish.rb" => "module Queries\n  module Operators\n    module Concerns\n      module Dateish\n      end\n    end\n  end\nend\n"
+      )).to be_empty
+    end
+
+    # The autoload root does not namespace its files, so the path is not their
+    # name; keeping one would report a constant the app does not have.
+    it "drops everything under the top-level concerns root" do
+      expect(models_in(
+        "concerns/trashable.rb" => "module Trashable\nend\n",
+        "concerns/oddity.rb" => "class Oddity < ApplicationRecord\nend\n"
+      )).to be_empty
+    end
+  end
+  # Six tools turn a model name back into app/models/<underscored>.rb. That is
+  # wrong for a model in a pack or engine, and wrong wherever the app registers
+  # an inflection, so the file travels with the model the way it does with a
+  # controller.
+  describe "the file a model was read from" do
+    # The booted tier answers from the constant, so it must not fall back to
+    # rebuilding the path from the name either.
+    it "carries it in the booted tier" do
+      expect(described_class.new(Rails.application).call["Post"][:file]).to eq("app/models/post.rb")
+    end
+
+    it "carries it for a model outside app/models" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "packs", "billing", "app", "models", "invoice.rb")
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, "class Invoice < ApplicationRecord\nend\n")
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result["Invoice"][:file]).to eq("packs/billing/app/models/invoice.rb")
+      end
+    end
+
+    it "names a model by the constant its source declares" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "app", "models", "activitypub", "activity.rb")
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, "module ActivityPub\n  class Activity < ApplicationRecord\n  end\nend\n")
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result.keys).to include("ActivityPub::Activity")
+        expect(result["ActivityPub::Activity"][:file]).to eq("app/models/activitypub/activity.rb")
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
@@ -669,10 +669,33 @@ RSpec.describe RailsAiContext::Introspectors::ModelIntrospector do
       )).to be_empty
     end
   end
-  # Six tools turn a model name back into app/models/<underscored>.rb. That is
-  # wrong for a model in a pack or engine, and wrong wherever the app registers
-  # an inflection, so the file travels with the model the way it does with a
-  # controller.
+  # The booted tier rejects `abstract_class?`, so a namespaced base class is
+  # not a model there. GitLab has three - Ci::ApplicationRecord,
+  # PackageMetadata::ApplicationRecord, SecApplicationRecord - and the static
+  # tier counted all three, giving the same app two different model counts.
+  describe "an abstract base class" do
+    it "is not a model in the static tier either" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "models", "ci"))
+        File.write(File.join(dir, "app", "models", "ci", "application_record.rb"), <<~RUBY)
+          module Ci
+            class ApplicationRecord < ::ApplicationRecord
+              self.abstract_class = true
+            end
+          end
+        RUBY
+        File.write(File.join(dir, "app", "models", "widget.rb"), "class Widget < ApplicationRecord\nend\n")
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result.keys).to contain_exactly("Widget")
+      end
+    end
+  end
+
+  # Rebuilding app/models/<underscored>.rb from the name is wrong for a model
+  # in a pack or an engine, and wrong wherever the app registers an inflection,
+  # so the file travels with the model the way it does with a controller.
   describe "the file a model was read from" do
     # The booted tier answers from the constant, so it must not fall back to
     # rebuilding the path from the name either.

--- a/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_context/introspectors/model_introspector_spec.rb
@@ -669,6 +669,39 @@ RSpec.describe RailsAiContext::Introspectors::ModelIntrospector do
       )).to be_empty
     end
   end
+  # Rails derives the table from the class name through its own inflector, so
+  # OAuthClientConfig is `oauth_client_configs`. The static tier has no
+  # inflector, and `"OAuthClientConfig".underscore` is `o_auth_client_config` -
+  # a table no app has. The file's own name is the reliable source: Zeitwerk
+  # resolved the constant from it, so it already carries the inflection.
+  describe "the table a model reads" do
+    it "reads it from the file, not from the inflected name" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "models"))
+        File.write(File.join(dir, "app", "models", "oauth_client_config.rb"),
+                   "class OAuthClientConfig < ApplicationRecord\nend\n")
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result["OAuthClientConfig"][:table_name]).to eq("oauth_client_configs")
+      end
+    end
+
+    # A namespaced model's table is the demodulized name, the way Rails does it
+    # without an explicit table_name_prefix.
+    it "uses the basename for a namespaced model" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "models", "billing"))
+        File.write(File.join(dir, "app", "models", "billing", "invoice.rb"),
+                   "module Billing\n  class Invoice < ApplicationRecord\n  end\nend\n")
+
+        result = described_class.new(RailsAiContext::StaticApp.new(dir)).static_call
+
+        expect(result["Billing::Invoice"][:table_name]).to eq("invoices")
+      end
+    end
+  end
+
   # The booted tier rejects `abstract_class?`, so a namespaced base class is
   # not a model there. GitLab has three - Ci::ApplicationRecord,
   # PackageMetadata::ApplicationRecord, SecApplicationRecord - and the static

--- a/spec/lib/rails_ai_context/payload_spec.rb
+++ b/spec/lib/rails_ai_context/payload_spec.rb
@@ -119,6 +119,25 @@ RSpec.describe RailsAiContext::Payload do
       expect(described_class.controller_for_route_key(other, "admin/badges")).to be_nil
     end
   end
+  # The reverse trip: a checker walking app/models/oauth_client_config.rb has
+  # to find the model it declares, and camelizing the path gives
+  # OauthClientConfig - a constant the app does not have.
+  describe ".model_for_file" do
+    let(:context) do
+      { models: { "OAuthClientConfig" => { file: "app/models/oauth_client_config.rb", table_name: "oauth_client_configs" } } }
+    end
+
+    it "finds the model a file declares" do
+      name, data = described_class.model_for_file(context, "app/models/oauth_client_config.rb")
+      expect(name).to eq("OAuthClientConfig")
+      expect(data[:table_name]).to eq("oauth_client_configs")
+    end
+
+    it "returns nil for a file no model was read from" do
+      expect(described_class.model_for_file(context, "app/models/nope.rb")).to be_nil
+    end
+  end
+
   # A model's file is carried for the same reason a controller's is: rebuilding
   # app/models/<underscored>.rb misses a pack, an engine, and any inflection.
   describe ".model_file" do

--- a/spec/lib/rails_ai_context/payload_spec.rb
+++ b/spec/lib/rails_ai_context/payload_spec.rb
@@ -65,10 +65,61 @@ RSpec.describe RailsAiContext::Payload do
         .to eq("invoices")
     end
 
+    # Rails does not require the _controller suffix on the filename, and
+    # leaving .rb on the key sent every path derived from it one directory
+    # deep into a file.
+    it "strips a plain .rb from a file that does not carry the suffix" do
+      expect(described_class.controller_route_key(ctx("app/controllers/invoices.rb"), "InvoicesController"))
+        .to eq("invoices")
+    end
+
     # The name is all there is for a controller reflection found and the
     # filesystem did not - and it is right whenever no inflection is involved.
     it "falls back to the underscored name when no file was carried" do
       expect(described_class.controller_route_key({}, "Admin::InvoicesController")).to eq("admin/invoices")
+    end
+  end
+  # A view directory is the route key: app/views/activitypub/ is rendered by
+  # whatever controller Rails routes as activitypub, and camelizing that back
+  # gives Activitypub, which is not the name Mastodon declares.
+  describe ".controller_for_route_key" do
+    let(:context) do
+      {
+        controllers: {
+          controllers: {
+            "ActivityPub::InboxesController" => { file: "app/controllers/activitypub/inboxes_controller.rb" },
+            "Admin::BadgesController" => { file: "app/controllers/admin/badges_controller.rb" }
+          }
+        }
+      }
+    end
+
+    it "finds a controller whose declared name does not camelize from its path" do
+      name, data = described_class.controller_for_route_key(context, "activitypub/inboxes")
+      expect(name).to eq("ActivityPub::InboxesController")
+      expect(data[:file]).to eq("app/controllers/activitypub/inboxes_controller.rb")
+    end
+
+    it "finds a namespaced controller by its path" do
+      expect(described_class.controller_for_route_key(context, "admin/badges").first)
+        .to eq("Admin::BadgesController")
+    end
+
+    it "returns nil for a directory no controller serves" do
+      expect(described_class.controller_for_route_key(context, "nope")).to be_nil
+    end
+  end
+  # A model's file is carried for the same reason a controller's is: rebuilding
+  # app/models/<underscored>.rb misses a pack, an engine, and any inflection.
+  describe ".model_file" do
+    let(:context) { { models: { "Invoice" => { file: "packs/billing/app/models/invoice.rb" } } } }
+
+    it "reads the file the model was read from" do
+      expect(described_class.model_file(context, "Invoice")).to eq("packs/billing/app/models/invoice.rb")
+    end
+
+    it "is nil for a model that carried none" do
+      expect(described_class.model_file({ models: { "Order" => {} } }, "Order")).to be_nil
     end
   end
 end

--- a/spec/lib/rails_ai_context/payload_spec.rb
+++ b/spec/lib/rails_ai_context/payload_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe RailsAiContext::Payload do
     it "returns nil for a directory no controller serves" do
       expect(described_class.controller_for_route_key(context, "nope")).to be_nil
     end
+
+    # The index is one slot. A second context must not be answered from the
+    # first one's controllers.
+    it "reindexes when the context changes" do
+      described_class.controller_for_route_key(context, "admin/badges")
+      other = { controllers: { controllers: { "OrdersController" => { file: "app/controllers/orders_controller.rb" } } } }
+
+      expect(described_class.controller_for_route_key(other, "orders").first).to eq("OrdersController")
+      expect(described_class.controller_for_route_key(other, "admin/badges")).to be_nil
+    end
   end
   # A model's file is carried for the same reason a controller's is: rebuilding
   # app/models/<underscored>.rb misses a pack, an engine, and any inflection.
@@ -118,8 +128,8 @@ RSpec.describe RailsAiContext::Payload do
       expect(described_class.model_file(context, "Invoice")).to eq("packs/billing/app/models/invoice.rb")
     end
 
-    it "is nil for a model that carried none" do
-      expect(described_class.model_file({ models: { "Order" => {} } }, "Order")).to be_nil
+    it "falls back to the conventional path for a model that carried none" do
+      expect(described_class.model_file({ models: { "Order" => {} } }, "Order")).to eq("app/models/order.rb")
     end
   end
 end

--- a/spec/lib/rails_ai_context/payload_spec.rb
+++ b/spec/lib/rails_ai_context/payload_spec.rb
@@ -48,4 +48,27 @@ RSpec.describe RailsAiContext::Payload do
       expect(described_class.list({}, :turbo, :turbo_frames)).to eq([])
     end
   end
+  describe ".controller_route_key" do
+    def ctx(file)
+      { controllers: { controllers: { "InvoicesController" => { file: file } } } }
+    end
+
+    it "reads the route key from the file the controller was read from" do
+      expect(described_class.controller_route_key(ctx("app/controllers/admin/invoices_controller.rb"), "InvoicesController"))
+        .to eq("admin/invoices")
+    end
+
+    # A pack or an in-repo engine puts the controllers root somewhere other
+    # than the start of the path, and Rails still routes by what follows it.
+    it "strips a controllers root that is not at the start of the path" do
+      expect(described_class.controller_route_key(ctx("packs/billing/app/controllers/invoices_controller.rb"), "InvoicesController"))
+        .to eq("invoices")
+    end
+
+    # The name is all there is for a controller reflection found and the
+    # filesystem did not - and it is right whenever no inflection is involved.
+    it "falls back to the underscored name when no file was carried" do
+      expect(described_class.controller_route_key({}, "Admin::InvoicesController")).to eq("admin/invoices")
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/serializers/context_file_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/context_file_serializer_spec.rb
@@ -112,6 +112,29 @@ RSpec.describe RailsAiContext::Serializers::ContextFileSerializer do
       expect(all.index(:opencode)).to be < all.index(:codex)
     end
 
+    # The install generator always records a tool selection, and every later
+    # `rails ai:context` passes that list here. `.ai-context.json` is not an AI
+    # tool and no install menu can offer it, so a selection used to turn the
+    # machine artifact off for good - while the generator still gitignored it.
+    it "writes .ai-context.json alongside a recorded tool selection" do
+      Dir.mktmpdir do |dir|
+        allow(RailsAiContext.configuration).to receive(:output_dir_for).and_return(dir)
+        described_class.new(context, format: %i[claude cursor copilot opencode codex]).call
+
+        expect(File).to exist(File.join(dir, ".ai-context.json"))
+      end
+    end
+
+    # An explicit `--format claude` asks for one thing and must get one thing.
+    it "does not write .ai-context.json for a single explicit format" do
+      Dir.mktmpdir do |dir|
+        allow(RailsAiContext.configuration).to receive(:output_dir_for).and_return(dir)
+        described_class.new(context, format: :claude).call
+
+        expect(File).not_to exist(File.join(dir, ".ai-context.json"))
+      end
+    end
+
     it "raises for unknown format" do
       Dir.mktmpdir do |dir|
         allow(RailsAiContext.configuration).to receive(:output_dir_for).and_return(dir)

--- a/spec/lib/rails_ai_context/serializers/context_file_serializer_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/context_file_serializer_spec.rb
@@ -135,6 +135,19 @@ RSpec.describe RailsAiContext::Serializers::ContextFileSerializer do
       end
     end
 
+    # An empty selection asks for nothing, and used to write nothing. Reading
+    # "a list means the machine artifact too" too literally turned it into a
+    # run that writes exactly one file nobody chose.
+    it "writes nothing for an empty selection" do
+      Dir.mktmpdir do |dir|
+        allow(RailsAiContext.configuration).to receive(:output_dir_for).and_return(dir)
+        result = described_class.new(context, format: []).call
+
+        expect(result[:written]).to be_empty
+        expect(File).not_to exist(File.join(dir, ".ai-context.json"))
+      end
+    end
+
     it "raises for unknown format" do
       Dir.mktmpdir do |dir|
         allow(RailsAiContext.configuration).to receive(:output_dir_for).and_return(dir)

--- a/spec/lib/rails_ai_context/serializers/stack_overview_helper_spec.rb
+++ b/spec/lib/rails_ai_context/serializers/stack_overview_helper_spec.rb
@@ -191,6 +191,26 @@ RSpec.describe RailsAiContext::Serializers::StackOverviewHelper do
       end
     end
 
+    # The generated files call these "Global before_actions", so a filter that
+    # is skipped or carries a condition does not belong in the list. Mastodon's
+    # ApplicationController skips verify_authenticity_token, and the file said
+    # it ran on every request.
+    it "leaves out filters that are skipped or conditional" do
+      Dir.mktmpdir do |root|
+        FileUtils.mkdir_p(File.join(root, "app", "controllers"))
+        File.write(File.join(root, "app", "controllers", "application_controller.rb"), <<~RUBY)
+          class ApplicationController < ActionController::Base
+            before_action :set_locale
+            skip_before_action :verify_authenticity_token
+            before_action :store_referrer, except: [ :create ], if: :devise_controller?
+            before_action :require_functional!, if: :user_signed_in?
+          end
+        RUBY
+
+        expect(test_class.new({}).detect_before_actions(root)).to eq(%w[set_locale])
+      end
+    end
+
     it "answers empty for a tree without those directories" do
       Dir.mktmpdir do |root|
         helper = test_class.new({})

--- a/spec/lib/rails_ai_context/server_spec.rb
+++ b/spec/lib/rails_ai_context/server_spec.rb
@@ -185,6 +185,14 @@ RSpec.describe RailsAiContext::Server do
         RailsAiContext.configuration.skip_tools = []
       end
 
+      it "excludes tools named with symbols" do
+        RailsAiContext.configuration.skip_tools = [ RailsAiContext::Tools::GetSchema.tool_name.to_sym ]
+        mcp_server = server.build
+        expect(mcp_server.tools.values).not_to include(RailsAiContext::Tools::GetSchema)
+      ensure
+        RailsAiContext.configuration.skip_tools = []
+      end
+
       it "includes all tools when skip_tools is empty" do
         RailsAiContext.configuration.skip_tools = []
         mcp_server = server.build

--- a/spec/lib/rails_ai_context/standalone_requires_spec.rb
+++ b/spec/lib/rails_ai_context/standalone_requires_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# `require_install_files!` in exe/rails-ai-context loads these six files
+# without the entry file, on purpose: the install path runs before Rails and
+# before Zeitwerk. That makes each one responsible for its own stdlib.
+#
+# lib/rails_ai_context.rb requires "set" and "date" for exactly this class of
+# bug, and the standalone list never reaches it - so `[...].to_set` in
+# legacy_cleanup raised NoMethodError on Ruby 3.1, where Set is not autoloaded.
+# Ruby 3.2+ hides it, which is why only the CI matrix ever saw it.
+RSpec.describe "the files the install path loads on their own" do
+  STANDALONE_FILES = %w[
+    install/ai_tool install/selection_record install/cleanup
+    install/program mcp_config_generator legacy_cleanup
+  ].freeze
+
+  let(:lib) { File.expand_path("../../../lib", __dir__) }
+
+  # The exe requires them in this order and nothing else, so that is the
+  # contract: the list loads as a unit, with no Rails and no entry file.
+  it "loads as a unit, in the order the exe requires them" do
+    script = STANDALONE_FILES.map { |f| "require #{File.join("rails_ai_context", f).inspect}" }.join("\n")
+    out = `ruby -I #{lib.shellescape} -e #{script.shellescape} 2>&1`
+
+    expect($?.exitstatus).to eq(0), out
+  end
+
+  # Loading is not the same as running. legacy_cleanup only reached its
+  # `to_set` when `init` actually called it.
+  it "runs the legacy prompt without the entry file" do
+    script = <<~RUBY
+      #{STANDALONE_FILES.map { |f| "require #{File.join("rails_ai_context", f).inspect}" }.join("\n")}
+      RailsAiContext.define_singleton_method(:log_warn) { |m| }
+      RailsAiContext::LegacyCleanup.prompt_legacy_files([ :claude, :cursor ], root: Dir.mktmpdir)
+    RUBY
+    out = `ruby -rtmpdir -I #{lib.shellescape} -e #{script.shellescape} 2>&1`
+
+    expect($?.exitstatus).to eq(0), out
+  end
+
+  # Loading is not enough: Set and Date resolve as constants under Ruby 3.2+
+  # whatever anyone required, and the method form is where 3.1 differs.
+  it "does not reach for a stdlib method the file never required" do
+    offenders = STANDALONE_FILES.filter_map do |file|
+      path = File.join(lib, "rails_ai_context", "#{file}.rb")
+      source = File.read(path)
+      needed = []
+      needed << "set"  if source.match?(/\bto_set\b|\bSet\.(new|\[)/) && !source.include?('require "set"')
+      needed << "date" if source.match?(/\bDate\.(today|parse|new)\b/) && !source.include?('require "date"')
+      "#{file} uses #{needed.join(", ")} without requiring it" if needed.any?
+    end
+
+    expect(offenders).to be_empty
+  end
+end

--- a/spec/lib/rails_ai_context/tools/analyze_feature_spec.rb
+++ b/spec/lib/rails_ai_context/tools/analyze_feature_spec.rb
@@ -193,6 +193,32 @@ RSpec.describe RailsAiContext::Tools::AnalyzeFeature do
       expect(text).not_to include("postmark")
     end
 
+    # A gap is a claim that something has no test. A scan that stopped at
+    # MAX_SCAN_FILES cannot make it: on an app with more specs than the cap,
+    # the ones covering the feature are simply never reached, and every
+    # controller in it was reported as untested.
+    it "claims no test gap when the spec scan stopped at the cap" do
+      Dir.mktmpdir("rac_gap") do |tmp|
+        spec_dir = File.join(tmp, "spec", "requests")
+        FileUtils.mkdir_p(spec_dir)
+        (described_class::MAX_SCAN_FILES + 5).times do |i|
+          File.write(File.join(spec_dir, "aaa_filler#{i}_spec.rb"), "# widget\n")
+        end
+        FileUtils.mkdir_p(File.join(tmp, "app", "controllers"))
+        File.write(File.join(tmp, "app", "controllers", "widgets_controller.rb"),
+                   "class WidgetsController < ApplicationController\n  def index; end\nend\n")
+
+        allow(described_class).to receive(:rails_app).and_return(double(root: Pathname.new(tmp)))
+        allow(described_class).to receive(:cached_context).and_return(
+          controllers: { controllers: { "WidgetsController" => { file: "app/controllers/widgets_controller.rb", actions: [ "index" ] } } }
+        )
+
+        text = described_class.call(feature: "widget").content.first[:text]
+
+        expect(text).not_to include("no test file found")
+      end
+    end
+
     context "DoS cap (v5.8.1 round 2)" do
       it "caps discover_services at MAX_SCAN_FILES and emits truncation note" do
         Dir.mktmpdir("rac_dos_services") do |tmp|

--- a/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
@@ -64,15 +64,13 @@ RSpec.describe RailsAiContext::Tools::GetI18n do
       end
 
       # A language-name table gives every one of them the same key count, and
-      # repeating it per name ran to 138 copies of "(1 keys)".
+      # repeating it per name ran to 138 copies of "(2 keys)" on Discourse.
       it "states a shared key count once instead of per name" do
         text = described_class.call.content.first[:text]
         expect(text).to include("Each defines 1 key of its own: aa, zu")
         expect(text).not_to include("aa (1 key)")
       end
 
-      # Asking for one of them by name must not answer with a silent gap where
-      # the coverage line sits for every other locale.
       # Grouping them keeps 138 rows of zeroes off the overview.
       it "keeps their rows out of the coverage list" do
         text = described_class.call.content.first[:text]

--- a/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
@@ -56,14 +56,14 @@ RSpec.describe RailsAiContext::Tools::GetI18n do
 
       it "says how many locales it left out of coverage" do
         text = described_class.call.content.first[:text]
-        expect(text).to include("2 of 4 locales translate none of en's keys")
+        expect(text).to include("2 of 4 locales translate under 0.1% of en's keys")
       end
 
       # Asking for one of them by name must not answer with a silent gap where
       # the coverage line sits for every other locale.
       it "says why the detail view has no coverage line" do
         text = described_class.call(locale: "aa").content.first[:text]
-        expect(text).to include("translates none of en's keys")
+        expect(text).to include("translates under 0.1% of en's keys")
       end
     end
 

--- a/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
@@ -56,14 +56,14 @@ RSpec.describe RailsAiContext::Tools::GetI18n do
 
       it "says how many locales it left out of coverage" do
         text = described_class.call.content.first[:text]
-        expect(text).to include("2 of 4 locales translate under 0.1% of en's keys")
+        expect(text).to include("2 of 4 locales round to 0.0% against en")
       end
 
       # Asking for one of them by name must not answer with a silent gap where
       # the coverage line sits for every other locale.
       it "says why the detail view has no coverage line" do
         text = described_class.call(locale: "aa").content.first[:text]
-        expect(text).to include("translates under 0.1% of en's keys")
+        expect(text).to include("rounds to 0.0% against en")
       end
     end
 

--- a/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe RailsAiContext::Tools::GetI18n do
       let(:i18n_data) do
         super().merge(
           available_locales: %w[en fr aa zu],
+          locale_coverage: super()[:locale_coverage].merge(
+            "aa" => { keys: 1, coverage_pct: 0.0, missing: 100, extra: 1 },
+            "zu" => { keys: 1, coverage_pct: 0.0, missing: 100, extra: 1 }
+          ),
           locales_without_translations: [ { locale: "aa", keys: 1 }, { locale: "zu", keys: 1 } ]
         )
       end
@@ -59,11 +63,28 @@ RSpec.describe RailsAiContext::Tools::GetI18n do
         expect(text).to include("2 of 4 locales round to 0.0% against en")
       end
 
+      # A language-name table gives every one of them the same key count, and
+      # repeating it per name ran to 138 copies of "(1 keys)".
+      it "states a shared key count once instead of per name" do
+        text = described_class.call.content.first[:text]
+        expect(text).to include("Each defines 1 key of its own: aa, zu")
+        expect(text).not_to include("aa (1 key)")
+      end
+
       # Asking for one of them by name must not answer with a silent gap where
       # the coverage line sits for every other locale.
-      it "says why the detail view has no coverage line" do
+      # Grouping them keeps 138 rows of zeroes off the overview.
+      it "keeps their rows out of the coverage list" do
+        text = described_class.call.content.first[:text]
+        expect(text).not_to include("**aa**: 0.0%")
+      end
+
+      # The group is a summary, not a deletion: asking for one by name still
+      # has to answer with its numbers.
+      it "still answers with the numbers when asked for one by name" do
         text = described_class.call(locale: "aa").content.first[:text]
-        expect(text).to include("rounds to 0.0% against en")
+        expect(text).to include("**Unique keys:** 1 (0.0% of en)")
+        expect(text).to include("100 missing")
       end
     end
 

--- a/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
@@ -56,7 +56,14 @@ RSpec.describe RailsAiContext::Tools::GetI18n do
 
       it "says how many locales it left out of coverage" do
         text = described_class.call.content.first[:text]
-        expect(text).to include("2 of 4 locales have no translations of their own")
+        expect(text).to include("2 of 4 locales translate none of en's keys")
+      end
+
+      # Asking for one of them by name must not answer with a silent gap where
+      # the coverage line sits for every other locale.
+      it "says why the detail view has no coverage line" do
+        text = described_class.call(locale: "aa").content.first[:text]
+        expect(text).to include("translates none of en's keys")
       end
     end
 

--- a/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
@@ -42,6 +42,24 @@ RSpec.describe RailsAiContext::Tools::GetI18n do
       expect(text).to include("**fr**: 80.0% - 80 unique keys")
     end
 
+    # An app whose config/locales holds a language-name table lists far more
+    # available locales than it has coverage rows for. Without a word about
+    # the gap, a reader counts 187 locales, then 49 rows, and cannot tell
+    # which number is wrong.
+    context "when some locales carry no translations" do
+      let(:i18n_data) do
+        super().merge(
+          available_locales: %w[en fr aa zu],
+          locales_without_translations: %w[aa zu]
+        )
+      end
+
+      it "says how many locales it left out of coverage" do
+        text = described_class.call.content.first[:text]
+        expect(text).to include("2 of 4 locales have no translations of their own")
+      end
+    end
+
     # Coverage counts a key path once; the per-file list below it counts each
     # file's leaves. Without the label the two numbers look like a bug.
     it "says the coverage key total counts unique paths" do

--- a/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_i18n_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RailsAiContext::Tools::GetI18n do
       let(:i18n_data) do
         super().merge(
           available_locales: %w[en fr aa zu],
-          locales_without_translations: %w[aa zu]
+          locales_without_translations: [ { locale: "aa", keys: 1 }, { locale: "zu", keys: 1 } ]
         )
       end
 
@@ -99,6 +99,26 @@ RSpec.describe RailsAiContext::Tools::GetI18n do
       it "shows coverage for the filtered locale" do
         text = described_class.call(locale: "fr").content.first[:text]
         expect(text).to include("**Unique keys:** 80 (80.0% of en)")
+      end
+
+      # The filename convention is not the only way a file serves a locale:
+      # gem-provided files are named for the gem, and GitLab's zh-CN lives in
+      # devise.zh-cn.yml. The tool listed both and then said it had none.
+      it "finds a locale's files when the filename does not spell the locale" do
+        allow(described_class).to receive(:cached_context).and_return(
+          i18n: i18n_data.merge(
+            available_locales: %w[en zh-CN],
+            locale_files: [
+              { file: "en.yml", key_count: 100, locales: %w[en] },
+              { file: "devise.zh-cn.yml", key_count: 49, locales: %w[zh-CN] }
+            ]
+          )
+        )
+
+        text = described_class.call(locale: "zh-CN").content.first[:text]
+
+        expect(text).to include("devise.zh-cn.yml")
+        expect(text).not_to include("No locale files found")
       end
 
       it "returns not-found with suggestions for an unknown locale" do

--- a/spec/lib/rails_ai_context/tools/get_model_details_spec.rb
+++ b/spec/lib/rails_ai_context/tools/get_model_details_spec.rb
@@ -253,4 +253,35 @@ RSpec.describe RailsAiContext::Tools::GetModelDetails do
       expect(text).to include("# User")
     end
   end
+  # A model in a pack does not live under app/models, so rebuilding the path
+  # from the name found nothing and every source-read section went quietly
+  # missing from an answer that otherwise looked complete.
+  describe "a model whose file is not under app/models" do
+    around do |example|
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "packs", "billing", "app", "models", "invoice.rb")
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, <<~RUBY)
+          class Invoice < ApplicationRecord
+            def overdue_by(days)
+            end
+          end
+        RUBY
+        @root = dir
+        example.run
+      end
+    end
+
+    it "reads the source from the file the model carries" do
+      described_class.reset_cache!
+      allow(RailsAiContext).to receive(:default_app).and_return(RailsAiContext::StaticApp.new(@root))
+      allow(described_class).to receive(:cached_context).and_return(
+        models: { "Invoice" => { table_name: "invoices", file: "packs/billing/app/models/invoice.rb" } }
+      )
+
+      text = described_class.call(model: "Invoice", detail: "full").content.first[:text]
+
+      expect(text).to include("overdue_by")
+    end
+  end
 end

--- a/spec/lib/rails_ai_context/tools/inflected_controller_spec.rb
+++ b/spec/lib/rails_ai_context/tools/inflected_controller_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+# Every tool that answers a question about a controller by looking somewhere
+# on disk has to turn its name back into a path. Underscoring the name is that
+# derivation, and it is wrong for any controller the app names through an
+# inflection: Mastodon declares ActivityPub::InboxesController, whose file,
+# route and spec all sit under activitypub/, not activity_pub/.
+#
+# Each example asserts the tool finds the thing. The failure this pins is a
+# confident negative - "no routes", "no test file found" - which is the answer
+# an agent acts on without checking.
+RSpec.describe "controllers named through an inflection" do
+  let(:root) { @root }
+
+  let(:context) do
+    {
+      controllers: {
+        controllers: {
+          "ActivityPub::InboxesController" => {
+            file: "app/controllers/activitypub/inboxes_controller.rb",
+            actions: [ "create" ]
+          }
+        }
+      },
+      routes: {
+        by_controller: { "activitypub/inboxes" => [ { verb: "POST", path: "/inbox", action: "create", name: "inbox" } ] }
+      },
+      views: {
+        templates: { "activitypub/inboxes/show.html.erb" => { lines: 3 } },
+        partials: {}
+      },
+      tests: { framework: "rspec" }
+    }
+  end
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @root = dir
+      FileUtils.mkdir_p(File.join(dir, "spec", "requests", "activitypub"))
+      File.write(File.join(dir, "spec", "requests", "activitypub", "inboxes_spec.rb"), "it 'posts' do\nend\n")
+      FileUtils.mkdir_p(File.join(dir, "app", "controllers", "activitypub"))
+      FileUtils.mkdir_p(File.join(dir, "app", "views", "activitypub", "inboxes"))
+      File.write(File.join(dir, "app", "views", "activitypub", "inboxes", "show.html.erb"), "<p>x</p>\n")
+      example.run
+    end
+  end
+
+  before do
+    [ RailsAiContext::Tools::GetRoutes, RailsAiContext::Tools::GetView,
+      RailsAiContext::Tools::GetTestInfo, RailsAiContext::Tools::GenerateTest,
+      RailsAiContext::Tools::AnalyzeFeature ].each do |tool|
+      tool.reset_cache! if tool.respond_to?(:reset_cache!)
+      allow(tool).to receive(:cached_context).and_return(context)
+    end
+    allow(RailsAiContext).to receive(:default_app).and_return(RailsAiContext::StaticApp.new(root))
+  end
+
+  def text(result) = result.content.first[:text]
+
+  it "finds the routes it has" do
+    expect(text(RailsAiContext::Tools::GetRoutes.call(controller: "ActivityPub::InboxesController")))
+      .to include("POST").and(satisfy { |t| !t.include?("No routes") })
+  end
+
+  it "finds the views it has" do
+    expect(text(RailsAiContext::Tools::GetView.call(controller: "ActivityPub::InboxesController")))
+      .to include("activitypub/inboxes/show.html.erb")
+  end
+
+  it "finds the spec file it has" do
+    expect(text(RailsAiContext::Tools::GetTestInfo.call(controller: "ActivityPub::InboxesController")))
+      .to include("spec/requests/activitypub/inboxes_spec.rb")
+  end
+
+  # A generated test that skips itself because it found no routes is worse
+  # than no generated test: it reads as a covered case.
+  it "generates a test against the routes it has" do
+    body = text(RailsAiContext::Tools::GenerateTest.call(controller: "ActivityPub::InboxesController"))
+    expect(body).to include("spec/requests/activitypub/inboxes_spec.rb")
+    expect(body).not_to include("no routes found")
+  end
+
+  # The view directory is the route key, so camelizing it back gives a name
+  # the app never declares and the undefined-ivar check silently stops running
+  # for every view under it.
+  it "still checks the views under an inflected directory" do
+    RailsAiContext::Tools::ValidateSemantics.reset_cache!
+    allow(RailsAiContext::Tools::ValidateSemantics).to receive(:cached_context)
+      .and_return(context.merge(schema: { tables: {} }, models: {}))
+    File.write(File.join(root, "app", "controllers", "activitypub", "inboxes_controller.rb"),
+               "class ActivityPub::InboxesController < ApplicationController\n  def create\n    @inbox = 1\n  end\nend\n")
+    view = "app/views/activitypub/inboxes/show.html.erb"
+    File.write(File.join(root, view), "<%= @nope %>\n")
+
+    warnings = RailsAiContext::Tools::ValidateSemantics.check_rails_semantics(view, File.join(root, view))
+
+    expect(warnings.join).to include("@nope")
+  end
+
+  it "does not report a controller with a spec as untested" do
+    expect(text(RailsAiContext::Tools::AnalyzeFeature.call(feature: "inbox")))
+      .not_to include("no test file found")
+  end
+end

--- a/spec/lib/rails_ai_context/tools/runtime_info_spec.rb
+++ b/spec/lib/rails_ai_context/tools/runtime_info_spec.rb
@@ -102,14 +102,36 @@ RSpec.describe RailsAiContext::Tools::RuntimeInfo do
     end
 
     describe "cache section coherence (MemoryStore)" do
-      it "shows real MemoryStore stats instead of the generic not-available message" do
-        allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+      # MemoryStore has no #stats, and its own #inspect is where the entry
+      # count and byte size live. Passing that string through put a raw
+      # `#<ActiveSupport::Cache::MemoryStore ...>` into the answer - the shape
+      # this gem has shipped as a defect before, when a Proc's address reached
+      # a file an app commits.
+      it "reports the numbers, not the object" do
+        store = ActiveSupport::Cache::MemoryStore.new
+        store.write("a", "1")
+        allow(Rails).to receive(:cache).and_return(store)
 
-        result = described_class.call(section: "cache")
-        text = result.content.first[:text]
+        text = described_class.call(section: "cache").content.first[:text]
+
         expect(text).to include("MemoryStore")
-        expect(text).to include("entries=")
+        expect(text).to include("**Entries:** 1")
+        expect(text).to match(/\*\*Size:\*\* \d+ bytes/)
+        expect(text).not_to include("#<")
         expect(text).not_to include("Stats not available for MemoryStore")
+      end
+
+      # A store that does answer #stats returns a Hash, and Hash#inspect is
+      # still an object dumped into prose.
+      it "renders a stats hash as facts" do
+        store = double("CacheStore", stats: { "curr_items" => 12, "bytes" => 3400 })
+        allow(store).to receive(:is_a?).and_return(false)
+        allow(Rails).to receive(:cache).and_return(store)
+
+        text = described_class.call(section: "cache").content.first[:text]
+
+        expect(text).to include("curr_items: 12")
+        expect(text).not_to include("=>")
       end
     end
   end

--- a/spec/lib/rails_ai_context/tools/search_code_spec.rb
+++ b/spec/lib/rails_ai_context/tools/search_code_spec.rb
@@ -45,6 +45,19 @@ RSpec.describe RailsAiContext::Tools::SearchCode do
       expect(text).to include("Search:")
     end
 
+    # search_extensions reached the Ruby fallback and not the ripgrep path, so
+    # the same config gave two different answers depending on whether rg
+    # happened to be installed - and on the machines where it is, which is most
+    # of them, narrowing the list did nothing at all.
+    it "honours search_extensions whichever search backend runs" do
+      RailsAiContext.configuration.search_extensions = %w[md]
+      text = described_class.call(pattern: "class").content.first[:text]
+
+      expect(text).not_to match(/\.rb[:\s]/)
+    ensure
+      RailsAiContext.configuration.search_extensions = %w[rb js erb yml yaml json ts tsx vue svelte haml slim]
+    end
+
     it "returns a not-found message for unmatched patterns" do
       result = described_class.call(pattern: "zzz_impossible_pattern_zzz_42")
       text = result.content.first[:text]

--- a/spec/lib/rails_ai_context/tools/search_code_spec.rb
+++ b/spec/lib/rails_ai_context/tools/search_code_spec.rb
@@ -47,23 +47,27 @@ RSpec.describe RailsAiContext::Tools::SearchCode do
 
     # Turning search_extensions into a positive glob list on the ripgrep path
     # made the two backends agree and cost the reach that makes the tool
-    # useful: a Gemfile, a Rakefile and a .md carry no listed extension.
+    # useful: a Gemfile, a Rakefile and a .md carry no listed extension. The
+    # Ruby fallback still globs by extension, so this is ripgrep's property.
     it "finds a match in a file whose name carries no listed extension" do
+      skip "requires ripgrep" unless described_class.send(:ripgrep_available?)
+
+      previous_root = RailsAiContext.configuration.app_root
       Dir.mktmpdir do |dir|
         FileUtils.mkdir_p(File.join(dir, "app", "models"))
         File.write(File.join(dir, "Gemfile"), %(source "https://rubygems.org"\ngem "devise"\n))
         File.write(File.join(dir, "app", "models", "post.rb"), "class Post; end\n")
-
-        allow(RailsAiContext).to receive(:configuration).and_wrap_original do |orig|
-          orig.call.tap { |c| c.app_root = dir }
-        end
+        RailsAiContext.configuration.app_root = dir
         allow(RailsAiContext).to receive(:tier).and_return(:static)
-        described_class.reset_cache! if described_class.respond_to?(:reset_cache!)
 
         text = described_class.call(pattern: "devise").content.first[:text]
 
         expect(text).to include("Gemfile")
       end
+    ensure
+      # app_root lives on the memoized configuration, so setting it without
+      # putting it back sends every later example at a deleted directory.
+      RailsAiContext.configuration.app_root = previous_root
     end
 
     it "returns a not-found message for unmatched patterns" do

--- a/spec/lib/rails_ai_context/tools/search_code_spec.rb
+++ b/spec/lib/rails_ai_context/tools/search_code_spec.rb
@@ -45,17 +45,25 @@ RSpec.describe RailsAiContext::Tools::SearchCode do
       expect(text).to include("Search:")
     end
 
-    # search_extensions reached the Ruby fallback and not the ripgrep path, so
-    # the same config gave two different answers depending on whether rg
-    # happened to be installed - and on the machines where it is, which is most
-    # of them, narrowing the list did nothing at all.
-    it "honours search_extensions whichever search backend runs" do
-      RailsAiContext.configuration.search_extensions = %w[md]
-      text = described_class.call(pattern: "class").content.first[:text]
+    # Turning search_extensions into a positive glob list on the ripgrep path
+    # made the two backends agree and cost the reach that makes the tool
+    # useful: a Gemfile, a Rakefile and a .md carry no listed extension.
+    it "finds a match in a file whose name carries no listed extension" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app", "models"))
+        File.write(File.join(dir, "Gemfile"), %(source "https://rubygems.org"\ngem "devise"\n))
+        File.write(File.join(dir, "app", "models", "post.rb"), "class Post; end\n")
 
-      expect(text).not_to match(/\.rb[:\s]/)
-    ensure
-      RailsAiContext.configuration.search_extensions = %w[rb js erb yml yaml json ts tsx vue svelte haml slim]
+        allow(RailsAiContext).to receive(:configuration).and_wrap_original do |orig|
+          orig.call.tap { |c| c.app_root = dir }
+        end
+        allow(RailsAiContext).to receive(:tier).and_return(:static)
+        described_class.reset_cache! if described_class.respond_to?(:reset_cache!)
+
+        text = described_class.call(pattern: "devise").content.first[:text]
+
+        expect(text).to include("Gemfile")
+      end
     end
 
     it "returns a not-found message for unmatched patterns" do


### PR DESCRIPTION
QA round 8 against GitLab, OpenProject, Canvas LMS, Discourse and Mastodon, plus three rounds of review over the fixes. Every defect here exits 0.

## The theme

A class's name cannot rebuild its path. Zeitwerk resolves a path through the app's own inflector, which the static tier never loads, and a pack or an in-repo engine moves the file out from under `app/` anyway. So controllers and models carry `file:` from whichever tier found them, and every consumer reads it through `Payload`.

Getting there took three passes: naming the constant correctly broke the six consumers that derived a path from the name, carrying `file:` fixed six of them and left five, and the review after that found two more plus an abstract-class rule. On Mastodon's 18 inflected controllers the failure was always a confident negative - `rails_test_info` reported 16 specs that exist as missing, `rails_get_routes` 4 routes, `rails_get_view` 2 views, and `rails_generate_test` wrote a spec whose body was `skip "no routes found"` for a controller with a route.

## Also in here

- `context`, `inspect`, `facts`, `preset`, `watch` and `init` take `--no-boot`; the static tier was reachable from `tool` and `serve` only.
- `rails_analyze_feature` no longer claims a test gap from a scan that stopped at 500 files. Discourse has 1,672 specs, so every controller in a feature was reported untested.
- "Global before_actions" in the generated files means global: three of Mastodon's five claims were false, including a filter that controller skips.
- i18n groups the locales below its rounding floor instead of deleting their rows, and reads the running environment's config file first.
- An abstract base class is not a model. GitLab answered 895 models without a boot and 888 with one.
- `rails_runtime_info` reports cache numbers rather than the store object.

## Verification

3671 specs, rubocop clean, e2e green including the Postgres harness. On the five apps: 3050 models and 632 controllers, every one carrying a file that exists, and no count moved except the abstract classes. Mastodon 100/100 on the full-surface battery.
